### PR TITLE
Update mean_functions.py

### DIFF
--- a/gpjax/mean_functions.py
+++ b/gpjax/mean_functions.py
@@ -86,9 +86,9 @@ class Constant(AbstractMeanFunction):
             Array: A vector of repeated constant values.
         """
         out_shape = (x.shape[0], self.output_dim)
-        return jnp.ones(shape=out_shape) * params["variance"]
+        return jnp.ones(shape=out_shape) * params["constant"]
 
     @property
     def params(self) -> dict:
         """The parameters of the mean function. For the constant-mean function, this is a dictionary with a single value."""
-        return {"variance": jnp.array(1.0)}
+        return {"constant": jnp.array([1.0])}


### PR DESCRIPTION
Name "variance" for the constant in the constant mean object `Constant` in `mean_functions.py` is nonsensical. This PR renames this to "constant". This PR additionally, changes the the default value for the constant to be a 1 dimensional array - to resolve consistency with other hyperparameter specification in GPJax.

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ X] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):