### PR TITLE
Natgrads

### DIFF
--- a/gpjax/__init__.py
+++ b/gpjax/__init__.py
@@ -21,7 +21,6 @@ from .likelihoods import Bernoulli, Gaussian
 from .mean_functions import Constant, Zero
 from .parameters import copy_dict_structure, initialise, transform
 from .types import Dataset
-
 from .variational_inference import StochasticVI
 from .variational_families import VariationalGaussian, WhitenedVariationalGaussian, NaturalVariationalGaussian
 

--- a/gpjax/__init__.py
+++ b/gpjax/__init__.py
@@ -21,7 +21,8 @@ from .likelihoods import Bernoulli, Gaussian
 from .mean_functions import Constant, Zero
 from .parameters import copy_dict_structure, initialise, transform
 from .types import Dataset
+
 from .variational_inference import StochasticVI
-from .variational_families import VariationalGaussian, WhitenedVariationalGaussian
+from .variational_families import VariationalGaussian, WhitenedVariationalGaussian, NaturalVariationalGaussian
 
 __version__ = "0.4.6"

--- a/gpjax/variational_families.py
+++ b/gpjax/variational_families.py
@@ -252,11 +252,11 @@ class NaturalVariationalGaussian(AbstractVariationalFamily):
             Array: The KL-divergence between our variational approximation and the GP prior.
         """
         natural_vector = params["variational_family"]["natural_vector"]
-        natural_covariance = params["variational_family"]["natural_covariance"]
+        natural_matrix = params["variational_family"]["natural_matrix"]
         z = params["variational_family"]["inducing_inputs"]
         m = self.num_inducing
         
-        S_inv = -2 * natural_covariance
+        S_inv = -2 * natural_matrix
         S_inv += I(m) * self.jitter
         L_inv = jnp.linalg.cholesky(S_inv)
         L = jsp.linalg.solve_triangular(L_inv, I(m), lower=True)
@@ -269,8 +269,8 @@ class NaturalVariationalGaussian(AbstractVariationalFamily):
         Kzz += I(m) * self.jitter
         Lz = jnp.linalg.cholesky(Kzz)
 
-        qu = dx.MultivariateNormalTri(mu.squeeze(), L)
-        pu = dx.MultivariateNormalTri(μz.squeeze(), Lz)
+        qu = dx.MultivariateNormalTri(jnp.atleast_1d(mu.squeeze()), L)
+        pu = dx.MultivariateNormalTri(jnp.atleast_1d(μz.squeeze()), Lz)
 
         return qu.kl_divergence(pu)
 
@@ -284,11 +284,11 @@ class NaturalVariationalGaussian(AbstractVariationalFamily):
             Callable[[Array], dx.Distribution]: A function that accepts a set of test points and will return the predictive distribution at those points.
         """        
         natural_vector = params["variational_family"]["natural_vector"]
-        natural_covariance = params["variational_family"]["natural_covariance"]
+        natural_matrix = params["variational_family"]["natural_matrix"]
         z = params["variational_family"]["inducing_inputs"]
         m = self.num_inducing
         
-        S_inv = -2 * natural_covariance
+        S_inv = -2 * natural_matrix
         S_inv += I(m) * self.jitter
         L_inv = jnp.linalg.cholesky(S_inv)
         L = jsp.linalg.solve_triangular(L_inv, I(m), lower=True)

--- a/gpjax/variational_families.py
+++ b/gpjax/variational_families.py
@@ -259,10 +259,13 @@ class NaturalVariationalGaussian(AbstractVariationalFamily):
         S_inv = -2 * natural_matrix
         S_inv += I(m) * self.jitter
         L_inv = jnp.linalg.cholesky(S_inv)
-        L = jsp.linalg.solve_triangular(L_inv, I(m), lower=True)
+        B = jsp.linalg.solve_triangular(L_inv, I(m), lower=True)
         
-        S = jnp.matmul(L, L.T)
+        S = jnp.matmul(B.T, B)
         mu = jnp.matmul(S, natural_vector)
+
+        S += I(m) * self.jitter
+        L = jnp.linalg.cholesky(S)
         
         μz = self.prior.mean_function(z, params["mean_function"])
         Kzz = gram(self.prior.kernel, z, params["kernel"])
@@ -291,11 +294,14 @@ class NaturalVariationalGaussian(AbstractVariationalFamily):
         S_inv = -2 * natural_matrix
         S_inv += I(m) * self.jitter
         L_inv = jnp.linalg.cholesky(S_inv)
-        L = jsp.linalg.solve_triangular(L_inv, I(m), lower=True)
+        B = jsp.linalg.solve_triangular(L_inv, I(m), lower=True)
         
