### PR TITLE
Relax Jax version

### DIFF
--- a/gpjax/config.py
+++ b/gpjax/config.py
@@ -5,8 +5,31 @@ from ml_collections import ConfigDict
 
 __config = None
 
-Identity = dx.Lambda(lambda x: x)
-Softplus = dx.Lambda(lambda x: jnp.log(1.0 + jnp.exp(x)))
+Identity = dx.Lambda(forward=lambda x: x, inverse=lambda x: x)
+Softplus = dx.Lambda(
+    forward=lambda x: jnp.log(1 + jnp.exp(x)),
+    inverse=lambda x: jnp.log(jnp.exp(x) - 1.0),
+)
+
+# class Softplus(dx.Bijector):
+#     def __init__(self):
+#         super().__init__(event_ndims_in=0)
+
+#     def forward_and_log_det(self, x):
+#         softplus = lambda xx: jnp.log(1 + jnp.exp(xx))
+#         y = softplus(x)
+#         logdet = softplus(-x)
+#         return y, logdet
+
+#     def inverse_and_log_det(self, y):
+#         """
+#         Y = Log[1 + exp{X}] ==> X = Log[exp{Y} - 1]
+#         ==> dX/dY = exp{Y} / (exp{Y} - 1)
+#                   = 1 / (1 - exp{-Y})
+#         """
+#         x = jnp.log(jnp.exp(y) - 1.0)
+#         logdet = 1 / (1 - jnp.exp(-y))
+#         return x, logdet
 
 
 def get_defaults() -> ConfigDict:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ REQUIRES = [
     "optax",
     "chex",
     "distrax>=0.1.2",
-    "tensorflow-probability==0.16.0",
+    "tensorflow-probability>=0.16.0",
     "tqdm>=4.0.0",
     "ml-collections==0.1.0",
     "jaxtyping",

--- a/setup.py
+++ b/setup.py
@@ -12,15 +12,14 @@ def parse_requirements_file(filename):
 
 
 REQUIRES = [
-    "jax==0.3.5",
-    "jaxlib==0.3.5",
-    "optax>=0.1.0",
-    "chex==0.1.3",
+    "jax>=0.1.67",
+    "jaxlib>=0.1.47",
+    "optax",
+    "chex",
     "distrax>=0.1.2",
     "tensorflow-probability==0.16.0",
     "tqdm>=4.0.0",
     "ml-collections==0.1.0",
-    "protobuf==3.19.0",
     "jaxtyping",
 ]
 

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -253,5 +253,5 @@ def test_output(num_datapoints, likelihood):
     a_constrainers, a_unconstrainers = build_transforms(augmented_params)
     assert "test_param" in list(a_constrainers.keys())
     assert "test_param" in list(a_unconstrainers.keys())
-    assert a_constrainers["test_param"](1.0) == 1.0
-    assert a_unconstrainers["test_param"](1.0) == 1.0
+    assert a_constrainers["test_param"](jnp.array([1.0])) == 1.0
+    assert a_unconstrainers["test_param"](jnp.array([1.0])) == 1.0


### PR DESCRIPTION
This PR relaxes the strict Jax requirement present in previous version of GPJax. This should resolve #102

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Right now we cannot use Jax versions beyond 0.3.5. By extending the distrax bijectors and updating some Jax tree-based operations, we can simply make this versioning an inequality to install the latest Jax version.

Issue Number: #102 
