### PR TITLE
Fixed A Warning in The README Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ import gpjax as gpx
 import jax
 import jax.numpy as jnp
 import jax.random as jr
-from jax.experimental import optimizers
+from jax.example_libraries import optimizers
 from jax import jit
 
 key = jr.PRNGKey(123)


### PR DESCRIPTION
This pull request fixed a negligible warning in the README example. Specifically, jax.experimental has been changed to jax.example_libraries. Merging this pull request can eliminate the warning when users run the simple example in README. (Honestly, this pull request is just an excuse to help me understand the process of contributing to this library :-))

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

FutureWarning: jax.experimental.optimizers is deprecated, import jax.example_libraries.optimizers instead
  warnings.warn('jax.experimental.optimizers is deprecated, '

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- No FutureWarning