-        S = jnp.matmul(L, L.T)
+        S = jnp.matmul(B.T, B)
         mu = jnp.matmul(S, natural_vector)
-        
+
+        S += I(m) * self.jitter
+        L = jnp.linalg.cholesky(S)
+
         Kzz = gram(self.prior.kernel, z, params["kernel"])
         Kzz += I(m) * self.jitter
         Lz = jnp.linalg.cholesky(Kzz)

--- a/gpjax/variational_families.py
+++ b/gpjax/variational_families.py
@@ -83,7 +83,6 @@ class VariationalGaussian(AbstractVariationalFamily):
                 }
         )
 
-    # Compute KL divergence at inducing points, KL[q(u)||p(u)]:
     def prior_kl(self, params: Dict) -> Array:
         """Compute the KL-divergence between our current variational approximation and the Gaussian process prior.
 
@@ -149,7 +148,8 @@ class VariationalGaussian(AbstractVariationalFamily):
 class WhitenedVariationalGaussian(VariationalGaussian):
     """The variational Gaussian family of probability distributions."""
 
-    # Compute KL divergence at inducing points, KL[q(u)||p(u)]:
+    name: str = "Whitened Gaussian"
+
     def prior_kl(self, params: Dict) -> Array:
         """Compute the KL-divergence between our current variational approximation and the Gaussian process prior.
 
@@ -196,6 +196,121 @@ class WhitenedVariationalGaussian(VariationalGaussian):
             V = jnp.matmul(A.T, sqrt)
             
             mean = μt + jnp.matmul(A.T, mu)
