### PR TITLE
Added missing prior mean at test inputs

### DIFF
--- a/gpjax/predict.py
+++ b/gpjax/predict.py
@@ -25,8 +25,9 @@ def mean(gp: ConjugatePosterior, param: dict, training: Dataset) -> Callable:
     weights = cho_solve(L, prior_distance)
 
     def meanf(test_inputs: Array) -> Array:
+        prior_mean_at_test_inputs = gp.prior.mean_function(test_inputs)
         Kfx = cross_covariance(gp.prior.kernel, X, test_inputs, param)
-        return jnp.dot(Kfx, weights)
+        return prior_mean_at_test_inputs + jnp.dot(Kfx, weights)
 
     return meanf
 


### PR DESCRIPTION
Hi! 

First of all, I really like your library! It has a nice and well decoupled code structure.

On to the pull request:
I noticed that the mean function (evaluated at the test inputs) is not added to the output of the predictive mean function of the conjugate posterior, which I reckon is a bug. 

Are you happy with the following fix?