### PR TITLE
Improve maths

### DIFF
--- a/gpjax/gps.py
+++ b/gpjax/gps.py
@@ -244,11 +244,12 @@ class NonConjugatePosterior(AbstractPosterior):
             Ktx = cross_covariance(self.prior.kernel, t, x, params["kernel"])
             Ktt = gram(self.prior.kernel, t, params["kernel"]) + I(nt) * self.jitter
             μt = self.prior.mean_function(t, params["mean_function"])
-            A = solve_triangular(Lx, Ktx.T, lower=True)
-            latent_var = jnp.diag(jnp.diag(Ktt - jnp.sum(jnp.square(A), -2)))
-            latent_mean = μt + jnp.matmul(A.T, params["latent"])
+            Lx_inv_Kxt = solve_triangular(Lx, Ktx.T, lower=True)
+            latent_var = jnp.diag(Ktt - jnp.matmul(Lx_inv_Kxt.T, Lx_inv_Kxt))
+            latent_mean = μt + jnp.matmul(Lx_inv_Kxt.T, params["latent"])
+
             return dx.MultivariateNormalFullCovariance(
-                jnp.atleast_1d(latent_mean.squeeze()), latent_var
+                jnp.atleast_1d(latent_mean.squeeze()), jnp.diag(latent_var)
             )
 
         return predict_fn

--- a/gpjax/variational_families.py
+++ b/gpjax/variational_families.py
@@ -117,9 +117,9 @@ class VariationalGaussian(AbstractVariationalFamily):
     def predict(self, params: dict) -> Callable[[Array], dx.Distribution]:
         """Compute the predictive distribution of the GP at the test inputs t.
 
-        This is the integral q(f(t)) = ∫ p(f(t)|u) q(u) du, which can be computed in closed form as
-          
-            N[f(.); μt + Ktz Kzz^{-1} (μ - μz),  Ktt - Ktz Kzz^{-1} Kzt + Ktz Kzz^{-1} S Kzz^{-1} Kzt ].
+        This is the integral q(f(t)) = ∫ p(f(t)|u) q(u) du, which can be computed in closed form as:
+
+            N[f(t); μt + Ktz Kzz^{-1} (μ - μz),  Ktt - Ktz Kzz^{-1} Kzt + Ktz Kzz^{-1} S Kzz^{-1} Kzt ].
 
         Args:
             params (dict): The set of parameters that are to be used to parameterise our variational approximation and GP.


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

The goal of this PR is to improve the closeness to the maths.
- Minor code changes in the non-conjugate posterior of `gps.py`, and the variational families in `variational_families.py`.
- Main thing is to add more comments about the maths in variational families. 


Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [X ] Code style update (formatting, renaming)
- [ X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

# Main issues to discuss

- Should we have code comments about the maths like this
```python
# Ktt  -  Ktz Kzz^{-1} Kzt  +  Ktz Kzz^{-1} S Kzz^{-1} Kzt  [recall S = sqrt sqrt ^{T}]
covariance = Ktt - jnp.matmul(Lz_inv_Kzt.T, Lz_inv_Kzt) + jnp.matmul(Ktz_Kzz_inv_sqrt, Ktz_Kzz_inv_sqrt.T)
```

... or like this?
```python
# Ktt  -  Ktz Kzz⁻¹ Kzt  +  Ktz Kzz⁻¹ S Kzz⁻¹ Kzt  [recall S = sqrt sqrtᵀ]
covariance = Ktt - jnp.matmul(Lz_inv_Kzt.T, Lz_inv_Kzt) + jnp.matmul(Ktz_Kzz_inv_sqrt, Ktz_Kzz_inv_sqrt.T)
```

- How should maths in the docstring be formatted?