+            covariance = Ktt - jnp.matmul(A.T, A) + jnp.matmul(V, V.T)
+
+            return dx.MultivariateNormalFullCovariance(
+                jnp.atleast_1d(mean.squeeze()), covariance
+            )
+
+        return predict_fn
+    
+
+@dataclass
+class NaturalVariationalGaussian(AbstractVariationalFamily):
+    """The variational Gaussian family of probability distributions."""
+    prior: Prior
+    inducing_inputs: Array
+    name: str = "Natural Gaussian"
+    natural_vector: Optional[Array] = None
+    natural_matrix: Optional[Array] = None
+    jitter: Optional[float] = DEFAULT_JITTER
+
+    def __post_init__(self):
+        """Initialise the variational Gaussian distribution."""
+        self.num_inducing = self.inducing_inputs.shape[0]
+        add_parameter("inducing_inputs", Identity)
+
+        m = self.num_inducing
+
+        if self.natural_vector is None:
+            self.natural_vector = jnp.zeros((m, 1))
+            add_parameter("natural_vector", Identity)
+
+        if self.natural_matrix is None:
+            self.natural_matrix = -.5 * I(m)
+            add_parameter("natural_matrix", Identity)
+
+    @property
+    def params(self) -> Dict:
+        """Return the natural vector and matrix, inducing inputs, and hyperparameters that parameterise the natural Gaussian distribution."""
+        return concat_dictionaries(
+            self.prior.params, {
+            "variational_family": {
+                "inducing_inputs": self.inducing_inputs,
+                "natural_vector": self.natural_vector,
+                "natural_matrix": self.natural_matrix}
+                }
+        )
+
+    def prior_kl(self, params: Dict) -> Array:
+        """Compute the KL-divergence between our current variational approximation and the Gaussian process prior.
+
+        Args:
+            params (Dict): The parameters at which our variational distribution and GP prior are to be evaluated.
+
+        Returns:
+            Array: The KL-divergence between our variational approximation and the GP prior.
+        """
+        natural_vector = params["variational_family"]["natural_vector"]
+        natural_covariance = params["variational_family"]["natural_covariance"]
+        z = params["variational_family"]["inducing_inputs"]
+        m = self.num_inducing
+        
+        S_inv = -2 * natural_covariance
+        S_inv += I(m) * self.jitter
+        L_inv = jnp.linalg.cholesky(S_inv)
+        L = jsp.linalg.solve_triangular(L_inv, I(m), lower=True)
+        
+        S = jnp.matmul(L, L.T)
+        mu = jnp.matmul(S, natural_vector)
+        
+        μz = self.prior.mean_function(z, params["mean_function"])
+        Kzz = gram(self.prior.kernel, z, params["kernel"])
+        Kzz += I(m) * self.jitter
+        Lz = jnp.linalg.cholesky(Kzz)
+
+        qu = dx.MultivariateNormalTri(mu.squeeze(), L)
+        pu = dx.MultivariateNormalTri(μz.squeeze(), Lz)
+
+        return qu.kl_divergence(pu)
+
+    def predict(self, params: dict) -> Callable[[Array], dx.Distribution]:
+        """Compute the predictive distribution of the GP at the test inputs.
+
+        Args:
+            params (dict): The set of parameters that are to be used to parameterise our variational approximation and GP.
+
+        Returns:
+            Callable[[Array], dx.Distribution]: A function that accepts a set of test points and will return the predictive distribution at those points.
+        """        
+        natural_vector = params["variational_family"]["natural_vector"]
+        natural_covariance = params["variational_family"]["natural_covariance"]
+        z = params["variational_family"]["inducing_inputs"]
+        m = self.num_inducing
+        
+        S_inv = -2 * natural_covariance
+        S_inv += I(m) * self.jitter
+        L_inv = jnp.linalg.cholesky(S_inv)
+        L = jsp.linalg.solve_triangular(L_inv, I(m), lower=True)
+        
+        S = jnp.matmul(L, L.T)
+        mu = jnp.matmul(S, natural_vector)
+        
+        Kzz = gram(self.prior.kernel, z, params["kernel"])
+        Kzz += I(m) * self.jitter
+        Lz = jnp.linalg.cholesky(Kzz)
+        μz = self.prior.mean_function(z, params["mean_function"])
+
+        def predict_fn(test_inputs: Array) -> dx.Distribution:
+            t = test_inputs
+            Ktt = gram(self.prior.kernel, t, params["kernel"])
+            Kzt = cross_covariance(self.prior.kernel, z, t, params["kernel"])
+            μt = self.prior.mean_function(t, params["mean_function"])
+            A = jsp.linalg.solve_triangular(Lz, Kzt, lower=True)
+            B = jsp.linalg.solve_triangular(Lz.T, A, lower=False)
+            V = jnp.matmul(B.T, L)
+            
+            mean = μt + jnp.matmul(B.T, mu - μz)
             covariance = Ktt - jnp.matmul(A.T, A) + jnp.matmul(V, V.T)
 
             return dx.MultivariateNormalFullCovariance(

--- a/gpjax/variational_families.py
+++ b/gpjax/variational_families.py
@@ -345,7 +345,7 @@ class ExpectationVariationalGaussian(AbstractVariationalFamily):
     """The variational Gaussian family of probability distributions."""
     prior: Prior
     inducing_inputs: Array
-    name: str = "Natural Gaussian"
+    name: str = "Expectation Gaussian"
     expectation_vector: Optional[Array] = None
     expectation_matrix: Optional[Array] = None
     jitter: Optional[float] = DEFAULT_JITTER
@@ -359,21 +359,21 @@ class ExpectationVariationalGaussian(AbstractVariationalFamily):
 
         if self.expectation_vector is None:
             self.expectation_vector = jnp.zeros((m, 1))
-            add_parameter("natural_vector", Identity)
+            add_parameter("expectation_vector", Identity)
 
         if self.expectation_matrix is None:
             self.expectation_matrix = I(m)
-            add_parameter("natural_matrix", Identity)
+            add_parameter("expectation_matrix", Identity)
 
     @property
     def params(self) -> Dict:
-        """Return the natural vector and matrix, inducing inputs, and hyperparameters that parameterise the natural Gaussian distribution."""
+        """Return the expectation vector and matrix, inducing inputs, and hyperparameters that parameterise the expectation Gaussian distribution."""
         return concat_dictionaries(
             self.prior.params, {
             "variational_family": {
                 "inducing_inputs": self.inducing_inputs,
-                "natural_vector": self.natural_vector,
-                "natural_matrix": self.natural_matrix}
+                "expectation_vector": self.expectation_vector,
+                "expectation_matrix": self.expectation_matrix}
                 }
         )
 
@@ -386,13 +386,13 @@ class ExpectationVariationalGaussian(AbstractVariationalFamily):
         Returns:
             Array: The KL-divergence between our variational approximation and the GP prior.
         """
-        natural_vector = params["variational_family"]["natural_vector"]
-        natural_matrix = params["variational_family"]["natural_matrix"]
+        expectation_vector = params["variational_family"]["expectation_vector"]
+        expectation_matrix = params["variational_family"]["expectation_matrix"]
         z = params["variational_family"]["inducing_inputs"]
         m = self.num_inducing
         
-        mu = natural_vector
-        S = natural_matrix - jnp.matmul(mu, mu.T)
+        mu = expectation_vector
+        S = expectation_matrix - jnp.matmul(mu, mu.T)
         S += I(m) * self.jitter
         sqrt = jnp.linalg.cholesky(S)
         
@@ -415,16 +415,16 @@ class ExpectationVariationalGaussian(AbstractVariationalFamily):
         Returns:
             Callable[[Array], dx.Distribution]: A function that accepts a set of test points and will return the predictive distribution at those points.
         """        
