### PR TITLE
Revise fit in abstractions & minor documentation update.

### DIFF
--- a/docs/nbs/barycentres.pct.py
+++ b/docs/nbs/barycentres.pct.py
@@ -101,7 +101,7 @@ def fit_gp(x: jnp.DeviceArray, y: jnp.DeviceArray):
     objective = jax.jit(posterior.marginal_log_likelihood(D, constrainers, negative=True))
 
     opt = ox.adam(learning_rate=0.01)
-    learned_params = gpx.optax_fit(
+    learned_params = gpx.fit(
         objective=objective,
         trainables=trainables,
         params=params,

--- a/docs/nbs/classification.pct.py
+++ b/docs/nbs/classification.pct.py
@@ -16,7 +16,7 @@
 # %% [markdown]
 # # Classification
 #
-# In this notebook we demonstate how to perform inference for Gaussian process models with non-Gaussian likelihoods via maximum a posteriori (MAP) and Markov chain Monte Carlo (MCMC). We focus on a classification task here and use [BlackJax](https://github.com/blackjax-devs/blackjax/) for sampling.
+# In this notebook we demonstrate how to perform inference for Gaussian process models with non-Gaussian likelihoods via maximum a posteriori (MAP) and Markov chain Monte Carlo (MCMC). We focus on a classification task here and use [BlackJax](https://github.com/blackjax-devs/blackjax/) for sampling.
 
 # %%
 import jax
@@ -72,7 +72,7 @@ mll = jax.jit(posterior.marginal_log_likelihood(D, constrainer, negative=True))
 # We can obtain a MAP estimate by optimising the marginal log-likelihood with Obtax's optimisers.
 # %%
 opt = ox.adam(learning_rate=0.01)
-map_estimate = gpx.abstractions.optax_fit(
+map_estimate = gpx.fit(
     mll,
     params,
     trainable,

--- a/docs/nbs/graph_kernels.pct.py
+++ b/docs/nbs/graph_kernels.pct.py
@@ -72,7 +72,7 @@ L = nx.laplacian_matrix(G).toarray()
 # Our task is to construct a Gaussian process $f(\cdot)$ that maps from the graph's vertex set $V$ onto the real line. 
 # To that end, we begin by simulating a signal on the graph's vertices that we will go on to try and predict. 
 # We use a single draw from a Gaussian process prior to draw our response values $\boldsymbol{y}$ where we hardcode parameter values. 
-# The correspodning input value set for this model, denoted $\boldsymbol{x}$, is the index set of the graph's vertices.
+# The corresponding input value set for this model, denoted $\boldsymbol{x}$, is the index set of the graph's vertices.
 
 # %%
 x = jnp.arange(G.number_of_nodes()).reshape(-1, 1)
@@ -122,7 +122,7 @@ mll = jit(
 )
 
 opt = ox.adam(learning_rate=0.01)
-learned_params = gpx.abstractions.optax_fit(
+learned_params = gpx.fit(
     objective=mll,
     params=params,
     trainables=trainable,

--- a/docs/nbs/haiku.pct.py
+++ b/docs/nbs/haiku.pct.py
@@ -155,7 +155,7 @@ opt = ox.chain(
     ox.adamw(learning_rate=schedule),
 )
 
-final_params = gpx.abstractions.optax_fit(
+final_params = gpx.fit(
     mll,
     params,
     trainables,

--- a/docs/nbs/kernels.pct.py
+++ b/docs/nbs/kernels.pct.py
@@ -219,7 +219,7 @@ params, trainable, constrainer, unconstrainer = gpx.initialise(circlular_posteri
 
 # Optimise GP's marginal log-likelihood using Adam
 mll = jit(circlular_posterior.marginal_log_likelihood(D, constrainer, negative=True))
-learned_params = gpx.optax_fit(
+learned_params = gpx.fit(
     mll,
     params,
     trainable,

--- a/docs/nbs/regression.pct.py
+++ b/docs/nbs/regression.pct.py
@@ -116,7 +116,7 @@ posterior = prior * likelihood
 # ## Hyperparameter optimisation
 #
 # %% [markdown]
-# Our kernel is parameterised by a lengthscale $\ell^2$ and variance parameter $\sigma^2$, while our likelihood controls the observation noise with $\alpha^2$. To optimise these hyperparameters, we begin by calling `initialise`.
+# Our kernel is parameterised by a length-scale $\ell^2$ and variance parameter $\sigma^2$, while our likelihood controls the observation noise with $\alpha^2$. To optimise these hyperparameters, we begin by calling `initialise`.
 # %%
 params, trainable, constrainer, unconstrainer = gpx.initialise(posterior)
 pp.pprint(params)
@@ -149,7 +149,7 @@ mll(params)
 
 # %%
 opt = ox.adam(learning_rate=0.01)
-final_params = gpx.abstractions.optax_fit(
+final_params = gpx.fit(
     mll,
     params,
     trainable,

--- a/docs/nbs/sparse_regression.pct.py
+++ b/docs/nbs/sparse_regression.pct.py
@@ -80,7 +80,7 @@ xtest = jnp.linspace(-5.5, 5.5, 500).reshape(-1, 1)
 # | Memory cost    | $\mathcal{O}(n^2)$ | $\mathcal{O}(n m)$ | $\mathcal{O}(b m)$ |
 
 
-# To apply SVGP inference to our dataset, we begin by initialising $m = 50$ eqaully spaced inducing inputs $\boldsymbol{z}$ across our observed data's support. These are depicted below via horizontal black lines.
+# To apply SVGP inference to our dataset, we begin by initialising $m = 50$ equally spaced inducing inputs $\boldsymbol{z}$ across our observed data's support. These are depicted below via horizontal black lines.
 
 # %%
 z = jnp.linspace(-5.0, 5.0, 50).reshape(-1, 1)
@@ -91,7 +91,7 @@ ax.plot(xtest, f(xtest))
 [ax.axvline(x=z_i, color="black", alpha=0.3, linewidth=1) for z_i in z]
 plt.show()
 # %% [markdown]
-# The inducing inputs will summarise our dataset, and since they are treated as variaitonal parameters, their locations will be optimised. The next step to SVGP is to define a variational family.
+# The inducing inputs will summarise our dataset, and since they are treated as variational parameters, their locations will be optimised. The next step to SVGP is to define a variational family.
 
 # %% [markdown]
 # ## Defining the variational process
@@ -102,7 +102,7 @@ plt.show()
 # p(f(\cdot) | \mathcal{D}) = \int p(f(\cdot)|f(\boldsymbol{x})) p(f(\boldsymbol{x})|\mathcal{D}) \text{d}f(\boldsymbol{x}). \qquad (\dagger) 
 # \end{align}
 #
-# To arrive at an approximation framework, we assume some redundacy in the data. Instead of predicting $f(\cdot)$ with function values at the datapoints $f(\boldsymbol{x})$, we assume this can be achieved with only function values at $m$ inducing inputs $\boldsymbol{z}$
+# To arrive at an approximation framework, we assume some redundancy in the data. Instead of predicting $f(\cdot)$ with function values at the datapoints $f(\boldsymbol{x})$, we assume this can be achieved with only function values at $m$ inducing inputs $\boldsymbol{z}$
 #
 # $$ p(f(\cdot) | \mathcal{D}) \approx \int p(f(\cdot)|f(\boldsymbol{z})) p(f(\boldsymbol{z})|\mathcal{D}) \text{d}f(\boldsymbol{z}). \qquad (\star) $$
 #
@@ -115,7 +115,7 @@ plt.show()
 # 
 # To measure the quality of the approximation, we consider the Kullback-Leibler divergence $\operatorname{KL}(\cdot || \cdot)$ from our approximate process $q(f(\cdot))$ to the true process $p(f(\cdot)|\mathcal{D})$. By parametrising $q(f(\boldsymbol{z}))$ over a variational family of distributions, we can optimise Kullback-Leibler divergence with respect to the variational parameters. Moreover, since inducing input locations $\boldsymbol{z}$ augment the model, they themselves can be treated as variational parameters without altering the true underlying model $p(f(\boldsymbol{z})|\mathcal{D})$. This is exactly what gives SVGPs great flexibility whilst retaining robustness to overfitting. 
 # 
-# It is popular to elect a Gaussian variational family $q(f(\boldsymbol{z})) = \mathcal{N}(f(\boldsymbol{z}); \mathbf{m}, \mathbf{S})$ with parameters $\{\boldsymbol{z}, \mathbf{m}, \mathbf{S}\}$, since conjugacy is provided between $q(f(\boldsymbol{z}))$ and $p(f(\cdot)|f(\boldsymbol{z}))$ so that the resulting variational process $q(f(\cdot))$ is a GP. We can impliment this in GPJax by the following.
+# It is popular to elect a Gaussian variational family $q(f(\boldsymbol{z})) = \mathcal{N}(f(\boldsymbol{z}); \mathbf{m}, \mathbf{S})$ with parameters $\{\boldsymbol{z}, \mathbf{m}, \mathbf{S}\}$, since conjugacy is provided between $q(f(\boldsymbol{z}))$ and $p(f(\cdot)|f(\boldsymbol{z}))$ so that the resulting variational process $q(f(\cdot))$ is a GP. We can implement this in GPJax by the following.
 # %%
 likelihood = gpx.Gaussian(num_datapoints=n)
 p = gpx.Prior(kernel=gpx.RBF()) * likelihood

--- a/gpjax/__init__.py
+++ b/gpjax/__init__.py
@@ -5,7 +5,7 @@ config.update("jax_enable_x64", True)
 # Highlight any potentially unintended broadcasting rank promoting ops.
 # config.update("jax_numpy_rank_promotion", "warn")
 
-from .abstractions import fit, fit_batches, optax_fit
+from .abstractions import fit, fit_batches
 from .gps import Prior, construct_posterior
 from .kernels import (
     RBF,

--- a/gpjax/abstractions.py
+++ b/gpjax/abstractions.py
@@ -84,47 +84,6 @@ def fit(
     objective: tp.Callable,
     params: tp.Dict,
     trainables: tp.Dict,
-    opt_init,
-    opt_update,
-    get_params,
-    n_iters: int = 100,
-    log_rate: int = 10,
-) -> tp.Dict:
-    """Abstracted method for fitting a GP model with respect to a supplied objective function.
-    Optimisers used here should originate from Jax's experimental module.
-    Args:
-        objective (tp.Callable): The objective function that we are optimising with respect to.
-        params (dict): The parameters for which we would like to minimise our objective function with.
-        trainables (dict): Boolean dictionary of same structure as 'params' that determines which parameters should be trained.
-        opt_init (tp.Callable): The supplied optimiser's initialisation function.
-        opt_update (tp.Callable): Optimiser's update method.
-        get_params (tp.Callable): Return the current parameter state set from the optimiser.
-        n_iters (int, optional): The number of optimisation steps to run. Defaults to 100.
-        log_rate (int, optional): How frequently the objective function's value should be printed. Defaults to 10.
-    Returns:
-        tp.Dict: An optimised set of parameters.
-    """
-    opt_state = opt_init(params)
-
-    def loss(params):
-        params = trainable_params(params, trainables)
-        return objective(params)
-
-    @progress_bar_scan(n_iters, log_rate)
-    def step(opt_state, i):
-        params = get_params(opt_state)
-        loss_val, loss_gradient = jax.value_and_grad(loss)(params)
-        return opt_update(i, loss_gradient, opt_state), loss_val
-
-    opt_state, _ = jax.lax.scan(step, opt_state, jnp.arange(n_iters))
-
-    return get_params(opt_state)
-
-
-def optax_fit(
-    objective: tp.Callable,
-    params: tp.Dict,
-    trainables: tp.Dict,
     optax_optim,
     n_iters: int = 100,
     log_rate: int = 10,

--- a/tests/test_abstractions.py
+++ b/tests/test_abstractions.py
@@ -7,7 +7,7 @@ from jax.experimental import optimizers
 
 import gpjax as gpx
 from gpjax import RBF, Dataset, Gaussian, Prior, initialise, transform
-from gpjax.abstractions import fit, fit_batches, optax_fit
+from gpjax.abstractions import fit, fit_batches
 
 tfd = tf.data
 
@@ -22,27 +22,8 @@ def test_fit(n):
     params, trainable_status, constrainer, unconstrainer = initialise(p)
     mll = p.marginal_log_likelihood(D, constrainer, negative=True)
     pre_mll_val = mll(params)
-    opt_init, opt_update, get_params = optimizers.adam(step_size=0.1)
-    optimised_params = fit(
-        mll, params, trainable_status, opt_init, opt_update, get_params, n_iters=10
-    )
-    optimised_params = transform(optimised_params, constrainer)
-    assert isinstance(optimised_params, dict)
-    assert mll(optimised_params) < pre_mll_val
-
-
-@pytest.mark.parametrize("n", [20])
-def test_optax_fit(n):
-    key = jr.PRNGKey(123)
-    x = jnp.sort(jr.uniform(key=key, minval=-2.0, maxval=2.0, shape=(n, 1)), axis=0)
-    y = jnp.sin(x) + jr.normal(key=key, shape=x.shape) * 0.1
-    D = Dataset(X=x, y=y)
-    p = Prior(kernel=RBF()) * Gaussian(num_datapoints=n)
-    params, trainable_status, constrainer, unconstrainer = initialise(p)
-    mll = p.marginal_log_likelihood(D, constrainer, negative=True)
-    pre_mll_val = mll(params)
     optimiser = optax.adam(learning_rate=0.1)
-    optimised_params = optax_fit(mll, params, trainable_status, optimiser, n_iters=10)
+    optimised_params = fit(mll, params, trainable_status, optimiser, n_iters=10)
     optimised_params = transform(optimised_params, constrainer)
     assert isinstance(optimised_params, dict)
     assert mll(optimised_params) < pre_mll_val
@@ -60,7 +41,7 @@ def test_stop_grads(optim_pkg):
         )
     elif optim_pkg == "optax":
         optimiser = optax.adam(learning_rate=0.1)
-        learned_params = optax_fit(loss_fn, params, trainables, optimiser, n_iters=1)
+        learned_params = fit(loss_fn, params, trainables, optimiser, n_iters=1)
     assert learned_params["y"] == params["y"]
     assert learned_params["x"] != params["x"]
 

--- a/tests/test_abstractions.py
+++ b/tests/test_abstractions.py
@@ -28,20 +28,12 @@ def test_fit(n):
     assert isinstance(optimised_params, dict)
     assert mll(optimised_params) < pre_mll_val
 
-
-@pytest.mark.parametrize("optim_pkg", ["jax", "optax"])
-def test_stop_grads(optim_pkg):
+def test_stop_grads():
     params = {"x": jnp.array(3.0), "y": jnp.array(4.0)}
     trainables = {"x": True, "y": False}
     loss_fn = lambda params: params["x"] ** 2 + params["y"] ** 2
-    if optim_pkg == "jax":
-        opt_init, opt_update, get_params = optimizers.adam(step_size=0.1)
-        learned_params = fit(
-            loss_fn, params, trainables, opt_init, opt_update, get_params, n_iters=1
-        )
-    elif optim_pkg == "optax":
-        optimiser = optax.adam(learning_rate=0.1)
-        learned_params = fit(loss_fn, params, trainables, optimiser, n_iters=1)
+    optimiser = optax.adam(learning_rate=0.1)
+    learned_params = fit(loss_fn, params, trainables, optimiser, n_iters=1)
     assert learned_params["y"] == params["y"]
     assert learned_params["x"] != params["x"]
 


### PR DESCRIPTION
Revise abstraction's `fit` to only support optax optimisers. 

This update involved:

- Removing the at present function `fit` from abstractions
- Renaming `optax_fit` to `fit` to act as the new function that only supports optax
- Revising documentation notebooks to accommodate the new `fit` function & fix minor typos