### PR TITLE
Fix Non-conjugate posterior + remove mean from GP prior.

### DIFF
--- a/gpjax/gps.py
+++ b/gpjax/gps.py
@@ -85,13 +85,6 @@ class Prior(AbstractGP):
 
         return predict_fn
 
-    def mean(self, params: dict) -> tp.Callable[[Array], Array]:
-        def mean_fn(test_inputs: Array) -> Array:
-            predictive_dist = self.predict(params)
-            return predictive_dist(test_inputs).mean()
-
-        return mean_fn
-
     @property
     def params(self) -> dict:
         """Initialise the GP prior's parameter set"""
@@ -204,12 +197,12 @@ class ConjugatePosterior(AbstractPosterior):
             params = transform(params=params, transform_map=transformations)
 
             obs_noise = params["likelihood"]["obs_noise"]
-            mu = self.prior.mean_function(x, params["mean_function"])
+            μx = self.prior.mean_function(x, params["mean_function"])
             Kxx = gram(self.prior.kernel, x, params["kernel"])
             Kxx += I(n) * self.jitter
             Lx = jnp.linalg.cholesky(Kxx + I(n) * obs_noise)
 
-            random_variable = dx.MultivariateNormalTri(mu.squeeze(), Lx)
+            random_variable = dx.MultivariateNormalTri(μx.squeeze(), Lx)
 
             log_prior_density = evaluate_priors(params, priors)
             constant = jnp.array(-1.0) if negative else jnp.array(1.0)
@@ -259,7 +252,7 @@ class NonConjugatePosterior(AbstractPosterior):
             t = test_inputs
             Ktx = cross_covariance(self.prior.kernel, t, x, params["kernel"])
             Ktt = gram(self.prior.kernel, t, params["kernel"])
-            μt = self.prior.mean(params)(t).reshape(-1, 1)
+            μt = self.prior.mean_function(t, params["mean_function"])
             A = solve_triangular(Lx, Ktx.T, lower=True)
             latent_var = Ktt - jnp.sum(jnp.square(A), -2)
             latent_mean = μt + jnp.matmul(A.T, params["latent"])
@@ -298,7 +291,7 @@ class NonConjugatePosterior(AbstractPosterior):
             Kxx = gram(self.prior.kernel, x, params["kernel"])
             Kxx += I(n) * self.jitter
             Lx = jnp.linalg.cholesky(Kxx)
-            μx = self.prior.mean(params)(x).reshape(-1, 1)
+            μx = self.prior.mean_function(x, params["mean_function"])
             fx = jnp.matmul(Lx, params["latent"]) + μx
             rv = self.likelihood.link_function(fx, params)
             ll = jnp.sum(rv.log_prob(y))

--- a/gpjax/sparse_gps.py
+++ b/gpjax/sparse_gps.py
@@ -180,10 +180,10 @@ class SVGP(VariationalPosterior):
 
         if not self.variational_family.whiten:
             M = solve_triangular(Lz.T, M, lower=False)
-            μz = self.prior.mean(params)(z).reshape(-1, 1)
+            μz = self.prior.mean_function(z, params["mean_function"])
             mu -= μz
 
-        mean = self.prior.mean(params)(t).reshape(-1, 1) + jnp.matmul(M.T, mu)
+        mean = self.prior.mean_function(t, params["mean_function"]) + jnp.matmul(M.T, mu)
         V = jnp.matmul(M.T, sqrt)
         covariance += jnp.matmul(V, V.T)
 
@@ -207,7 +207,7 @@ class SVGP(VariationalPosterior):
         # Variational mean:
         mu = params["variational_family"]["variational_mean"]
         if not self.variational_family.whiten:
-            μz = self.prior.mean(params)(z).reshape(-1, 1)
+            μz = self.prior.mean_function(z, params["mean_function"])
             mu -= μz
 
         # Variational sqrt cov:
@@ -223,7 +223,7 @@ class SVGP(VariationalPosterior):
             if not self.variational_family.whiten:
                 M = solve_triangular(Lz.T, M, lower=False)
 
-            μt = self.prior.mean(params)(t).reshape(-1, 1)
+            μt = self.prior.mean_function(t, params["mean_function"])
             mean = μt + jnp.matmul(M.T, mu)
 
             V = jnp.matmul(M.T, sqrt)


### PR DESCRIPTION
- Fixed issue #58 to allow nonconjugate posteriors to work with non-zero mean functions.
- Removed `mean` method from GP `Prior` -> this was redundant. 