-        natural_vector = params["variational_family"]["natural_vector"]
-        natural_matrix = params["variational_family"]["natural_matrix"]
+        expectation_vector = params["variational_family"]["expectation_vector"]
+        expectation_matrix = params["variational_family"]["expectation_matrix"]
         z = params["variational_family"]["inducing_inputs"]
         m = self.num_inducing
         
         # μ = η₁
-        mu = natural_vector
+        mu = expectation_vector
 
         # S = η₂ - η₁ η₁ᵀ
-        S = natural_matrix - jnp.matmul(mu, mu.T)
+        S = expectation_matrix - jnp.matmul(mu, mu.T)
         S += I(m) * self.jitter
 
         # S = sqrt sqrtᵀ
@@ -461,3 +461,4 @@ class ExpectationVariationalGaussian(AbstractVariationalFamily):
             )
 
         return predict_fn
+

--- a/gpjax/variational_families.py
+++ b/gpjax/variational_families.py
@@ -259,9 +259,9 @@ class NaturalVariationalGaussian(AbstractVariationalFamily):
         S_inv = -2 * natural_matrix
         S_inv += I(m) * self.jitter
         L_inv = jnp.linalg.cholesky(S_inv)
-        B = jsp.linalg.solve_triangular(L_inv, I(m), lower=True)
+        C = jsp.linalg.solve_triangular(L_inv, I(m), lower=True)
         
-        S = jnp.matmul(B.T, B)
+        S = jnp.matmul(C.T, C)
         mu = jnp.matmul(S, natural_vector)
 
         S += I(m) * self.jitter

--- a/gpjax/variational_families.py
+++ b/gpjax/variational_families.py
@@ -265,14 +265,14 @@ class NaturalVariationalGaussian(AbstractVariationalFamily):
         mu = jnp.matmul(S, natural_vector)
 
         S += I(m) * self.jitter
-        L = jnp.linalg.cholesky(S)
+        sqrt = jnp.linalg.cholesky(S)
         
         μz = self.prior.mean_function(z, params["mean_function"])
         Kzz = gram(self.prior.kernel, z, params["kernel"])
         Kzz += I(m) * self.jitter
         Lz = jnp.linalg.cholesky(Kzz)
 
-        qu = dx.MultivariateNormalTri(jnp.atleast_1d(mu.squeeze()), L)
+        qu = dx.MultivariateNormalTri(jnp.atleast_1d(mu.squeeze()), sqrt)
         pu = dx.MultivariateNormalTri(jnp.atleast_1d(μz.squeeze()), Lz)
 
         return qu.kl_divergence(pu)
@@ -294,13 +294,10 @@ class NaturalVariationalGaussian(AbstractVariationalFamily):
         S_inv = -2 * natural_matrix
         S_inv += I(m) * self.jitter
         L_inv = jnp.linalg.cholesky(S_inv)
-        B = jsp.linalg.solve_triangular(L_inv, I(m), lower=True)
+        C = jsp.linalg.solve_triangular(L_inv, I(m), lower=True)
         
-        S = jnp.matmul(B.T, B)
+        S = jnp.matmul(C.T, C)
         mu = jnp.matmul(S, natural_vector)
-
-        S += I(m) * self.jitter
-        L = jnp.linalg.cholesky(S)
 
         Kzz = gram(self.prior.kernel, z, params["kernel"])
         Kzz += I(m) * self.jitter
@@ -314,7 +311,7 @@ class NaturalVariationalGaussian(AbstractVariationalFamily):
             μt = self.prior.mean_function(t, params["mean_function"])
             A = jsp.linalg.solve_triangular(Lz, Kzt, lower=True)
             B = jsp.linalg.solve_triangular(Lz.T, A, lower=False)
-            V = jnp.matmul(B.T, L)
+            V = jnp.matmul(B.T, C.T)
             
             mean = μt + jnp.matmul(B.T, mu - μz)
             covariance = Ktt - jnp.matmul(A.T, A) + jnp.matmul(V, V.T)

--- a/gpjax/variational_families.py
+++ b/gpjax/variational_families.py
@@ -207,7 +207,7 @@ class WhitenedVariationalGaussian(VariationalGaussian):
 
 @dataclass
 class NaturalVariationalGaussian(AbstractVariationalFamily):
-    """The variational Gaussian family of probability distributions."""
+    """The natural variational Gaussian family of probability distributions."""
     prior: Prior
     inducing_inputs: Array
     name: str = "Natural Gaussian"
