### PR TITLE
Fix conjugate regression bug for a single datapoint.

### DIFF
--- a/gpjax/gps.py
+++ b/gpjax/gps.py
@@ -234,7 +234,8 @@ class ConjugatePosterior(AbstractPosterior):
 
             constant = jnp.array(-1.0) if negative else jnp.array(1.0)
             return constant * (
-                marginal_likelihood.log_prob(y.squeeze()).squeeze() + log_prior_density
+                marginal_likelihood.log_prob(jnp.atleast_1d(y.squeeze())).squeeze()
+                + log_prior_density
             )
 
         return mll

--- a/tests/test_abstractions.py
+++ b/tests/test_abstractions.py
@@ -11,7 +11,7 @@ from gpjax.abstractions import fit, fit_batches
 tfd = tf.data
 
 
-@pytest.mark.parametrize("n", [20])
+@pytest.mark.parametrize("n", [1, 20])
 def test_fit(n):
     key = jr.PRNGKey(123)
     x = jnp.sort(jr.uniform(key=key, minval=-2.0, maxval=2.0, shape=(n, 1)), axis=0)
@@ -26,6 +26,7 @@ def test_fit(n):
     optimised_params = transform(optimised_params, constrainer)
     assert isinstance(optimised_params, dict)
     assert mll(optimised_params) < pre_mll_val
+
 
 def test_stop_grads():
     params = {"x": jnp.array(3.0), "y": jnp.array(4.0)}

--- a/tests/test_gp.py
+++ b/tests/test_gp.py
@@ -5,7 +5,7 @@ import jax.numpy as jnp
 import jax.random as jr
 import pytest
 
-from gpjax import Dataset, initialise, likelihoods, transform
+from gpjax import Dataset, initialise, transform
 from gpjax.gps import (
     AbstractGP,
     ConjugatePosterior,
@@ -36,7 +36,7 @@ def test_prior(num_datapoints):
     assert sigma.shape == (num_datapoints, num_datapoints)
 
 
-@pytest.mark.parametrize("num_datapoints", [2, 10])
+@pytest.mark.parametrize("num_datapoints", [1, 2, 10])
 def test_conjugate_posterior(num_datapoints):
     key = jr.PRNGKey(123)
     x = jnp.sort(
@@ -80,7 +80,7 @@ def test_conjugate_posterior(num_datapoints):
     assert sigma.shape == (num_datapoints, num_datapoints)
 
 
-@pytest.mark.parametrize("num_datapoints", [2, 10])
+@pytest.mark.parametrize("num_datapoints", [1, 2, 10])
 @pytest.mark.parametrize("likel", NonConjugateLikelihoods)
 def test_nonconjugate_posterior(num_datapoints, likel):
     key = jr.PRNGKey(123)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

Thanks @krunolp for raising this issue.

Conjugate regression contains a bug that arises when calculating the marginal log-likelihood on a single data point. In particular, fitting a GP using only single input-output pair [both with shape (1,1)] results in the following error:

```
bijector BlockShift has event_ndims_out==1, but the input has only 0 array dimensions. 
```

This PR fixes this bug and updates the tests for this edge-case. 

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):