### PR TITLE
Add method to combine datasets.

### DIFF
--- a/gpjax/types.py
+++ b/gpjax/types.py
@@ -24,7 +24,7 @@ class Dataset:
         )
 
     def __add__(self, other: "Dataset") -> "Dataset":
-        """Combines two datasets into one."""
+        """Combines two datasets into one. The right-hand dataset is stacked beneath left."""
         x = jnp.concatenate((self.X, other.X))  
         y = jnp.concatenate((self.y, other.y))  
 

--- a/gpjax/types.py
+++ b/gpjax/types.py
@@ -23,6 +23,13 @@ class Dataset:
             f"- Number of datapoints: {self.X.shape[0]}\n- Dimension: {self.X.shape[1]}"
         )
 
+    def __add__(self, other: "Dataset") -> "Dataset":
+        """Combines two datasets into one."""
+        x = jnp.concatenate((self.X, other.X))  
+        y = jnp.concatenate((self.y, other.y))  
+
+        return Dataset(X=x, y=y)
+
     @property
     def n(self) -> int:
         """The number of observations in the dataset."""

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -9,10 +9,11 @@ def test_nonetype():
     assert isinstance(None, NoneType)
 
 
-@pytest.mark.parametrize("n", [1, 10, 100])
+@pytest.mark.parametrize("n", [1, 10])
 @pytest.mark.parametrize("outd", [1, 2, 10])
 @pytest.mark.parametrize("ind", [1, 2, 10])
-def test_dataset(n, outd, ind):
+@pytest.mark.parametrize("n2", [1, 10])
+def test_dataset(n, outd, ind, n2):
     x = jnp.ones((n, ind))
     y = jnp.ones((n, outd))
     d = Dataset(X=x, y=y)
@@ -20,6 +21,20 @@ def test_dataset(n, outd, ind):
     assert d.n == n
     assert d.in_dim == ind
     assert d.out_dim == outd
+
+    # test combine datasets
+    x2 = 2*jnp.ones((n2, ind))
+    y2 = 2*jnp.ones((n2, outd))
+    d2 = Dataset(X=x2, y=y2)
+
+    d_combined = d + d2
+    assert d_combined.n == n + n2
+    assert d_combined.in_dim == ind
+    assert d_combined.out_dim == outd
+    assert (d_combined.y[:n] == 1.).all()
+    assert (d_combined.y[n:] == 2.).all()
+    assert (d_combined.X[:n] == 1.).all()
+    assert (d_combined.X[n:] == 2.).all()
 
 
 @pytest.mark.parametrize("nx, ny", [(1, 2), (2, 1), (10, 5), (5, 10)])


### PR DESCRIPTION
Use `__add__` method on `Dataset` object to facilitate combining two datasets (useful for optimal design purposes).

Example:
```python
import jax.numpy as jnp
import gpjax as gpx

x1 = jnp.array([[1., 2.], [3., 4.])
y1 = jnp.array([[2.], [5.]])

D1 = gpx.Dataset(X=x1, y=y1)

x2 = jnp.array([[7., 11.], [1., 3.], [5., 5.]])
y2 = jnp.array([[8.], [3.], [7.]])

D2 = gpx.Dataset(X=x2, y=y2)

D_combined = D1 + D2
```

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):