@@ -291,12 +291,20 @@ class NaturalVariationalGaussian(AbstractVariationalFamily):
         z = params["variational_family"]["inducing_inputs"]
         m = self.num_inducing
         
+        # S⁻¹ = -2θ₂
         S_inv = -2 * natural_matrix
         S_inv += I(m) * self.jitter
-        L_inv = jnp.linalg.cholesky(S_inv)
-        C = jsp.linalg.solve_triangular(L_inv, I(m), lower=True)
+
+        # S⁻¹ = LLᵀ
+        L = jnp.linalg.cholesky(S_inv)
+
+        # C = L⁻¹I
+        C = jsp.linalg.solve_triangular(L, I(m), lower=True)
         
+        # S = CᵀC
         S = jnp.matmul(C.T, C)
+
+        # μ = Sθ₁
         mu = jnp.matmul(S, natural_vector)
 
         Kzz = gram(self.prior.kernel, z, params["kernel"])
@@ -309,12 +317,144 @@ class NaturalVariationalGaussian(AbstractVariationalFamily):
             Ktt = gram(self.prior.kernel, t, params["kernel"])
             Kzt = cross_covariance(self.prior.kernel, z, t, params["kernel"])
             μt = self.prior.mean_function(t, params["mean_function"])
-            A = jsp.linalg.solve_triangular(Lz, Kzt, lower=True)
-            B = jsp.linalg.solve_triangular(Lz.T, A, lower=False)
-            V = jnp.matmul(B.T, C.T)
+
+            # Lz⁻¹ Kzt
+            Lz_inv_Kzt = jsp.linalg.solve_triangular(Lz, Kzt, lower=True)
+
+            # Kzz⁻¹ Kzt
+            Kzz_inv_Kzt = jsp.linalg.solve_triangular(Lz.T, Lz_inv_Kzt, lower=False)
+
+            # Ktz Kzz⁻¹ Cᵀ
+            Ktz_Kzz_inv_CT = jnp.matmul(Kzz_inv_Kzt.T, C.T)
             
-            mean = μt + jnp.matmul(B.T, mu - μz)
-            covariance = Ktt - jnp.matmul(A.T, A) + jnp.matmul(V, V.T)
+            # μt  +  Ktz Kzz⁻¹ (μ  -  μz)
+            mean = μt + jnp.matmul(Kzz_inv_Kzt.T, mu - μz)
+
+            # Ktt  -  Ktz Kzz⁻¹ Kzt  +  Ktz Kzz⁻¹ S Kzz⁻¹ Kzt  [recall S = CᵀC]
+            covariance = Ktt - jnp.matmul(Lz_inv_Kzt.T, Lz_inv_Kzt) + jnp.matmul(Ktz_Kzz_inv_CT, Ktz_Kzz_inv_CT.T)
+
+            return dx.MultivariateNormalFullCovariance(
+                jnp.atleast_1d(mean.squeeze()), covariance
+            )
+
+        return predict_fn
+
+
+@dataclass
+class ExpectationVariationalGaussian(AbstractVariationalFamily):
+    """The variational Gaussian family of probability distributions."""
+    prior: Prior
+    inducing_inputs: Array
+    name: str = "Natural Gaussian"
+    expectation_vector: Optional[Array] = None
+    expectation_matrix: Optional[Array] = None
+    jitter: Optional[float] = DEFAULT_JITTER
+
+    def __post_init__(self):
+        """Initialise the variational Gaussian distribution."""
+        self.num_inducing = self.inducing_inputs.shape[0]
+        add_parameter("inducing_inputs", Identity)
+
+        m = self.num_inducing
+
+        if self.expectation_vector is None:
+            self.expectation_vector = jnp.zeros((m, 1))
+            add_parameter("natural_vector", Identity)
+
+        if self.expectation_matrix is None:
+            self.expectation_matrix = I(m)
+            add_parameter("natural_matrix", Identity)
+
+    @property
+    def params(self) -> Dict:
+        """Return the natural vector and matrix, inducing inputs, and hyperparameters that parameterise the natural Gaussian distribution."""
+        return concat_dictionaries(
+            self.prior.params, {
+            "variational_family": {
+                "inducing_inputs": self.inducing_inputs,
+                "natural_vector": self.natural_vector,
+                "natural_matrix": self.natural_matrix}
+                }
+        )
+
+    def prior_kl(self, params: Dict) -> Array:
+        """Compute the KL-divergence between our current variational approximation and the Gaussian process prior.
+
+        Args:
+            params (Dict): The parameters at which our variational distribution and GP prior are to be evaluated.
+
+        Returns:
+            Array: The KL-divergence between our variational approximation and the GP prior.
+        """
+        natural_vector = params["variational_family"]["natural_vector"]
+        natural_matrix = params["variational_family"]["natural_matrix"]
+        z = params["variational_family"]["inducing_inputs"]
+        m = self.num_inducing
+        
+        mu = natural_vector
+        S = natural_matrix - jnp.matmul(mu, mu.T)
+        S += I(m) * self.jitter
+        sqrt = jnp.linalg.cholesky(S)
+        
+        μz = self.prior.mean_function(z, params["mean_function"])
+        Kzz = gram(self.prior.kernel, z, params["kernel"])
+        Kzz += I(m) * self.jitter
+        Lz = jnp.linalg.cholesky(Kzz)
+
+        qu = dx.MultivariateNormalTri(jnp.atleast_1d(mu.squeeze()), sqrt)
+        pu = dx.MultivariateNormalTri(jnp.atleast_1d(μz.squeeze()), Lz)
+
+        return qu.kl_divergence(pu)
+
+    def predict(self, params: dict) -> Callable[[Array], dx.Distribution]:
+        """Compute the predictive distribution of the GP at the test inputs.
+
+        Args:
+            params (dict): The set of parameters that are to be used to parameterise our variational approximation and GP.
+
+        Returns:
+            Callable[[Array], dx.Distribution]: A function that accepts a set of test points and will return the predictive distribution at those points.
+        """        
+        natural_vector = params["variational_family"]["natural_vector"]
+        natural_matrix = params["variational_family"]["natural_matrix"]
+        z = params["variational_family"]["inducing_inputs"]
+        m = self.num_inducing
+        
+        # μ = η₁
+        mu = natural_vector
+
+        # S = η₂ - η₁ η₁ᵀ
+        S = natural_matrix - jnp.matmul(mu, mu.T)
+        S += I(m) * self.jitter
+
+        # S = sqrt sqrtᵀ
+        sqrt = jnp.linalg.cholesky(S)
+
+        Kzz = gram(self.prior.kernel, z, params["kernel"])
+        Kzz += I(m) * self.jitter
+        Lz = jnp.linalg.cholesky(Kzz)
+        μz = self.prior.mean_function(z, params["mean_function"])
+
+        def predict_fn(test_inputs: Array) -> dx.Distribution:
+            t = test_inputs
+            Ktt = gram(self.prior.kernel, t, params["kernel"])
+            Kzt = cross_covariance(self.prior.kernel, z, t, params["kernel"])
+            μt = self.prior.mean_function(t, params["mean_function"])
+            
+            # Lz⁻¹ Kzt
+            Lz_inv_Kzt = jsp.linalg.solve_triangular(Lz, Kzt, lower=True)
+
+            # Kzz⁻¹ Kzt
+            Kzz_inv_Kzt = jsp.linalg.solve_triangular(Lz.T, Lz_inv_Kzt , lower=False)
+
+            # Ktz Kzz⁻¹ sqrt
+            Ktz_Kzz_inv_sqrt = jnp.matmul(Kzz_inv_Kzt.T, sqrt)
+            
+            # μt  +  Ktz Kzz⁻¹ (μ  -  μz)
+            mean = μt + jnp.matmul(Kzz_inv_Kzt.T, mu - μz)
+
+            # Ktt  -  Ktz Kzz⁻¹ Kzt  +  Ktz Kzz⁻¹ S Kzz⁻¹ Kzt  [recall S = sqrt sqrtᵀ]
+            covariance = Ktt - jnp.matmul(Lz_inv_Kzt.T, Lz_inv_Kzt ) + jnp.matmul(Ktz_Kzz_inv_sqrt, Ktz_Kzz_inv_sqrt.T)
 
             return dx.MultivariateNormalFullCovariance(
                 jnp.atleast_1d(mean.squeeze()), covariance

--- a/tests/test_variational_families.py
+++ b/tests/test_variational_families.py
@@ -94,15 +94,40 @@ def test_variational_gaussian(diag, n_inducing, n_test, whiten):
     assert sigma.shape == (n_test, n_test)
 
 
+@pytest.mark.parametrize("n_test", [1, 10])
 @pytest.mark.parametrize("n_inducing", [1, 10, 20])
-def test_natural_variational_gaussian_params(n_inducing):
+def test_natural_variational_gaussian(n_inducing, n_test):
     prior = gpx.Prior(kernel=gpx.RBF())
-    inducing_points = jnp.linspace(-3.0, 3.0, n_inducing).reshape(-1, 1)
+    
+    inducing_inputs = jnp.linspace(-5.0, 5.0, n_inducing).reshape(-1, 1)
+    test_inputs = jnp.linspace(-5.0, 5.0, n_test).reshape(-1, 1)
+
+
     variational_family = gpx.variational_families.NaturalVariationalGaussian(
         prior=prior,
-        inducing_inputs=inducing_points
+        inducing_inputs=inducing_inputs
     )
 
+    # Test init
+    assert variational_family.num_inducing == n_inducing
+
+    assert jnp.sum(variational_family.natural_vector) == 0.0
+    assert variational_family.natural_vector.shape == (n_inducing, 1)
+
+    assert variational_family.natural_matrix.shape == (
+        n_inducing,
+        n_inducing,
+    )
+    assert jnp.all(jnp.diag(variational_family.natural_matrix) == -.5)
+
+    params = gpx.config.get_defaults()
+    assert "variational_root_covariance" in params["transformations"].keys()
+    assert "variational_mean" in params["transformations"].keys()
+
+    assert (variational_family.natural_matrix == -.5 * jnp.eye(n_inducing)).all()
+    assert (variational_family.natural_vector == jnp.zeros((n_inducing, 1))).all()
+
+    # params
     params = variational_family.params
     assert isinstance(params, dict)
     assert "inducing_inputs" in params["variational_family"].keys()
@@ -123,3 +148,24 @@ def test_natural_variational_gaussian_params(n_inducing):
 
     assert (variational_family.natural_matrix == -.5 * jnp.eye(n_inducing)).all()
     assert (variational_family.natural_vector == jnp.zeros((n_inducing, 1))).all()
+
+
+    #Test KL
+    params = variational_family.params
+    kl = variational_family.prior_kl(params)
+    assert isinstance(kl, jnp.ndarray)
+
+    # Test predictions
+    predictive_dist_fn = variational_family(params)
+    assert isinstance(predictive_dist_fn, tp.Callable)
+
+    predictive_dist = predictive_dist_fn(test_inputs)
+    assert isinstance(predictive_dist, dx.Distribution)
+
+    mu = predictive_dist.mean()
+    sigma = predictive_dist.covariance()
+
+    assert isinstance(mu, jnp.ndarray)
+    assert isinstance(sigma, jnp.ndarray)
+    assert mu.shape == (n_test,)
+    assert sigma.shape == (n_test, n_test)

--- a/tests/test_variational_families.py
+++ b/tests/test_variational_families.py
@@ -1,6 +1,7 @@
 import typing as tp
 
 import distrax as dx
+
 import jax.numpy as jnp
 import pytest
 
@@ -91,3 +92,34 @@ def test_variational_gaussian(diag, n_inducing, n_test, whiten):
     assert isinstance(sigma, jnp.ndarray)
     assert mu.shape == (n_test,)
     assert sigma.shape == (n_test, n_test)
+
+
+@pytest.mark.parametrize("n_inducing", [1, 10, 20])
+def test_natural_variational_gaussian_params(n_inducing):
+    prior = gpx.Prior(kernel=gpx.RBF())
+    inducing_points = jnp.linspace(-3.0, 3.0, n_inducing).reshape(-1, 1)
+    variational_family = gpx.variational_families.NaturalVariationalGaussian(
+        prior=prior,
+        inducing_inputs=inducing_points
+    )
+
+    params = variational_family.params
+    assert isinstance(params, dict)
+    assert "inducing_inputs" in params["variational_family"].keys()
+    assert "natural_vector" in params["variational_family"].keys()
+    assert "natural_matrix" in params["variational_family"].keys()
+
+    assert params["variational_family"]["inducing_inputs"].shape == (n_inducing, 1)
+    assert params["variational_family"]["natural_vector"].shape == (n_inducing, 1)
+    assert params["variational_family"]["natural_matrix"].shape == (n_inducing, n_inducing)
+
+    assert isinstance(params["variational_family"]["inducing_inputs"], jnp.DeviceArray)
+    assert isinstance(params["variational_family"]["natural_vector"], jnp.DeviceArray)
+    assert isinstance(params["variational_family"]["natural_matrix"], jnp.DeviceArray)
+   
+    params = gpx.config.get_defaults()
+    assert "natural_vector" in params["transformations"].keys()
+    assert "natural_matrix" in params["transformations"].keys()
+
+    assert (variational_family.natural_matrix == -.5 * jnp.eye(n_inducing)).all()
+    assert (variational_family.natural_vector == jnp.zeros((n_inducing, 1))).all()

--- a/tests/test_variational_families.py
+++ b/tests/test_variational_families.py
@@ -169,3 +169,81 @@ def test_natural_variational_gaussian(n_inducing, n_test):
     assert isinstance(sigma, jnp.ndarray)
     assert mu.shape == (n_test,)
     assert sigma.shape == (n_test, n_test)
+
+
+@pytest.mark.parametrize("n_test", [1, 10])
+@pytest.mark.parametrize("n_inducing", [1, 10, 20])
+def test_expectation_variational_gaussian(n_inducing, n_test):
+    prior = gpx.Prior(kernel=gpx.RBF())
+    
+    inducing_inputs = jnp.linspace(-5.0, 5.0, n_inducing).reshape(-1, 1)
+    test_inputs = jnp.linspace(-5.0, 5.0, n_test).reshape(-1, 1)
+
+
+    variational_family = gpx.variational_families.ExpectationVariationalGaussian(
+        prior=prior,
+        inducing_inputs=inducing_inputs
+    )
+
+    # Test init
+    assert variational_family.num_inducing == n_inducing
+
+    assert jnp.sum(variational_family.expectation_vector) == 0.0
+    assert variational_family.expectation_vector.shape == (n_inducing, 1)
+
+    assert variational_family.expectation_matrix.shape == (
+        n_inducing,
+        n_inducing,
+    )
+    assert jnp.all(jnp.diag(variational_family.expectation_matrix) == 1.0)
+
+    params = gpx.config.get_defaults()
+    assert "variational_root_covariance" in params["transformations"].keys()
+    assert "variational_mean" in params["transformations"].keys()
+
+    assert (variational_family.expectation_matrix == jnp.eye(n_inducing)).all()
+    assert (variational_family.expectation_vector == jnp.zeros((n_inducing, 1))).all()
+
+    # params
+    params = variational_family.params
+    assert isinstance(params, dict)
+    assert "inducing_inputs" in params["variational_family"].keys()
+    assert "expectation_vector" in params["variational_family"].keys()
+    assert "expectation_matrix" in params["variational_family"].keys()
+
+    assert params["variational_family"]["inducing_inputs"].shape == (n_inducing, 1)
+    assert params["variational_family"]["expectation_vector"].shape == (n_inducing, 1)
+    assert params["variational_family"]["expectation_matrix"].shape == (n_inducing, n_inducing)
+
+    assert isinstance(params["variational_family"]["inducing_inputs"], jnp.DeviceArray)
+    assert isinstance(params["variational_family"]["expectation_vector"], jnp.DeviceArray)
+    assert isinstance(params["variational_family"]["expectation_matrix"], jnp.DeviceArray)
+   
+    params = gpx.config.get_defaults()
+    assert "expectation_vector" in params["transformations"].keys()
+    assert "expectation_matrix" in params["transformations"].keys()
+
+    assert (variational_family.expectation_matrix == jnp.eye(n_inducing)).all()
+    assert (variational_family.expectation_vector == jnp.zeros((n_inducing, 1))).all()
+
+
+    #Test KL
+    params = variational_family.params
+    kl = variational_family.prior_kl(params)
+    assert isinstance(kl, jnp.ndarray)
+
+    # Test predictions
+    predictive_dist_fn = variational_family(params)
+    assert isinstance(predictive_dist_fn, tp.Callable)
+
+    predictive_dist = predictive_dist_fn(test_inputs)
+    assert isinstance(predictive_dist, dx.Distribution)
+
+    mu = predictive_dist.mean()
+    sigma = predictive_dist.covariance()
+
+    assert isinstance(mu, jnp.ndarray)
+    assert isinstance(sigma, jnp.ndarray)
+    assert mu.shape == (n_test,)
+    assert sigma.shape == (n_test, n_test)
+


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

The goal of this PR is to improve the closeness to the maths.
- Minor code changes in the non-conjugate posterior of `gps.py`, and the variational families in `variational_families.py`.
- Main thing is to add more comments about the maths in variational families. 


Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X ] Code style update (formatting, renaming)
- [ X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

# Main issues to discuss

- Should we have code comments about the maths like this
```python
# Ktt  -  Ktz Kzz^{-1} Kzt  +  Ktz Kzz^{-1} S Kzz^{-1} Kzt  [recall S = sqrt sqrt ^{T}]
covariance = Ktt - jnp.matmul(Lz_inv_Kzt.T, Lz_inv_Kzt) + jnp.matmul(Ktz_Kzz_inv_sqrt, Ktz_Kzz_inv_sqrt.T)
```

... or like this?
```python
# Ktt  -  Ktz Kzz⁻¹ Kzt  +  Ktz Kzz⁻¹ S Kzz⁻¹ Kzt  [recall S = sqrt sqrtᵀ]
covariance = Ktt - jnp.matmul(Lz_inv_Kzt.T, Lz_inv_Kzt) + jnp.matmul(Ktz_Kzz_inv_sqrt, Ktz_Kzz_inv_sqrt.T)
```

- How should maths in the docstring be formatted?
