### PR TITLE
Transformations

### DIFF
--- a/examples/barycentres.ipynb
+++ b/examples/barycentres.ipynb
@@ -118,24 +118,23 @@
     "    if y.ndim == 1:\n",
     "        y = y.reshape(-1, 1)\n",
     "    D = gpx.Dataset(X=x, y=y)\n",
+    "\n",
     "    likelihood = gpx.Gaussian(num_datapoints=n)\n",
     "    posterior = gpx.Prior(kernel=gpx.RBF()) * likelihood\n",
-    "    params, trainables, constrainers, unconstrainers = gpx.initialise(posterior, key).unpack()\n",
-    "    params = gpx.transform(params, unconstrainers)\n",
     "\n",
-    "    objective = jax.jit(posterior.marginal_log_likelihood(D, constrainers, negative=True))\n",
+    "    parameter_state = gpx.initialise(posterior, key)\n",
+    "    negative_mll = jax.jit(posterior.marginal_log_likelihood(D, negative=True))\n",
+    "    optimiser = ox.adam(learning_rate=0.01)\n",
     "\n",
-    "    opt = ox.adam(learning_rate=0.01)\n",
-    "    learned_params, training_history = gpx.fit(\n",
-    "        objective=objective,\n",
-    "        trainables=trainables,\n",
-    "        params=params,\n",
-    "        optax_optim=opt,\n",
+    "    inference_state = gpx.fit(\n",
+    "        objective=negative_mll,\n",
+    "        parameter_state=parameter_state,\n",
+    "        optax_optim=optimiser,\n",
     "        n_iters=1000,\n",
-    "    ).unpack()\n",
-    "    learned_params = gpx.transform(learned_params, constrainers)\n",
-    "    return likelihood(posterior(D, learned_params)(xtest), learned_params)\n",
+    "    )\n",
     "\n",
+    "    learned_params, training_history = inference_state.unpack()\n",
+    "    return likelihood(posterior(D, learned_params)(xtest), learned_params)\n",
     "\n",
     "posterior_preds = [fit_gp(x, i) for i in ys]"
    ]
@@ -279,7 +278,7 @@
    "encoding": "# -*- coding: utf-8 -*-"
   },
   "kernelspec": {
-   "display_name": "Python 3.9.7 ('gpjax')",
+   "display_name": "Python 3.10.0 ('base')",
    "language": "python",
    "name": "python3"
   },
@@ -293,11 +292,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.0"
   },
   "vscode": {
    "interpreter": {
-    "hash": "920091140e6b97de16b405af485d142952a229f5dad61a888f46227f5acb94cf"
+    "hash": "3d597f4c481aa0f25dceb95d2a0067e73c0966dcbd003d741d821a7208527ecf"
    }
   }
  },

--- a/examples/classification.ipynb
+++ b/examples/classification.ipynb
@@ -421,7 +421,7 @@
     "\n",
     "mll = jax.jit(posterior.marginal_log_likelihood(D, constrainer, negative=False))\n",
     "\n",
-    "adapt = blackjax.window_adaptation(blackjax.nuts, mll, num_adapt, target_acceptance_rate=0.65)\n",
+    "adapt = blackjax.window_adaptation(blackjax.nuts, unconstrained_mll, num_adapt, target_acceptance_rate=0.65)\n",
     "\n",
     "# Initialise the chain\n",
     "last_state, kernel, _ = adapt.run(key, params)\n",

--- a/examples/classification.ipynb
+++ b/examples/classification.ipynb
@@ -39,9 +39,9 @@
    "source": [
     "## Dataset\n",
     "\n",
-    "With the necessary modules imported, we simulate a dataset $\\mathcal{D} = (\\boldsymbol{x}, \\boldsymbol{y}) = \\{(x_i, y_i)\\}_{i=1}^{100}$ with inputs $\\boldsymbol{x}$ sampled uniformly on $(-1., 1)$ and corresponding binary outputs\n",
+    "With the necessary modules imported, we simulate a dataset $\\mathcal{D} = (, \\boldsymbol{y}) = \\{(x_i, y_i)\\}_{i=1}^{100}$ with inputs $\\boldsymbol{x}$ sampled uniformly on $(-1., 1)$ and corresponding binary outputs\n",
     "\n",
-    "$$\\boldsymbol{y} = 0.5 * \\text{sign}(\\cos(2 * \\boldsymbol{x} + \\boldsymbol{\\epsilon})) + 0.5, \\quad \\boldsymbol{\\epsilon} \\sim \\mathcal{N} \\left(\\textbf{0}, \\textbf{I} * (0.05)^{2} \\right).$$\n",
+    "$$\\boldsymbol{y} = 0.5 * \\text{sign}(\\cos(2 *  + \\boldsymbol{\\epsilon})) + 0.5, \\quad \\boldsymbol{\\epsilon} \\sim \\mathcal{N} \\left(\\textbf{0}, \\textbf{I} * (0.05)^{2} \\right).$$\n",
     "\n",
     "We store our data $\\mathcal{D}$ as a GPJax `Dataset` and create test inputs for later."
    ]
@@ -130,7 +130,7 @@
     "lines_to_next_cell": 0
    },
    "source": [
-    "To begin we obtain a set of initial parameter values through the `initialise` callable, and transform these to the unconstrained space via `transform` (see the [regression notebook](https://gpjax.readthedocs.io/en/latest/nbs/regression.html)). We also define the negative marginal log-likelihood, and JIT compile this to accelerate training."
+    "To begin we obtain an initial parameter state through the `initialise` callable (see the [regression notebook](https://gpjax.readthedocs.io/en/latest/nbs/regression.html)). We can obtain a MAP estimate by optimising the marginal log-likelihood with Optax's optimisers."
    ]
   },
   {
@@ -141,43 +141,18 @@
    "outputs": [],
    "source": [
     "parameter_state = gpx.initialise(posterior)\n",
-    "params, trainable, constrainer, unconstrainer = parameter_state.unpack()\n",
-    "params = gpx.transform(params, unconstrainer)\n",
+    "negative_mll = jax.jit(posterior.marginal_log_likelihood(D, negative=True))\n",
     "\n",
-    "mll = jax.jit(posterior.marginal_log_likelihood(D, constrainer, negative=True))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e7d24f78",
-   "metadata": {
-    "lines_to_next_cell": 0
-   },
-   "source": [
-    "We can obtain a MAP estimate by optimising the marginal log-likelihood with Obtax's optimisers."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "62001a7d",
-   "metadata": {
-    "lines_to_next_cell": 0
-   },
-   "outputs": [],
-   "source": [
-    "opt = ox.adam(learning_rate=0.01)\n",
-    "unconstrained_params, training_history = gpx.fit(\n",
-    "    mll,\n",
-    "    params,\n",
-    "    trainable,\n",
-    "    opt,\n",
-    "    n_iters=500,\n",
-    ").unpack()\n",
+    "optimiser = ox.adam(learning_rate=0.01)\n",
     "\n",
-    "negative_Hessian = jax.jacfwd(jax.jacrev(mll))(unconstrained_params)[\"latent\"][\"latent\"][:,0,:,0]\n",
+    "inference_state = gpx.fit(\n",
+    "    objective=negative_mll,\n",
+    "    parameter_state=parameter_state,\n",
+    "    optax_optim=optimiser,\n",
+    "    n_iters=1000,\n",
+    ")\n",
     "\n",
-    "map_estimate = gpx.transform(unconstrained_params, constrainer)"
+    "map_estimate , training_history = inference_state.unpack()"
    ]
   },
   {
@@ -197,11 +172,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "latent_dist = posterior(D, map_estimate)(xtest)\n",
+    "map_latent_dist = posterior(D, map_estimate)(xtest)\n",
     "\n",
-    "predictive_dist = likelihood(latent_dist, map_estimate)\n",
+    "predictive_dist = likelihood(map_latent_dist, map_estimate)\n",
     "\n",
     "predictive_mean = predictive_dist.mean()\n",
+    "a = predictive_dist.mean()\n",
     "predictive_std = predictive_dist.stddev()\n",
     "\n",
     "fig, ax = plt.subplots(figsize=(12, 5))\n",
@@ -223,6 +199,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0814299a",
+   "metadata": {},
+   "source": [
+    "Here we projected the map estimates $\\hat{\\boldsymbol{f}}$ for the function values $\\boldsymbol{f}$ at the data points $\\boldsymbol{x}$ to get predictions over the whole domain,\n",
+    "\n",
+    "\\begin{align}\n",
+    "p(f(\\cdot)| \\mathcal{D})  \\approx q_{map}(f(\\cdot)) := \\int p(f(\\cdot)| \\boldsymbol{f}) \\delta(\\boldsymbol{f} - \\hat{\\boldsymbol{f}}) d \\boldsymbol{f} = \\mathcal{N}(\\mathbf{K}_{\\boldsymbol{(\\cdot)x}}  \\mathbf{K}_{\\boldsymbol{xx}}^{-1} \\hat{\\boldsymbol{f}},  \\mathbf{K}_{\\boldsymbol{(\\cdot, \\cdot)}} - \\mathbf{K}_{\\boldsymbol{(\\cdot)\\boldsymbol{x}}} \\mathbf{K}_{\\boldsymbol{xx}}^{-1} \\mathbf{K}_{\\boldsymbol{\\boldsymbol{x}(\\cdot)}}).\n",
+    "\\end{align}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "219d35b2",
    "metadata": {
     "lines_to_next_cell": 0
@@ -239,8 +227,18 @@
    },
    "source": [
     "## Laplace approximation\n",
-    "The Laplace approximation improves uncertainty quantification by incorporating curvature induced by the marginal log-likelihood's Hessian to construct an approximate Gaussian distribution centered on the MAP estimate.\n",
-    "Since the negative Hessian is positive definite, we can use the Cholesky decomposition to obtain the covariance matrix of the Laplace approximation at the datapoints below."
+    "The Laplace approximation improves uncertainty quantification by incorporating curvature induced by the marginal log-likelihood's Hessian to construct an approximate Gaussian distribution centered on the MAP estimate. Writing $\\tilde{p}(\\boldsymbol{f}|\\mathcal{D}) = p(\\boldsymbol{y}|\\boldsymbol{f}) p(\\boldsymbol{f})$ as the unormalised posterior for function values $\\boldsymbol{f}$ at the datapoints $\\boldsymbol{x}$, we can expand the log of this about the posterior mode $\\hat{\\boldsymbol{f}}$ via a Taylor expansion. This gives:\n",
+    "\n",
+    "\\begin{align}\n",
+    "\\log\\tilde{p}(\\boldsymbol{f}|\\mathcal{D}) = \\log\\tilde{p}(\\hat{\\boldsymbol{f}}|\\mathcal{D}) + \\left[\\nabla \\log\\tilde{p}({\\boldsymbol{f}}|\\mathcal{D})|_{\\hat{\\boldsymbol{f}}}\\right]^{T} (\\boldsymbol{f}-\\hat{\\boldsymbol{f}}) + \\frac{1}{2} (\\boldsymbol{f}-\\hat{\\boldsymbol{f}})^{T} \\left[\\nabla^2 \\tilde{p}(\\boldsymbol{y}|\\boldsymbol{f})|_{\\hat{\\boldsymbol{f}}} \\right] (\\boldsymbol{f}-\\hat{\\boldsymbol{f}}) + \\mathcal{O}(\\lVert \\boldsymbol{f} - \\hat{\\boldsymbol{f}} \\rVert^3).\n",
+    "\\end{align}\n",
+    "\n",
+    "Now since $\\nabla \\log\\tilde{p}({\\boldsymbol{f}}|\\mathcal{D})$ is zero at the mode, this suggests the following approximation\n",
+    "\\begin{align}\n",
+    "\\tilde{p}(\\boldsymbol{f}|\\mathcal{D}) \\approx \\log\\tilde{p}(\\hat{\\boldsymbol{f}}|\\mathcal{D}) \\exp\\left\\{ \\frac{1}{2} (\\boldsymbol{f}-\\hat{\\boldsymbol{f}})^{T} \\left[-\\nabla^2 \\tilde{p}(\\boldsymbol{y}|\\boldsymbol{f})|_{\\hat{\\boldsymbol{f}}} \\right] (\\boldsymbol{f}-\\hat{\\boldsymbol{f}}) \\right\\}\n",
+    "\\end{align},\n",
+    "\n",
+    "that we identify as a Gaussian distribution,  $p(\\boldsymbol{f}| \\mathcal{D}) \\approx q(\\boldsymbol{f}) := \\mathcal{N}(\\hat{\\boldsymbol{f}}, [-\\nabla^2 \\tilde{p}(\\boldsymbol{y}|\\boldsymbol{f})|_{\\hat{\\boldsymbol{f}}} ]^{-1} )$. Since the negative Hessian is positive definite, we can use the Cholesky decomposition to obtain the covariance matrix of the Laplace approximation at the datapoints below."
    ]
   },
   {
@@ -250,18 +248,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "f_map_estimate = posterior(D, map_estimate)(x).mean()\n",
-    "\n",
+    "from gpjax.kernels import gram, cross_covariance\n",
     "jitter = 1e-6\n",
     "\n",
+    "# Compute (latent) function value map estimates at training points:\n",
+    "Kxx = gram(prior.kernel, x, map_estimate[\"kernel\"])\n",
+    "Kxx += I(D.n) * jitter\n",
+    "Lx = jnp.linalg.cholesky(Kxx)\n",
+    "f_hat = jnp.matmul(Lx, map_estimate[\"latent\"])\n",
+    "\n",
+    "# Negative Hessian,  H = -∇²p_tilde(y|f):\n",
+    "H = jax.jacfwd(jax.jacrev(negative_mll))(map_estimate)[\"latent\"][\"latent\"][:,0,:,0]\n",
+    "\n",
     "# LLᵀ = H\n",
-    "L = jnp.linalg.cholesky(negative_Hessian + I(D.n) * jitter)\n",
+    "L = jnp.linalg.cholesky(H + I(D.n) * jitter)\n",
     "\n",
     "# H⁻¹ = H⁻¹ I = (LLᵀ)⁻¹ I = L⁻ᵀL⁻¹ I\n",
     "L_inv = jsp.linalg.solve_triangular(L, I(D.n), lower=True)\n",
     "H_inv = jsp.linalg.solve_triangular(L.T, L_inv, lower=False)\n",
     "\n",
-    "laplace_approximation = dx.MultivariateNormalFullCovariance(f_map_estimate, H_inv)"
+    "# p(f|D) ≈ N(f_hat, H⁻¹) \n",
+    "laplace_approximation = dx.MultivariateNormalFullCovariance(jnp.atleast_1d(f_hat.squeeze()), H_inv)"
    ]
   },
   {
@@ -271,70 +278,44 @@
     "lines_to_next_cell": 0
    },
    "source": [
-    "For novel inputs, we must interpolate the above distribution, which can be achived via the function defined below."
+    "For novel inputs, we must project the above approximating distribution through the Gaussian conditional distribution $p(f(\\cdot)| \\boldsymbol{f})$,\n",
+    "\n",
+    "\\begin{align}\n",
+    "p(f(\\cdot)| \\mathcal{D}) \\approx q_{Laplace}(f(\\cdot)) := \\int p(f(\\cdot)| \\boldsymbol{f}) q(\\boldsymbol{f}) d \\boldsymbol{f} = \\mathcal{N}(\\mathbf{K}_{\\boldsymbol{(\\cdot)x}}  \\mathbf{K}_{\\boldsymbol{xx}}^{-1} \\hat{\\boldsymbol{f}},  \\mathbf{K}_{\\boldsymbol{(\\cdot, \\cdot)}} - \\mathbf{K}_{\\boldsymbol{(\\cdot)\\boldsymbol{x}}} \\mathbf{K}_{\\boldsymbol{xx}}^{-1} (\\mathbf{K}_{\\boldsymbol{xx}} - [-\\nabla^2 \\tilde{p}(\\boldsymbol{y}|\\boldsymbol{f})|_{\\hat{\\boldsymbol{f}}} ]^{-1}) \\mathbf{K}_{\\boldsymbol{xx}}^{-1} \\mathbf{K}_{\\boldsymbol{\\boldsymbol{x}(\\cdot)}}).\n",
+    "\\end{align}\n",
+    "\n",
+    "This is the same approximate distribution $q_{map}(f(\\cdot))$, but we have pertubed the covariance by a curvature term of $\\mathbf{K}_{\\boldsymbol{(\\cdot)\\boldsymbol{x}}} \\mathbf{K}_{\\boldsymbol{xx}}^{-1} [-\\nabla^2 \\tilde{p}(\\boldsymbol{y}|\\boldsymbol{f})|_{\\hat{\\boldsymbol{f}}} ]^{-1} \\mathbf{K}_{\\boldsymbol{xx}}^{-1} \\mathbf{K}_{\\boldsymbol{\\boldsymbol{x}(\\cdot)}}$. We take the latent distribution computed in the previous section and add this term to the covariance to construct $q_{Laplace}(f(\\cdot))$."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b6cb53e",
-   "metadata": {
-    "lines_to_next_cell": 0
-   },
+   "id": "0f6c2bcc",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "from gpjax.types import  Dataset\n",
-    "from gpjax.kernels import gram, cross_covariance\n",
+    "def construct_laplace(test_inputs: Float[Array, \"N D\"]) -> dx.MultivariateNormalFullCovariance:\n",
+    "    \n",
+    "    map_latent_dist = posterior(D, map_estimate)(test_inputs)\n",
     "\n",
+    "    Kxt = cross_covariance(prior.kernel,  x, test_inputs, map_estimate[\"kernel\"])\n",
+    "    Kxx = gram(prior.kernel, x, map_estimate[\"kernel\"])\n",
+    "    Kxx += I(D.n) * jitter\n",
+    "    Lx = jnp.linalg.cholesky(Kxx)\n",
     "\n",
-    "def predict(laplace_at_data: dx.Distribution, train_data: Dataset, test_inputs: Float[Array, \"N D\"], jitter: int = 1e-6) ->  dx.Distribution:\n",
-    "    \"\"\"Compute the predictive distribution of the Laplace approximation at novel inputs.\n",
-    "\n",
-    "    Args:\n",
-    "        laplace_at_data (dict): The Laplace approximation at the datapoints.\n",
-    "\n",
-    "    Returns:\n",
-    "        dx.Distribution: The Laplace approximation at novel inputs.\n",
-    "    \"\"\"\n",
-    "    x, n = train_data.X, train_data.n\n",
-    "\n",
-    "    t = test_inputs\n",
-    "    n_test = t.shape[0]\n",
-    "\n",
-    "    mu = laplace_at_data.mean().reshape(-1, 1)\n",
-    "    cov = laplace_at_data.covariance()\n",
-    "\n",
-    "    Ktt = gram(prior.kernel, t, params[\"kernel\"])\n",
-    "    Kxx = gram(prior.kernel, x, params[\"kernel\"])\n",
-    "    Kxt = cross_covariance(prior.kernel, x, t, params[\"kernel\"])\n",
-    "    μt = prior.mean_function(t, params[\"mean_function\"])\n",
-    "    μx = prior.mean_function(x, params[\"mean_function\"])\n",
-    "\n",
-    "    # Lx Lxᵀ = Kxx\n",
-    "    Lx = jnp.linalg.cholesky(Kxx + I(n) * jitter)\n",
-    "\n",
-    "    # sqrt sqrtᵀ = Σ\n",
-    "    sqrt = jnp.linalg.cholesky(cov + I(n) * jitter)\n",
-    "\n",
-    "    # Lz⁻¹ Kxt\n",
-    "    Lx_inv_Kxt = jsp.linalg.solve_triangular(Lx, Kxt, lower=True)\n",
+    "    # Lx⁻¹ Kxt\n",
+    "    Lx_inv_Ktx = jsp.linalg.solve_triangular(Lx, Kxt, lower=True)\n",
     "\n",
     "    # Kxx⁻¹ Kxt\n",
-    "    Kxx_inv_Kxt = jsp.linalg.solve_triangular(Lx.T, Lx_inv_Kxt, lower=False)\n",
+    "    Kxx_inv_Ktx = jsp.linalg.solve_triangular(Lx.T, Lx_inv_Ktx, lower=False)\n",
     "\n",
-    "    # Ktx Kxx⁻¹ sqrt\n",
-    "    Ktx_Kxx_inv_sqrt = jnp.matmul(Kxx_inv_Kxt.T, sqrt)\n",
-    "    \n",
-    "    # μt + Ktx Kxx⁻¹ (μ - μx)\n",
-    "    mean = μt + jnp.matmul(Kxx_inv_Kxt.T, mu - μx)\n",
+    "    # Ktx Kxx⁻¹[ H⁻¹ ] Kxx⁻¹ Kxt\n",
+    "    laplace_cov_term =  jnp.matmul(jnp.matmul(Kxx_inv_Ktx.T, H_inv), Kxx_inv_Ktx)\n",
     "\n",
-    "    # Ktt  -  Ktx Kxx⁻¹ Kxt  +  Ktx Kxx⁻¹ S Kxx⁻¹ Kxt\n",
-    "    covariance = Ktt - jnp.matmul(Lx_inv_Kxt.T, Lx_inv_Kxt) + jnp.matmul(Ktx_Kxx_inv_sqrt, Ktx_Kxx_inv_sqrt.T)\n",
-    "    covariance += I(n_test) * jitter\n",
+    "    mean = map_latent_dist.mean()\n",
+    "    covariance = map_latent_dist.covariance() + laplace_cov_term\n",
     "\n",
-    "    return dx.MultivariateNormalFullCovariance(\n",
-    "        jnp.atleast_1d(mean.squeeze()), covariance\n",
-    "    )"
+    "    return dx.MultivariateNormalFullCovariance(jnp.atleast_1d(mean.squeeze()), covariance)"
    ]
   },
   {
@@ -356,9 +337,8 @@
    },
    "outputs": [],
    "source": [
-    "latent_dist = predict(laplace_approximation, D, xtest)\n",
-    "\n",
-    "predictive_dist = likelihood(latent_dist, map_estimate)\n",
+    "laplace_latent_dist = construct_laplace(xtest)\n",
+    "predictive_dist = likelihood(laplace_latent_dist, map_estimate)\n",
     "\n",
     "predictive_mean = predictive_dist.mean()\n",
     "predictive_std = predictive_dist.stddev()\n",
@@ -376,7 +356,6 @@
     ")\n",
     "ax.plot(xtest, predictive_mean - predictive_std, color=\"tab:blue\", linestyle=\"--\", linewidth=1)\n",
     "ax.plot(xtest, predictive_mean + predictive_std, color=\"tab:blue\", linestyle=\"--\", linewidth=1)\n",
-    "\n",
     "ax.legend()"
    ]
   },
@@ -411,7 +390,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43dbf9b6",
+   "id": "a0bd8213",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params, trainables, bijectors = gpx.initialise(posterior, key).unpack()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a990f322",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -419,13 +408,16 @@
     "num_adapt = 500\n",
     "num_samples = 500\n",
     "\n",
-    "mll = jax.jit(posterior.marginal_log_likelihood(D, constrainer, negative=False))\n",
+    "params, trainables, bijectors = gpx.initialise(posterior, key).unpack()\n",
+    "mll = posterior.marginal_log_likelihood(D, negative=False)\n",
+    "\n",
+    "unconstrained_mll = jax.jit(lambda params: mll(gpx.constrain(params, bijectors)))\n",
     "\n",
     "adapt = blackjax.window_adaptation(blackjax.nuts, unconstrained_mll, num_adapt, target_acceptance_rate=0.65)\n",
     "\n",
     "# Initialise the chain\n",
-    "last_state, kernel, _ = adapt.run(key, params)\n",
-    "\n",
+    "unconstrained_params = gpx.unconstrain(params, bijectors)\n",
+    "last_state, kernel, _ = adapt.run(key, unconstrained_params)\n",
     "\n",
     "def inference_loop(rng_key, kernel, initial_state, num_samples):\n",
     "    def one_step(state, rng_key):\n",
@@ -520,7 +512,7 @@
     "    ps[\"kernel\"][\"lengthscale\"] = states.position[\"kernel\"][\"lengthscale\"][i]\n",
     "    ps[\"kernel\"][\"variance\"] = states.position[\"kernel\"][\"variance\"][i]\n",
     "    ps[\"latent\"] = states.position[\"latent\"][i, :, :]\n",
-    "    ps = gpx.transform(ps, constrainer)\n",
+    "    ps = gpx.constrain(ps, bijectors)\n",
     "\n",
     "    latent_dist = posterior(D, ps)(xtest)\n",
     "    predictive_dist = likelihood(latent_dist, ps)\n",
@@ -586,7 +578,7 @@
    "custom_cell_magics": "kql"
   },
   "kernelspec": {
-   "display_name": "Python 3.9.7 ('gpjax')",
+   "display_name": "Python 3.10.0 ('base')",
    "language": "python",
    "name": "python3"
   },
@@ -600,11 +592,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.0"
   },
   "vscode": {
    "interpreter": {
-    "hash": "920091140e6b97de16b405af485d142952a229f5dad61a888f46227f5acb94cf"
+    "hash": "3d597f4c481aa0f25dceb95d2a0067e73c0966dcbd003d741d821a7208527ecf"
    }
   }
  },

--- a/examples/collapsed_vi.ipynb
+++ b/examples/collapsed_vi.ipynb
@@ -186,22 +186,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "params, trainables, constrainers, unconstrainers = gpx.initialise(sgpr, key).unpack()\n",
+    "parameter_state = gpx.initialise(sgpr, key)\n",
     "\n",
-    "loss_fn = jit(sgpr.elbo(D, constrainers, negative=True))\n",
+    "negative_elbo = jit(sgpr.elbo(D, negative=True))\n",
     "\n",
     "optimiser = ox.adam(learning_rate=0.005)\n",
     "\n",
-    "params = gpx.transform(params, unconstrainers)\n",
-    "\n",
-    "learned_params, training_history = gpx.fit(\n",
-    "    objective = loss_fn,\n",
-    "    params = params,\n",
-    "    trainables = trainables,\n",
-    "    optax_optim = optimiser,\n",
+    "inference_state = gpx.fit(\n",
+    "    objective=negative_elbo,\n",
+    "    parameter_state=parameter_state,\n",
+    "    optax_optim=optimiser,\n",
     "    n_iters=2000,\n",
-    ").unpack()\n",
-    "learned_params = gpx.transform(learned_params, constrainers)"
+    ")\n",
+    "\n",
+    "learned_params, training_history = inference_state.unpack()"
    ]
   },
   {
@@ -268,10 +266,10 @@
    "outputs": [],
    "source": [
     "full_rank_model = gpx.Prior(kernel = gpx.RBF()) * gpx.Gaussian(num_datapoints=D.n)\n",
-    "fr_params, fr_trainables, fr_constrainers, fr_unconstrainers = gpx.initialise(full_rank_model, key).unpack()\n",
-    "fr_params = gpx.transform(fr_params, fr_unconstrainers)\n",
-    "mll = jit(full_rank_model.marginal_log_likelihood(D, fr_constrainers, negative=True))\n",
-    "%timeit mll(fr_params).block_until_ready()"
+    "fr_params, *_ = gpx.initialise(full_rank_model, key).unpack()\n",
+    "negative_mll = jit(full_rank_model.marginal_log_likelihood(D, negative=True))\n",
+    "\n",
+    "%timeit negative_mll(fr_params).block_until_ready()"
    ]
   },
   {
@@ -281,8 +279,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sparse_elbo = jit(sgpr.elbo(D, constrainers, negative=True))\n",
-    "%timeit sparse_elbo(params).block_until_ready()"
+    "params, *_ = gpx.initialise(sgpr, key).unpack()\n",
+    "negative_elbo = jit(sgpr.elbo(D, negative=True))\n",
+    "\n",
+    "%timeit negative_elbo(params).block_until_ready()"
    ]
   },
   {
@@ -318,7 +318,7 @@
    "custom_cell_magics": "kql"
   },
   "kernelspec": {
-   "display_name": "Python 3.9.7 ('gpjax')",
+   "display_name": "Python 3.10.0 ('base')",
    "language": "python",
    "name": "python3"
   },
@@ -332,11 +332,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.0"
   },
   "vscode": {
    "interpreter": {
-    "hash": "920091140e6b97de16b405af485d142952a229f5dad61a888f46227f5acb94cf"
+    "hash": "3d597f4c481aa0f25dceb95d2a0067e73c0966dcbd003d741d821a7208527ecf"
    }
   }
  },

--- a/examples/graph_kernels.ipynb
+++ b/examples/graph_kernels.ipynb
@@ -111,16 +111,16 @@
     "x = jnp.arange(G.number_of_nodes()).reshape(-1, 1)\n",
     "\n",
     "kernel = gpx.GraphKernel(laplacian=L)\n",
-    "f = gpx.Prior(kernel=kernel)\n",
+    "prior = gpx.Prior(kernel=kernel)\n",
     "\n",
-    "true_params = f._initialise_params(key)\n",
+    "true_params = prior._initialise_params(key)\n",
     "true_params[\"kernel\"] = {\n",
     "    \"lengthscale\": jnp.array(2.3),\n",
     "    \"variance\": jnp.array(3.2),\n",
     "    \"smoothness\": jnp.array(6.1),\n",
     "}\n",
     "\n",
-    "fx = f(true_params)(x)\n",
+    "fx = prior(true_params)(x)\n",
     "y = fx.sample(seed=key).reshape(-1, 1)\n",
     "\n",
     "D = gpx.Dataset(X=x, y=y)"
@@ -173,23 +173,21 @@
    "outputs": [],
    "source": [
     "likelihood = gpx.Gaussian(num_datapoints=y.shape[0])\n",
-    "posterior = f * likelihood\n",
-    "params, trainable, constrainer, unconstrainer = gpx.initialise(posterior, key).unpack()\n",
-    "params = gpx.transform(params, unconstrainer)\n",
+    "posterior = prior * likelihood\n",
     "\n",
-    "mll = jit(\n",
-    "    posterior.marginal_log_likelihood(train_data=D, transformations=constrainer, negative=True)\n",
+    "\n",
+    "parameter_state = gpx.initialise(posterior, key)\n",
+    "negative_mll = jit(posterior.marginal_log_likelihood(train_data=D, negative=True))\n",
+    "optimiser = ox.adam(learning_rate=0.01)\n",
+    "\n",
+    "inference_state = gpx.fit(\n",
+    "    objective=negative_mll,\n",
+    "    parameter_state=parameter_state,\n",
+    "    optax_optim=optimiser,\n",
+    "    n_iters=1000,\n",
     ")\n",
     "\n",
-    "opt = ox.adam(learning_rate=0.01)\n",
-    "learned_params, training_history = gpx.fit(\n",
-    "    objective=mll,\n",
-    "    params=params,\n",
-    "    trainables=trainable,\n",
-    "    optax_optim=opt,\n",
-    "    n_iters=1000,\n",
-    ").unpack()\n",
-    "learned_params = gpx.transform(learned_params, constrainer)"
+    "learned_params, training_history = inference_state.unpack()"
    ]
   },
   {
@@ -213,7 +211,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "initial_dist = likelihood(posterior(D, params)(x), params)\n",
+    "initial_params = parameter_state.params\n",
+    "initial_dist = likelihood(posterior(D, initial_params)(x), initial_params)\n",
     "predictive_dist = likelihood(posterior(D, learned_params)(x), learned_params)\n",
     "\n",
     "initial_mean = initial_dist.mean()\n",
@@ -294,7 +293,7 @@
    "encoding": "# -*- coding: utf-8 -*-"
   },
   "kernelspec": {
-   "display_name": "Python 3.9.7 ('gpjax')",
+   "display_name": "Python 3.10.0 ('base')",
    "language": "python",
    "name": "python3"
   },
@@ -308,11 +307,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.0"
   },
   "vscode": {
    "interpreter": {
-    "hash": "920091140e6b97de16b405af485d142952a229f5dad61a888f46227f5acb94cf"
+    "hash": "3d597f4c481aa0f25dceb95d2a0067e73c0966dcbd003d741d821a7208527ecf"
    }
   }
  },

--- a/examples/haiku.ipynb
+++ b/examples/haiku.ipynb
@@ -173,10 +173,7 @@
     "kernel.initialise(x, key)\n",
     "prior = gpx.Prior(kernel=kernel)\n",
     "likelihood = gpx.Gaussian(num_datapoints=D.n)\n",
-    "posterior = prior * likelihood\n",
-    "\n",
-    "params, trainables, constrainers, unconstrainers = gpx.initialise(posterior, key).unpack()\n",
-    "params = gpx.transform(params, unconstrainers)"
+    "posterior = prior * likelihood"
    ]
   },
   {
@@ -200,8 +197,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mll = jax.jit(posterior.marginal_log_likelihood(D, constrainers, negative=True))\n",
-    "mll(params)\n",
+    "parameter_state = gpx.initialise(posterior, key)\n",
+    "\n",
+    "negative_mll = jax.jit(posterior.marginal_log_likelihood(D, negative=True))\n",
+    "negative_mll(parameter_state.params)\n",
     "\n",
     "schedule = ox.warmup_cosine_decay_schedule(\n",
     "    init_value=0.0,\n",
@@ -211,19 +210,19 @@
     "    end_value=0.0,\n",
     ")\n",
     "\n",
-    "opt = ox.chain(\n",
+    "optimiser = ox.chain(\n",
     "    ox.clip(1.0),\n",
     "    ox.adamw(learning_rate=schedule),\n",
     ")\n",
     "\n",
-    "final_params, training_history = gpx.fit(\n",
-    "    mll,\n",
-    "    params,\n",
-    "    trainables,\n",
-    "    opt,\n",
+    "inference_state = gpx.fit(\n",
+    "    objective=negative_mll,\n",
+    "    parameter_state=parameter_state,\n",
+    "    optax_optim=optimiser,\n",
     "    n_iters=5000,\n",
-    ").unpack()\n",
-    "final_params = gpx.transform(final_params, constrainers)"
+    ")\n",
+    "\n",
+    "learned_params, training_history = inference_state.unpack()"
    ]
   },
   {
@@ -243,8 +242,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "latent_dist = posterior(D, final_params)(xtest)\n",
-    "predictive_dist = likelihood(latent_dist, final_params)\n",
+    "latent_dist = posterior(D, learned_params)(xtest)\n",
+    "predictive_dist = likelihood(latent_dist, learned_params)\n",
     "\n",
     "predictive_mean = predictive_dist.mean()\n",
     "predictive_std = predictive_dist.stddev()\n",
@@ -290,7 +289,7 @@
    "custom_cell_magics": "kql"
   },
   "kernelspec": {
-   "display_name": "Python 3.9.7 ('gpjax')",
+   "display_name": "Python 3.10.0 ('base')",
    "language": "python",
    "name": "python3"
   },
@@ -304,11 +303,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.0"
   },
   "vscode": {
    "interpreter": {
-    "hash": "920091140e6b97de16b405af485d142952a229f5dad61a888f46227f5acb94cf"
+    "hash": "3d597f4c481aa0f25dceb95d2a0067e73c0966dcbd003d741d821a7208527ecf"
    }
   }
  },

--- a/examples/kernels.ipynb
+++ b/examples/kernels.ipynb
@@ -71,7 +71,7 @@
     "\n",
     "for k, ax in zip(kernels, axes.ravel()):\n",
     "    prior = gpx.Prior(kernel=k)\n",
-    "    params, _, _, _ = gpx.initialise(prior, key).unpack()\n",
+    "    params, *_ = gpx.initialise(prior, key).unpack()\n",
     "    rv = prior(params)(x)\n",
     "    y = rv.sample(sample_shape=10, seed=key)\n",
     "\n",
@@ -303,14 +303,14 @@
     "        super().__init__()\n",
     "        self.period = period\n",
     "```\n",
-    "As objects become increasingly large and complex, the conciseness of a dataclass becomes increasingly attractive. To ensure full compatability with Jax, it is crucial that the dataclass decorator is imported from Chex, not base Python's `dataclass` module. Functionally, the two objects are identical. However, unlike regular Python dataclasses, it is possilbe to apply operations such as`jit`, `vmap` and `grad` to the dataclasses given by Chex as they are registrered PyTrees. \n",
+    "As objects become increasingly large and complex, the conciseness of a dataclass becomes increasingly attractive. To ensure full compatability with Jax, it is crucial that the dataclass decorator is imported from Chex, not base Python's `dataclass` module. Functionally, the two objects are identical. However, unlike regular Python dataclasses, it is possilbe to apply operations such as `jit`, `vmap` and `grad` to the dataclasses given by Chex as they are registrered PyTrees. \n",
     "\n",
     "\n",
     "### Custom Parameter Bijection\n",
     "\n",
     "The constraint on $\\tau$ makes optimisation challenging with gradient descent. It would be much easier if we could instead parameterise $\\tau$ to be on the real line. Fortunately, this can be taken care of with GPJax's `add parameter` function, only requiring us to define the parameter's name and matching bijection (either a Distrax of TensorFlow probability bijector). Under the hood, calling this function updates a configuration object to register this parameter and its corresponding transform.\n",
     "\n",
-    "To define a bijector here we'll make use of the `Lambda` operator given in Distrax. This lets us convert any regular Jax function into a bijection. Given that we require $\\tau$ to be strictly greater than $4.$, we'll apply a [softplus transformation](https://jax.readthedocs.io/en/latest/_autosummary/jax.nn.softplus.html) where the lower bound is shifted by $4.$."
+    "To define a bijector here we'll make use of the `Lambda` operator given in Distrax. This lets us convert any regular Jax function into a bijection. Given that we require $\\tau$ to be strictly greater than $4$, we'll apply a [softplus transformation](https://jax.readthedocs.io/en/latest/_autosummary/jax.nn.softplus.html) where the lower bound is shifted by $4$."
    ]
   },
   {
@@ -322,10 +322,12 @@
    "source": [
     "from gpjax.config import add_parameter\n",
     "\n",
-    "bij_fn = lambda x: jax.nn.softplus(x+jnp.array(4.))\n",
-    "bij = dx.Lambda(bij_fn)\n",
+    "tau_bijector = dx.Lambda(\n",
+    "    forward=lambda x: jnp.log(1 + jnp.exp(x + 4.0)),\n",
+    "    inverse=lambda x: jnp.log(jnp.exp(x - 4.0) - 1.0),\n",
+    ")\n",
     "\n",
-    "add_parameter(\"tau\", bij)"
+    "add_parameter(\"tau\", tau_bijector)"
    ]
   },
   {
@@ -362,21 +364,21 @@
     "likelihood = gpx.Gaussian(num_datapoints=n)\n",
     "circlular_posterior = gpx.Prior(kernel=PKern) * likelihood\n",
     "\n",
-    "# Initialise parameters and corresponding transformations\n",
-    "params, trainable, constrainer, unconstrainer = gpx.initialise(circlular_posterior, key).unpack()\n",
+    "# Initialise parameter state:\n",
+    "parameter_state = gpx.initialise(circlular_posterior, key)\n",
     "\n",
     "# Optimise GP's marginal log-likelihood using Adam\n",
-    "mll = jit(circlular_posterior.marginal_log_likelihood(D, constrainer, negative=True))\n",
-    "learned_params, training_history = gpx.fit(\n",
-    "    mll,\n",
-    "    params,\n",
-    "    trainable,\n",
-    "    adam(learning_rate=0.05),\n",
-    "    n_iters=1000,\n",
-    ").unpack()\n",
+    "negative_mll = jit(circlular_posterior.marginal_log_likelihood(D, negative=True))\n",
+    "optimiser = adam(learning_rate=0.05)\n",
     "\n",
-    "# Untransform learned parameters\n",
-    "final_params = gpx.transform(learned_params, constrainer)"
+    "inference_state = gpx.fit(\n",
+    "    objective=negative_mll,\n",
+    "    parameter_state=parameter_state,\n",
+    "    optax_optim=optimiser,\n",
+    "    n_iters=1000,\n",
+    ")\n",
+    "\n",
+    "learned_params, training_history = inference_state.unpack()"
    ]
   },
   {
@@ -396,7 +398,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "posterior_rv = likelihood(circlular_posterior(D, final_params)(angles), final_params)\n",
+    "posterior_rv = likelihood(circlular_posterior(D, learned_params)(angles), learned_params)\n",
     "mu = posterior_rv.mean()\n",
     "one_sigma = posterior_rv.stddev()"
    ]
@@ -459,7 +461,7 @@
    "encoding": "# -*- coding: utf-8 -*-"
   },
   "kernelspec": {
-   "display_name": "Python 3.9.7 ('gpjax')",
+   "display_name": "Python 3.10.0 ('base')",
    "language": "python",
    "name": "python3"
   },
@@ -473,11 +475,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.0"
   },
   "vscode": {
    "interpreter": {
-    "hash": "920091140e6b97de16b405af485d142952a229f5dad61a888f46227f5acb94cf"
+    "hash": "3d597f4c481aa0f25dceb95d2a0067e73c0966dcbd003d741d821a7208527ecf"
    }
   }
  },

--- a/examples/regression.ipynb
+++ b/examples/regression.ipynb
@@ -236,8 +236,7 @@
     "|---|---|\n",
     "|  `params` | Initial parameter values.  |\n",
     "| `trainable`  | Boolean dictionary that determines the training status of parameters (`True` for being trained and `False` otherwise).  |\n",
-    "|  `constrainer` | Transformations that map parameters from the _unconstrained space_ back to their original _constrained space_.  |\n",
-    "|  `unconstrainer` | Transformations that map parameters from their original _constrained space_ to an _unconstrained space_ for optimisation. |\n",
+    "|  `bijectors` | Bijectors that can map parameters between the _unconstrained space_ and their original _constrained space_.  |\n",
     "\n",
     "Further, upon calling `initialise`, we can state specific initial values for some, or all, of the parameters within our model. By default, the kernel lengthscale and variance and the likelihood's variance parameter are all initialised to 1. However, in the following cell, we'll demonstrate how the kernel lengthscale can be initialised to 0.5."
    ]
@@ -272,7 +271,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "params, trainable, constrainer, unconstrainer = parameter_state.unpack()\n",
+    "params, trainable, bijectors = parameter_state.unpack()\n",
     "pp.pprint(params)"
    ]
   },
@@ -281,17 +280,7 @@
    "id": "28475bd7",
    "metadata": {},
    "source": [
-    "To motivate the purpose of `constrainer` and `unconstrainer` more precisely, notice that our model hyperparameters $\\{\\ell^2, \\sigma^2, \\alpha^2 \\}$ are all strictly positive. To ensure more stable optimisation, it is strongly advised to transform the parameters onto an unconstrained space first via `transform`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e8748952",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "params = gpx.transform(params, unconstrainer)"
+    "To motivate the purpose the `bijectors` more precisely, notice that our model hyperparameters $\\{\\ell^2, \\sigma^2, \\alpha^2 \\}$ are all strictly positive, bijectors act to unconstrain these during the optimisation proceedure."
    ]
   },
   {
@@ -311,8 +300,8 @@
    },
    "outputs": [],
    "source": [
-    "mll = jit(posterior.marginal_log_likelihood(D, constrainer, negative=True))\n",
-    "mll(params)"
+    "negative_mll = jit(posterior.marginal_log_likelihood(D, negative=True))\n",
+    "negative_mll(params)"
    ]
   },
   {
@@ -338,12 +327,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "opt = ox.adam(learning_rate=0.01)\n",
+    "optimiser = ox.adam(learning_rate=0.01)\n",
+    "\n",
     "inference_state = gpx.fit(\n",
-    "    mll,\n",
-    "    params,\n",
-    "    trainable,\n",
-    "    opt,\n",
+    "    objective = negative_mll,\n",
+    "    parameter_state = parameter_state,\n",
+    "    optax_optim= optimiser,\n",
     "    n_iters=500,\n",
     ")"
    ]
@@ -363,27 +352,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "final_params, training_history = inference_state.unpack()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "faef08b8",
-   "metadata": {},
-   "source": [
+    "learned_params, training_history = inference_state.unpack()\n",
     "\n",
-    "The exact value of our learned parameters is often useful in answering certain questions about the underlying process. To obtain these values, we untransfom our trained unconstrained parameters back to their original constrained space with `transform` and `constrainer`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "67015714",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "final_params = gpx.transform(final_params, constrainer)\n",
-    "pp.pprint(final_params)"
+    "pp.pprint(learned_params)"
    ]
   },
   {
@@ -403,8 +374,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "latent_dist = posterior(D, final_params)(xtest)\n",
-    "predictive_dist = likelihood(latent_dist, final_params)\n",
+    "latent_dist = posterior(D, learned_params)(xtest)\n",
+    "predictive_dist = likelihood(latent_dist, learned_params)\n",
     "\n",
     "predictive_mean = predictive_dist.mean()\n",
     "predictive_std = predictive_dist.stddev()"
@@ -470,7 +441,7 @@
    "custom_cell_magics": "kql"
   },
   "kernelspec": {
-   "display_name": "Python 3.9.7 ('gpjax')",
+   "display_name": "Python 3.10.0 ('base')",
    "language": "python",
    "name": "python3"
   },
@@ -484,11 +455,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.0"
   },
   "vscode": {
    "interpreter": {
-    "hash": "920091140e6b97de16b405af485d142952a229f5dad61a888f46227f5acb94cf"
+    "hash": "3d597f4c481aa0f25dceb95d2a0067e73c0966dcbd003d741d821a7208527ecf"
    }
   }
  },

--- a/examples/tfp_integration.ipynb
+++ b/examples/tfp_integration.ipynb
@@ -104,7 +104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "params, _, constrainers, unconstrainers = gpx.initialise(posterior, key).unpack()"
+    "params, _, bijectors = gpx.initialise(posterior, key).unpack()"
    ]
   },
   {
@@ -201,9 +201,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mll = posterior.marginal_log_likelihood(\n",
-    "    D, constrainers, priors=priors, negative=False\n",
-    ")\n",
+    "mll = posterior.marginal_log_likelihood(D, priors=priors, negative=False)\n",
     "mll(params)"
    ]
   },
@@ -225,6 +223,7 @@
     "def build_log_pi(target, mapper_fn):\n",
     "    def array_mll(parameter_array):\n",
     "        parameter_dict = mapper_fn([jnp.array(i) for i in parameter_array])\n",
+    "        gpx.constrain(parameter_dict, bijectors)\n",
     "        return target(parameter_dict)\n",
     "\n",
     "    return array_mll\n",
@@ -252,7 +251,6 @@
    "source": [
     "n_samples = 500\n",
     "\n",
-    "\n",
     "def run_chain(key, state):\n",
     "    kernel = tfp.mcmc.NoUTurnSampler(mll_array_form, 1e-1)\n",
     "    return tfp.mcmc.sample_chain(\n",
@@ -279,7 +277,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "states, log_probs = jax.jit(run_chain)(key, jnp.array(dict_to_array(params)))"
+    "unconstrained_params = gpx.unconstrain(params, bijectors)\n",
+    "states, log_probs = jax.jit(run_chain)(key, jnp.array(dict_to_array(unconstrained_params)))"
    ]
   },
   {
@@ -305,7 +304,7 @@
     "\n",
     "samples = [states[burn_in:, i, :][::thin_factor] for i in range(n_params)]\n",
     "sample_dict = array_to_dict(samples)\n",
-    "constrained_samples = gpx.transform(sample_dict, constrainers)\n",
+    "constrained_samples = gpx.constrain(sample_dict, bijectors)\n",
     "constrained_sample_list = dict_to_array(constrained_samples)"
    ]
   },
@@ -400,7 +399,7 @@
    "id": "bca69c91",
    "metadata": {},
    "source": [
-    "Since things look good, this concludes our tutorial on interfacing TensorFlow Probability with GPJax. \n",
+    "This concludes our tutorial on interfacing TensorFlow Probability with GPJax. \n",
     "The workflow demonstrated here only scratches the surface regarding the inference possible with a large number of samplers available in TensorFlow probability."
    ]
   },
@@ -429,7 +428,7 @@
    "custom_cell_magics": "kql"
   },
   "kernelspec": {
-   "display_name": "Python 3.9.7 ('gpjax')",
+   "display_name": "Python 3.10.0 ('base')",
    "language": "python",
    "name": "python3"
   },
@@ -443,11 +442,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.0"
   },
   "vscode": {
    "interpreter": {
-    "hash": "920091140e6b97de16b405af485d142952a229f5dad61a888f46227f5acb94cf"
+    "hash": "3d597f4c481aa0f25dceb95d2a0067e73c0966dcbd003d741d821a7208527ecf"
    }
   }
  },

--- a/examples/tfp_integration.ipynb
+++ b/examples/tfp_integration.ipynb
@@ -277,8 +277,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "unconstrained_params = gpx.unconstrain(params, bijectors)\n",
-    "states, log_probs = jax.jit(run_chain)(key, jnp.array(dict_to_array(unconstrained_params)))"
+    "#unconstrained_params = gpx.unconstrain(params, bijectors)\n",
+    "#states, log_probs = jax.jit(run_chain)(key, jnp.array(dict_to_array(unconstrained_params)))\n",
+    "states, log_probs = jax.jit(run_chain)(key, jnp.array(dict_to_array(params)))"
    ]
   },
   {

--- a/examples/tfp_integration.ipynb
+++ b/examples/tfp_integration.ipynb
@@ -223,7 +223,7 @@
     "def build_log_pi(target, mapper_fn):\n",
     "    def array_mll(parameter_array):\n",
     "        parameter_dict = mapper_fn([jnp.array(i) for i in parameter_array])\n",
-    "        gpx.constrain(parameter_dict, bijectors)\n",
+    "        parameter_dict = gpx.constrain(parameter_dict, bijectors)\n",
     "        return target(parameter_dict)\n",
     "\n",
     "    return array_mll\n",
@@ -277,8 +277,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#unconstrained_params = gpx.unconstrain(params, bijectors)\n",
-    "#states, log_probs = jax.jit(run_chain)(key, jnp.array(dict_to_array(unconstrained_params)))\n",
+    "unconstrained_params = gpx.unconstrain(params, bijectors)\n",
+    "states, log_probs = jax.jit(run_chain)(key, jnp.array(dict_to_array(unconstrained_params)))\n",
     "states, log_probs = jax.jit(run_chain)(key, jnp.array(dict_to_array(params)))"
    ]
   },

--- a/examples/uncollapsed_vi.ipynb
+++ b/examples/uncollapsed_vi.ipynb
@@ -221,10 +221,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "params, trainables, constrainers, unconstrainers = gpx.initialise(svgp, key).unpack()\n",
-    "params = gpx.transform(params, unconstrainers)\n",
-    "\n",
-    "loss_fn = jit(svgp.elbo(D, constrainers, negative=True))"
+    "negative_elbo = jit(svgp.elbo(D, negative=True))"
    ]
   },
   {
@@ -246,20 +243,20 @@
    },
    "outputs": [],
    "source": [
+    "parameter_state = gpx.initialise(svgp, key)\n",
     "optimiser = ox.adam(learning_rate=0.01)\n",
     "\n",
     "inference_state = gpx.fit_batches(\n",
-    "    objective = loss_fn,\n",
-    "    params = params,\n",
-    "    trainables = trainables,\n",
+    "    objective = negative_elbo,\n",
+    "    parameter_state= parameter_state,\n",
     "    train_data = D, \n",
     "    optax_optim = optimiser,\n",
     "    n_iters=4000,\n",
     "    key = jr.PRNGKey(42),\n",
-    "    batch_size= 128\n",
+    "    batch_size= 128,\n",
     ")\n",
-    "learned_params, training_history = inference_state.unpack()\n",
-    "learned_params = gpx.transform(learned_params, constrainers)"
+    "\n",
+    "learned_params, training_history = inference_state.unpack()"
    ]
   },
   {

--- a/examples/yacht.ipynb
+++ b/examples/yacht.ipynb
@@ -166,10 +166,7 @@
     "\n",
     "likelihood = gpx.Gaussian(num_datapoints=n_train)\n",
     "\n",
-    "posterior = prior * likelihood\n",
-    "\n",
-    "params, trainables, constrainers, unconstrainers = gpx.initialise(posterior, key).unpack()\n",
-    "params = gpx.transform(params, unconstrainers)"
+    "posterior = prior * likelihood"
    ]
   },
   {
@@ -189,9 +186,18 @@
    "source": [
     "training_data = gpx.Dataset(X = scaled_Xtr, y=scaled_ytr)\n",
     "\n",
-    "mll = jit(posterior.marginal_log_likelihood(train_data = training_data, transformations=constrainers, negative=True))\n",
-    "learned_params, training_history = gpx.fit(objective=mll, params=params, trainables=trainables, optax_optim=ox.adam(0.05), n_iters=1000, log_rate=50).unpack()\n",
-    "learned_params = gpx.transform(learned_params, constrainers)"
+    "parameter_state = gpx.initialise(posterior, key)\n",
+    "negative_mll = jit(posterior.marginal_log_likelihood(train_data = training_data, negative=True))\n",
+    "optimiser = ox.adam(0.05)\n",
+    "\n",
+    "inference_state = gpx.fit(objective=negative_mll, \n",
+    "                            parameter_state=parameter_state, \n",
+    "                            optax_optim=optimiser, \n",
+    "                            n_iters=1000, \n",
+    "                            log_rate=50,\n",
+    "                            )\n",
+    "                            \n",
+    "learned_params, training_history = inference_state.unpack()"
    ]
   },
   {
@@ -303,7 +309,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.7 ('gpjax')",
+   "display_name": "Python 3.10.0 ('base')",
    "language": "python",
    "name": "python3"
   },
@@ -317,11 +323,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.0"
   },
   "vscode": {
    "interpreter": {
-    "hash": "920091140e6b97de16b405af485d142952a229f5dad61a888f46227f5acb94cf"
+    "hash": "3d597f4c481aa0f25dceb95d2a0067e73c0966dcbd003d741d821a7208527ecf"
    }
   }
  },

--- a/gpjax/__init__.py
+++ b/gpjax/__init__.py
@@ -19,7 +19,7 @@ from .kernels import (
 )
 from .likelihoods import Bernoulli, Gaussian
 from .mean_functions import Constant, Zero
-from .parameters import copy_dict_structure, initialise, transform
+from .parameters import constrain, copy_dict_structure, initialise, unconstrain
 from .types import Dataset
 from .variational_families import (
     CollapsedVariationalGaussian,

--- a/gpjax/abstractions.py
+++ b/gpjax/abstractions.py
@@ -114,18 +114,19 @@ def fit(
         InferenceState: An InferenceState object comprising the optimised parameters and training history respectively.
     """
 
+    params, trainables, bijectors = parameter_state.unpack()
+
     def loss(params):
-        parameter_state = trainable_params(parameter_state)
-        parameter_state = constrain(parameter_state)
-        params = parameter_state.params
+        params = trainable_params(params, trainables)
+        params = constrain(params, bijectors)
         return objective(params)
 
     iter_nums = jnp.arange(n_iters)
 
     # Tranform params to unconstrained space:
-    parameter_state = unconstrain(parameter_state)
+    params = unconstrain(params, bijectors)
 
-    opt_state = optax_optim.init(parameter_state.params)
+    opt_state = optax_optim.init(params)
 
     @progress_bar_scan(n_iters, log_rate)
     def step(carry, iter_num):
@@ -139,9 +140,9 @@ def fit(
     (params, _), history = jax.lax.scan(step, (params, opt_state), iter_nums)
 
     # Tranform params to constrained space:
-    parameter_state.params = params
-    params = constrain(parameter_state)
-    inf_state = InferenceState(params=parameter_state.params, history=history)
+    params = constrain(params, bijectors)
+
+    inf_state = InferenceState(params=params, history=history)
 
     return inf_state
 
@@ -171,14 +172,15 @@ def fit_batches(
         InferenceState: An InferenceState object comprising the optimised parameters and training history respectively.
     """
 
+    params, trainables, bijectors = parameter_state.unpack()
+
     def loss(params, batch):
-        parameter_state = trainable_params(parameter_state)
-        parameter_state = constrain(parameter_state)
-        params = parameter_state.params
+        params = trainable_params(params, trainables)
+        params = constrain(params, bijectors)
         return objective(params, batch)
 
-    parameter_state = unconstrain(parameter_state)
-    params = parameter_state.params
+    params = unconstrain(params, bijectors)
+
     opt_state = optax_optim.init(params)
     keys = jr.split(key, n_iters)
     iter_nums = jnp.arange(n_iters)
@@ -199,9 +201,8 @@ def fit_batches(
 
     (params, _), history = jax.lax.scan(step, (params, opt_state), (iter_nums, keys))
 
-    parameter_state.params = params
-    parameter_state = constrain(parameter_state)
-    inf_state = InferenceState(params=parameter_state.params, history=history)
+    params = constrain(params, bijectors)
+    inf_state = InferenceState(params=params, history=history)
 
     return inf_state
 

--- a/gpjax/gps.py
+++ b/gpjax/gps.py
@@ -20,7 +20,7 @@ from .likelihoods import (
     NonConjugateLikelihoodType,
 )
 from .mean_functions import AbstractMeanFunction, Zero
-from .parameters import copy_dict_structure, evaluate_priors, transform
+from .parameters import copy_dict_structure, evaluate_priors
 from .types import Dataset
 from .utils import I, concat_dictionaries
 
@@ -194,7 +194,6 @@ class ConjugatePosterior(AbstractPosterior):
     def marginal_log_likelihood(
         self,
         train_data: Dataset,
-        transformations: Dict,
         priors: dict = None,
         negative: bool = False,
     ) -> tp.Callable[[dict], Float[Array, "1"]]:
@@ -202,7 +201,6 @@ class ConjugatePosterior(AbstractPosterior):
 
         Args:
             train_data (Dataset): The training dataset used to compute the marginal log-likelihood.
-            transformations (Dict): A dictionary of transformations that should be applied to the training dataset to unconstrain the parameters.
             priors (dict, optional): _description_. Optional argument that contains the priors placed on the model's parameters. Defaults to None.
             negative (bool, optional): Whether or not the returned function should be negative. For optimisation, the negative is useful as minimisation of the negative marginal log-likelihood is equivalent to maximisation of the marginal log-likelihood. Defaults to False.
 
@@ -214,8 +212,6 @@ class ConjugatePosterior(AbstractPosterior):
         def mll(
             params: dict,
         ):
-            params = transform(params=params, transform_map=transformations)
-
             # Observation noise σ²
             obs_noise = params["likelihood"]["obs_noise"]
             μx = self.prior.mean_function(x, params["mean_function"])
@@ -305,7 +301,6 @@ class NonConjugatePosterior(AbstractPosterior):
     def marginal_log_likelihood(
         self,
         train_data: Dataset,
-        transformations: Dict,
         priors: dict = None,
         negative: bool = False,
     ) -> tp.Callable[[dict], Float[Array, "1"]]:
@@ -313,7 +308,6 @@ class NonConjugatePosterior(AbstractPosterior):
 
         Args:
             train_data (Dataset): The training dataset used to compute the marginal log-likelihood.
-            transformations (Dict): A dictionary of transformations that should be applied to the training dataset to unconstrain the parameters.
             priors (dict, optional): _description_. Optional argument that contains the priors placed on the model's parameters. Defaults to None.
             negative (bool, optional): Whether or not the returned function should be negative. For optimisation, the negative is useful as minimisation of the negative marginal log-likelihood is equivalent to maximisation of the marginal log-likelihood. Defaults to False.
 
@@ -327,7 +321,6 @@ class NonConjugatePosterior(AbstractPosterior):
             priors["latent"] = dx.Normal(loc=0.0, scale=1.0)
 
         def mll(params: dict):
-            params = transform(params=params, transform_map=transformations)
             Kxx = gram(self.prior.kernel, x, params["kernel"])
             Kxx += I(n) * self.jitter
             Lx = jnp.linalg.cholesky(Kxx)

--- a/gpjax/parameters.py
+++ b/gpjax/parameters.py
@@ -22,7 +22,7 @@ Identity = dx.Lambda(forward=lambda x: x, inverse=lambda x: x)
 ################################
 @dataclass
 class ParameterState:
-    """The state of the model. This includes the parameter set and the functions that allow parameters to be constrained and unconstrained."""
+    """The state of the model. This includes the parameter set, which parameters are to be trained and bijectors that allow parameters to be constrained and unconstrained."""
 
     params: tp.Dict
     trainables: tp.Dict

--- a/gpjax/parameters.py
+++ b/gpjax/parameters.py
@@ -139,8 +139,8 @@ def build_bijectors(params: tp.Dict) -> tp.Dict:
     return recursive_bijectors(params, bijectors)
 
 
-def transform(params: tp.Dict, bijectors: tp.Dict, forward: bool) -> tp.Dict:
-    """Transform the parameters according to the constraining or unconstraining function dictionary.
+def constrain(params: tp.Dict, bijectors: tp.Dict) -> tp.Dict:
+    """Transform the parameters to the constrained space for corresponding bijectors.
 
     Args:
         params (tp.Dict): The parameters that are to be transformed.
@@ -151,10 +151,24 @@ def transform(params: tp.Dict, bijectors: tp.Dict, forward: bool) -> tp.Dict:
         tp.Dict: A transformed parameter set. The dictionary is equal in structure to the input params dictionary.
     """
 
-    fwd = lambda param, trans: trans.forward(param)
-    inv = lambda param, trans: trans.inverse(param)
+    map = lambda param, trans: trans.forward(param)
 
-    map = fwd if forward else inv
+    return jax.tree_util.tree_map(map, params, bijectors)
+
+
+def unconstrain(params: tp.Dict, bijectors: tp.Dict) -> tp.Dict:
+    """Transform the parameters to the unconstrained space for corresponding bijectors.
+
+    Args:
+        params (tp.Dict): The parameters that are to be transformed.
+        transform_map (tp.Dict): The corresponding dictionary of transforms that should be applied to the parameter set.
+        foward (bool): Whether the parameters should be constrained (foward=True) or unconstrained (foward=False).
+
+    Returns:
+        tp.Dict: A transformed parameter set. The dictionary is equal in structure to the input params dictionary.
+    """
+
+    map = lambda param, trans: trans.inverse(param)
 
     return jax.tree_util.tree_map(map, params, bijectors)
 

--- a/gpjax/parameters.py
+++ b/gpjax/parameters.py
@@ -139,43 +139,38 @@ def build_bijectors(params: tp.Dict) -> tp.Dict:
     return recursive_bijectors(params, bijectors)
 
 
-def constrain(state: ParameterState) -> ParameterState:
-    """Transform the parameters to a constrained space using the corresponding set of bijectors.
+def constrain(params: tp.Dict, bijectors: tp.Dict) -> tp.Dict:
+    """Transform the parameters to the constrained space for corresponding bijectors.
 
     Args:
-        state (ParameterState): The state object containing the parameters and corresponding bijectors that are to be transformed.
+        params (tp.Dict): The parameters that are to be transformed.
+        transform_map (tp.Dict): The corresponding dictionary of transforms that should be applied to the parameter set.
+        foward (bool): Whether the parameters should be constrained (foward=True) or unconstrained (foward=False).
 
     Returns:
-        ParameterState: A transformed parameter set. The state object is equal in structure to the input state, the only difference being that the parameters have now been constrained.
+        tp.Dict: A transformed parameter set. The dictionary is equal in structure to the input params dictionary.
     """
 
-    params, bijectors = state.params, state.bijectors
     map = lambda param, trans: trans.forward(param)
-    transformed_params = jax.tree_util.tree_map(map, params, bijectors)
-    return ParameterState(
-        params=transformed_params,
-        trainables=state.trainables,
-        bijectors=bijectors,
-    )
+
+    return jax.tree_util.tree_map(map, params, bijectors)
 
 
-def unconstrain(state: ParameterState) -> ParameterState:
-    """Transform the parameters to a unconstrained space using the corresponding set of  bijectors.
+def unconstrain(params: tp.Dict, bijectors: tp.Dict) -> tp.Dict:
+    """Transform the parameters to the unconstrained space for corresponding bijectors.
 
     Args:
-        state (ParameterState): The state object containing the parameters and corresponding bijectors that are to be transformed.
+        params (tp.Dict): The parameters that are to be transformed.
+        transform_map (tp.Dict): The corresponding dictionary of transforms that should be applied to the parameter set.
+        foward (bool): Whether the parameters should be constrained (foward=True) or unconstrained (foward=False).
 
     Returns:
-        ParameterState: A transformed parameter set. The state object is equal in structure to the input state, the only difference being that the parameters have now been unconstrained.
+        tp.Dict: A transformed parameter set. The dictionary is equal in structure to the input params dictionary.
     """
-    params, bijectors = state.params, state.bijectors
+
     map = lambda param, trans: trans.inverse(param)
-    transformed_params = jax.tree_util.tree_map(map, params, bijectors)
-    return ParameterState(
-        params=transformed_params,
-        trainables=state.trainables,
-        bijectors=bijectors,
-    )
+
+    return jax.tree_util.tree_map(map, params, bijectors)
 
 
 ################################
@@ -275,12 +270,8 @@ def stop_grad(param: tp.Dict, trainable: tp.Dict):
     return jax.lax.cond(trainable, lambda x: x, jax.lax.stop_gradient, param)
 
 
-def trainable_params(state: ParameterState) -> ParameterState:
+def trainable_params(params: tp.Dict, trainables: tp.Dict) -> tp.Dict:
     """Stop the gradients flowing through parameters whose trainable status is False"""
-    params, trainables = state.params, state.trainables
-    trainable_params = jax.tree_util.tree_map(
+    return jax.tree_util.tree_map(
         lambda param, trainable: stop_grad(param, trainable), params, trainables
-    )
-    return ParameterState(
-        params=trainable_params, trainables=trainables, bijectors=state.bijectors
     )

--- a/gpjax/parameters.py
+++ b/gpjax/parameters.py
@@ -173,26 +173,6 @@ def unconstrain(params: tp.Dict, bijectors: tp.Dict) -> tp.Dict:
     return jax.tree_util.tree_map(map, params, bijectors)
 
 
-def transform_state(
-    state: ParameterState, projection_fn: tp.Callable[[tp.Dict, tp.Dict], tp.Dict]
-) -> ParameterState:
-    """Transfrom the parameters of a `ParameterState` object using the corresponding set of bijectors.
-    The projection function accepts the parameters and corresponding bijectors as a dictionary input and
-    returns a dictionary of transformed parameters.
-
-    Args:
-        state (ParameterState): The ParameterState object to be transformed.
-        projection_fn (tp.Callable[[tp.Dict, tp.Dict], tp.Dict]): The projection function that transforms the parameters.
-
-    Returns:
-        ParameterState: A transformed ParameterState object.
-    """
-    params = projection_fn(state.params, state.bijectors)
-    return ParameterState(
-        params=params, trainables=state.trainables, bijectors=state.bijectors
-    )
-
-
 ################################
 # Priors
 ################################

--- a/gpjax/parameters.py
+++ b/gpjax/parameters.py
@@ -1,6 +1,5 @@
 import typing as tp
 import warnings
-from collections import namedtuple
 from copy import deepcopy
 from warnings import warn
 
@@ -27,11 +26,10 @@ class ParameterState:
 
     params: tp.Dict
     trainables: tp.Dict
-    constrainers: tp.Dict
-    unconstrainers: tp.Dict
+    bijectors: tp.Dict
 
     def unpack(self):
-        return self.params, self.trainables, self.constrainers, self.unconstrainers
+        return self.params, self.trainables, self.bijectors
 
 
 def initialise(model, key: PRNGKeyType = None, **kwargs) -> ParameterState:
@@ -44,13 +42,12 @@ def initialise(model, key: PRNGKeyType = None, **kwargs) -> ParameterState:
         _validate_kwargs(kwargs, params)
         for k, v in kwargs.items():
             params[k] = merge_dictionaries(params[k], v)
-    constrainers, unconstrainers = build_transforms(params)
+    bijectors = build_bijectors(params)
     trainables = build_trainables(params)
     state = ParameterState(
         params=params,
         trainables=trainables,
-        constrainers=constrainers,
-        unconstrainers=unconstrainers,
+        bijectors=bijectors,
     )
     return state
 
@@ -92,8 +89,6 @@ def recursive_complete(d1: tp.Dict, d2: tp.Dict) -> tp.Dict:
         if type(value) is dict:
             if key in d2.keys():
                 recursive_complete(value, d2[key])
-            # else:
-            #     pass
         else:
             if key in d2.keys():
                 d1[key] = d2[key]
@@ -144,54 +139,24 @@ def build_bijectors(params: tp.Dict) -> tp.Dict:
     return recursive_bijectors(params, bijectors)
 
 
-def build_transforms(params: tp.Dict) -> tp.Tuple[tp.Dict, tp.Dict]:
-    """Using the bijector that is associated with each parameter, construct a pair of functions from the bijector that allow the parameter to be constrained and unconstrained.
-
-    Args:
-        params (tp.Dict): The parameter set for which transformations should be derived from.
-
-    Returns:
-        tp.Tuple[tp.Dict, tp.Dict]: A pair of dictionaries. The first dictionary maps each parameter to a function that constrains the parameter. The second dictionary maps each parameter to a function that unconstrains the parameter.
-    """
-
-    def forward(bijector):
-        return bijector.forward
-
-    def inverse(bijector):
-        return bijector.inverse
-
-    bijectors = build_bijectors(params)
-
-    constrainers = jax.tree_util.tree_map(lambda _: forward, deepcopy(params))
-    unconstrainers = jax.tree_util.tree_map(lambda _: inverse, deepcopy(params))
-
-    constrainers = jax.tree_util.tree_map(lambda f, b: f(b), constrainers, bijectors)
-    unconstrainers = jax.tree_util.tree_map(
-        lambda f, b: f(b), unconstrainers, bijectors
-    )
-
-    return constrainers, unconstrainers
-
-
-def transform(params: tp.Dict, transform_map: tp.Dict) -> tp.Dict:
+def transform(params: tp.Dict, bijectors: tp.Dict, forward: bool) -> tp.Dict:
     """Transform the parameters according to the constraining or unconstraining function dictionary.
 
     Args:
         params (tp.Dict): The parameters that are to be transformed.
         transform_map (tp.Dict): The corresponding dictionary of transforms that should be applied to the parameter set.
+        foward (bool): Whether the parameters should be constrained (foward=True) or unconstrained (foward=False).
 
     Returns:
-        tp.Dict: A transformed parameter set.s The dictionary is equal in structure to the input params dictionary.
+        tp.Dict: A transformed parameter set. The dictionary is equal in structure to the input params dictionary.
     """
-    warn(
-        "`transform` will be deprecated in a future release. As of v0.5.0, please use `constrain`"
-        " or `unconstrain` instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return jax.tree_util.tree_map(
-        lambda param, trans: trans(param), params, transform_map
-    )
+
+    fwd = lambda param, trans: trans.forward(param)
+    inv = lambda param, trans: trans.inverse(param)
+
+    map = fwd if forward else inv
+
+    return jax.tree_util.tree_map(map, params, bijectors)
 
 
 ################################

--- a/gpjax/parameters.py
+++ b/gpjax/parameters.py
@@ -173,6 +173,26 @@ def unconstrain(params: tp.Dict, bijectors: tp.Dict) -> tp.Dict:
     return jax.tree_util.tree_map(map, params, bijectors)
 
 
+def transform_state(
+    state: ParameterState, projection_fn: tp.Callable[[tp.Dict, tp.Dict], tp.Dict]
+) -> ParameterState:
+    """Transfrom the parameters of a `ParameterState` object using the corresponding set of bijectors.
+    The projection function accepts the parameters and corresponding bijectors as a dictionary input and
+    returns a dictionary of transformed parameters.
+
+    Args:
+        state (ParameterState): The ParameterState object to be transformed.
+        projection_fn (tp.Callable[[tp.Dict, tp.Dict], tp.Dict]): The projection function that transforms the parameters.
+
+    Returns:
+        ParameterState: A transformed ParameterState object.
+    """
+    params = projection_fn(state.params, state.bijectors)
+    return ParameterState(
+        params=params, trainables=state.trainables, bijectors=state.bijectors
+    )
+
+
 ################################
 # Priors
 ################################

--- a/gpjax/variational_inference.py
+++ b/gpjax/variational_inference.py
@@ -40,7 +40,8 @@ class AbstractVariationalInference:
 
     @abc.abstractmethod
     def elbo(
-        self, train_data: Dataset,
+        self,
+        train_data: Dataset,
     ) -> Callable[[Dict], Float[Array, "1"]]:
         """Placeholder method for computing the evidence lower bound function (ELBO), given a training dataset and a set of transformations that map each parameter onto the entire real line.
 
@@ -138,7 +139,7 @@ class CollapsedVI(AbstractVariationalInference):
 
     def elbo(
         self, train_data: Dataset, negative: bool = False
-    ) -> Callable[[dict],Float[Array, "1"]:]:
+    ) -> Callable[[dict], Float[Array, "1"]]:
         """Compute the evidence lower bound under this model. In short, this requires evaluating the expectation of the model's log-likelihood under the variational approximation. To this, we sum the KL divergence from the variational posterior to the prior. When batching occurs, the result is scaled by the batch size relative to the full dataset size.
 
         Args:

--- a/tests/test_abstractions.py
+++ b/tests/test_abstractions.py
@@ -4,8 +4,9 @@ import optax
 import pytest
 
 import gpjax as gpx
-from gpjax import RBF, Dataset, Gaussian, Prior, initialise, transform
+from gpjax import RBF, Dataset, Gaussian, Prior, initialise
 from gpjax.abstractions import InferenceState, fit, fit_batches, get_batch
+from gpjax.parameters import build_bijectors
 
 
 @pytest.mark.parametrize("n_iters", [10])
@@ -16,13 +17,12 @@ def test_fit(n_iters, n):
     y = jnp.sin(x) + jr.normal(key=key, shape=x.shape) * 0.1
     D = Dataset(X=x, y=y)
     p = Prior(kernel=RBF()) * Gaussian(num_datapoints=n)
-    params, trainable_status, constrainer, unconstrainer = initialise(p, key).unpack()
-    mll = p.marginal_log_likelihood(D, constrainer, negative=True)
+    params, trainables, bijectors = initialise(p, key).unpack()
+    mll = p.marginal_log_likelihood(D, negative=True)
     pre_mll_val = mll(params)
     optimiser = optax.adam(learning_rate=0.1)
-    inference_state = fit(mll, params, trainable_status, optimiser, n_iters)
+    inference_state = fit(mll, params, trainables, bijectors, optimiser, n_iters)
     optimised_params, history = inference_state.params, inference_state.history
-    optimised_params = transform(optimised_params, constrainer)
     assert isinstance(inference_state, InferenceState)
     assert isinstance(optimised_params, dict)
     assert mll(optimised_params) < pre_mll_val
@@ -33,9 +33,10 @@ def test_fit(n_iters, n):
 def test_stop_grads():
     params = {"x": jnp.array(3.0), "y": jnp.array(4.0)}
     trainables = {"x": True, "y": False}
+    bijectors = build_bijectors(params)
     loss_fn = lambda params: params["x"] ** 2 + params["y"] ** 2
     optimiser = optax.adam(learning_rate=0.1)
-    inference_state = fit(loss_fn, params, trainables, optimiser, n_iters=1)
+    inference_state = fit(loss_fn, params, trainables, bijectors, optimiser, n_iters=1)
     learned_params = inference_state.params
     assert isinstance(inference_state, InferenceState)
     assert learned_params["y"] == params["y"]
@@ -58,23 +59,22 @@ def test_batch_fitting(n_iters, nb, ndata):
     q = gpx.VariationalGaussian(prior=prior, inducing_inputs=z)
 
     svgp = gpx.StochasticVI(posterior=p, variational_family=q)
-    params, trainable_status, constrainer, unconstrainer = initialise(
-        svgp, key
-    ).unpack()
-    params = gpx.transform(params, unconstrainer)
-    objective = svgp.elbo(D, constrainer)
+    params, trainables, bijectors = initialise(svgp, key).unpack()
+    objective = svgp.elbo(D)
+
+    pre_mll_val = objective(params, D)
 
     D = Dataset(X=x, y=y)
 
     optimiser = optax.adam(learning_rate=0.1)
     key = jr.PRNGKey(42)
     inference_state = fit_batches(
-        objective, params, trainable_status, D, optimiser, key, nb, n_iters
+        objective, params, trainables, bijectors, D, optimiser, key, nb, n_iters
     )
     optimised_params, history = inference_state.params, inference_state.history
-    optimised_params = transform(optimised_params, constrainer)
     assert isinstance(inference_state, InferenceState)
     assert isinstance(optimised_params, dict)
+    assert objective(optimised_params, D) < pre_mll_val
     assert isinstance(history, jnp.ndarray)
     assert history.shape[0] == n_iters
 

--- a/tests/test_gp.py
+++ b/tests/test_gp.py
@@ -5,7 +5,7 @@ import jax.numpy as jnp
 import jax.random as jr
 import pytest
 
-from gpjax import Dataset, initialise, transform
+from gpjax import Dataset, initialise
 from gpjax.gps import (
     AbstractGP,
     ConjugatePosterior,
@@ -60,7 +60,6 @@ def test_conjugate_posterior(num_datapoints):
 
     parameter_state = initialise(post, key)
     params, _, bijectors = parameter_state.unpack()
-    params = transform(params, bijectors, forward=False)
 
     # Marginal likelihood
     mll = post.marginal_log_likelihood(train_data=D)
@@ -101,8 +100,7 @@ def test_nonconjugate_posterior(num_datapoints, likel):
     assert isinstance(p, AbstractGP)
 
     parameter_state = initialise(post, key)
-    params, _, bijectors = parameter_state.unpack()
-    params = transform(params, bijectors, forward=False)
+    params, _, _ = parameter_state.unpack()
     assert isinstance(parameter_state, ParameterState)
 
     # Marginal likelihood

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -36,7 +36,7 @@ def test_gram(kern, dim, fn):
     if dim > 1:
         x = jnp.hstack([x] * dim)
     parameter_state = initialise(kern, key)
-    params, trainable_status, constrainer, unconstrainer = parameter_state.unpack()
+    params, _, _ = parameter_state.unpack()
     gram_matrix = fn(kern, x, params)
     assert gram_matrix.shape[0] == x.shape[0]
     assert gram_matrix.shape[0] == gram_matrix.shape[1]
@@ -50,7 +50,7 @@ def test_cross_covariance(kern, n1, n2):
     x1 = jnp.linspace(-1.0, 1.0, num=n1).reshape(-1, 1)
     x2 = jnp.linspace(-1.0, 1.0, num=n2).reshape(-1, 1)
     parameter_state = initialise(kern, key)
-    params, trainable_status, constrainer, unconstrainer = parameter_state.unpack()
+    params, _, _ = parameter_state.unpack()
     kernel_matrix = cross_covariance(kern, x1, x2, params)
     assert kernel_matrix.shape == (n1, n2)
 
@@ -59,7 +59,7 @@ def test_cross_covariance(kern, n1, n2):
 def test_call(kernel):
     key = jr.PRNGKey(123)
     parameter_state = initialise(kernel, key)
-    params, trainable_status, constrainer, unconstrainer = parameter_state.unpack()
+    params, _, _ = parameter_state.unpack()
     x, y = jnp.array([[1.0]]), jnp.array([[0.5]])
     point_corr = kernel(x, y, params)
     assert isinstance(point_corr, jnp.DeviceArray)
@@ -93,7 +93,7 @@ def test_initialisation(kernel, dim):
     else:
         kern = kernel(active_dims=[i for i in range(dim)])
         parameter_state = initialise(kern, key)
-        params, trainable_status, constrainer, unconstrainer = parameter_state.unpack()
+        params, _, _ = parameter_state.unpack()
         assert list(params.keys()) == ["lengthscale", "variance"]
         assert all(params["lengthscale"] == jnp.array([1.0] * dim))
         assert params["variance"] == jnp.array([1.0])
@@ -107,7 +107,7 @@ def test_initialisation(kernel, dim):
 def test_dtype(kernel):
     key = jr.PRNGKey(123)
     parameter_state = initialise(kernel(), key)
-    params, trainable_status, constrainer, unconstrainer = parameter_state.unpack()
+    params, _, _ = parameter_state.unpack()
     for k, v in params.items():
         assert v.dtype == jnp.float64
 

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -25,7 +25,7 @@ true_initialisation = {
 def test_initialisers(num_datapoints, lik):
     key = jr.PRNGKey(123)
     lhood = lik(num_datapoints=num_datapoints)
-    params, _, _, _ = initialise(lhood, key).unpack()
+    params, _, _ = initialise(lhood, key).unpack()
     assert list(params.keys()) == true_initialisation[lhood.name]
     assert len(list(params.values())) == len(true_initialisation[lhood.name])
 
@@ -37,7 +37,7 @@ def test_predictive_moment(n):
     fmean = jr.uniform(key=key, shape=(n,)) * -1
     fvar = jr.uniform(key=key, shape=(n,))
     pred_mom_fn = lhood.predictive_moment_fn
-    params, _, _, _ = initialise(lhood, key).unpack()
+    params, _, _ = initialise(lhood, key).unpack()
     rv = pred_mom_fn(fmean, fvar, params)
     mu = rv.mean()
     sigma = rv.variance()
@@ -51,7 +51,7 @@ def test_predictive_moment(n):
 def test_link_fns(lik: AbstractLikelihood, n: int):
     key = jr.PRNGKey(123)
     lhood = lik(num_datapoints=n)
-    params, _, _, _ = initialise(lhood, key).unpack()
+    params, _, _ = initialise(lhood, key).unpack()
     link_fn = lhood.link_function
     assert isinstance(link_fn, tp.Callable)
     x = jnp.linspace(-3.0, 3.0).reshape(-1, 1)

--- a/tests/test_mean_functions.py
+++ b/tests/test_mean_functions.py
@@ -16,7 +16,7 @@ def test_shape(meanf, dim):
     x = jnp.linspace(-1.0, 1.0, num=10).reshape(-1, 1)
     if dim > 1:
         x = jnp.hstack([x] * dim)
-    params, _, _, _ = initialise(meanf, key).unpack()
+    params, _, _ = initialise(meanf, key).unpack()
     mu = meanf(x, params)
     assert mu.shape[0] == x.shape[0]
     assert mu.shape[1] == dim
@@ -25,5 +25,5 @@ def test_shape(meanf, dim):
 @pytest.mark.parametrize("meanf", [Zero, Constant])
 def test_initialisers(meanf):
     key = jr.PRNGKey(123)
-    params, _, _, _ = initialise(meanf(), key).unpack()
+    params, _, _ = initialise(meanf(), key).unpack()
     assert isinstance(params, tp.Dict)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -11,6 +11,7 @@ from gpjax.kernels import RBF
 from gpjax.likelihoods import Bernoulli, Gaussian
 from gpjax.parameters import (
     build_bijectors,
+    constrain,
     copy_dict_structure,
     evaluate_priors,
     initialise,
@@ -19,7 +20,7 @@ from gpjax.parameters import (
     recursive_complete,
     recursive_items,
     structure_priors,
-    transform,
+    unconstrain,
 )
 
 
@@ -234,11 +235,11 @@ def test_output(num_datapoints, likelihood):
         assert isinstance(v1.forward, tp.Callable)
         assert isinstance(v2.inverse, tp.Callable)
 
-    unconstrained_params = transform(params, bijectors, forward=False)
+    unconstrained_params = unconstrain(params, bijectors)
     assert (
         unconstrained_params["kernel"]["lengthscale"] != params["kernel"]["lengthscale"]
     )
-    backconstrained_params = transform(unconstrained_params, bijectors, forward=True)
+    backconstrained_params = constrain(unconstrained_params, bijectors)
     for k, v1, v2 in recursive_items(params, unconstrained_params):
         assert v1.dtype == v2.dtype
 

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -9,8 +9,8 @@ from tensorflow_probability.substrates.jax import distributions as tfd
 from gpjax.gps import Prior
 from gpjax.kernels import RBF
 from gpjax.likelihoods import Bernoulli, Gaussian
-from gpjax.parameters import (  # build_all_transforms,
-    build_transforms,
+from gpjax.parameters import (
+    build_bijectors,
     copy_dict_structure,
     evaluate_priors,
     initialise,
@@ -30,7 +30,7 @@ from gpjax.parameters import (  # build_all_transforms,
 def test_initialise(lik):
     key = jr.PRNGKey(123)
     posterior = Prior(kernel=RBF()) * lik(num_datapoints=10)
-    params, _, _, _ = initialise(posterior, key).unpack()
+    params, _, _ = initialise(posterior, key).unpack()
     assert list(sorted(params.keys())) == [
         "kernel",
         "likelihood",
@@ -40,7 +40,7 @@ def test_initialise(lik):
 
 def test_non_conjugate_initialise():
     posterior = Prior(kernel=RBF()) * Bernoulli(num_datapoints=10)
-    params, _, _, _ = initialise(posterior, jr.PRNGKey(123)).unpack()
+    params, _, _ = initialise(posterior, jr.PRNGKey(123)).unpack()
     assert list(sorted(params.keys())) == [
         "kernel",
         "latent",
@@ -64,7 +64,7 @@ def test_lpd(x):
 @pytest.mark.parametrize("lik", [Gaussian, Bernoulli])
 def test_prior_template(lik):
     posterior = Prior(kernel=RBF()) * lik(num_datapoints=10)
-    params, _, _, _ = initialise(posterior, jr.PRNGKey(123)).unpack()
+    params, _, _ = initialise(posterior, jr.PRNGKey(123)).unpack()
     prior_container = copy_dict_structure(params)
     for (
         k,
@@ -77,7 +77,7 @@ def test_prior_template(lik):
 @pytest.mark.parametrize("lik", [Gaussian, Bernoulli])
 def test_recursive_complete(lik):
     posterior = Prior(kernel=RBF()) * lik(num_datapoints=10)
-    params, _, _, _ = initialise(posterior, jr.PRNGKey(123)).unpack()
+    params, _, _ = initialise(posterior, jr.PRNGKey(123)).unpack()
     priors = {"kernel": {}}
     priors["kernel"]["lengthscale"] = tfd.HalfNormal(scale=2.0)
     container = copy_dict_structure(params)
@@ -167,7 +167,7 @@ def test_checks(num_datapoints):
 
 def test_structure_priors():
     posterior = Prior(kernel=RBF()) * Gaussian(num_datapoints=10)
-    params, _, _, _ = initialise(posterior, jr.PRNGKey(123)).unpack()
+    params, _, _ = initialise(posterior, jr.PRNGKey(123)).unpack()
     priors = {
         "kernel": {
             "lengthscale": tfd.Gamma(1.0, 1.0),
@@ -227,21 +227,18 @@ def test_prior_checks(latent_prior):
 @pytest.mark.parametrize("likelihood", [Gaussian, Bernoulli])
 def test_output(num_datapoints, likelihood):
     posterior = Prior(kernel=RBF()) * likelihood(num_datapoints=num_datapoints)
-    params, _, constrainer, unconstrainer = initialise(
-        posterior, jr.PRNGKey(123)
-    ).unpack()
+    params, _, bijectors = initialise(posterior, jr.PRNGKey(123)).unpack()
 
-    assert isinstance(constrainer, dict)
-    assert isinstance(unconstrainer, dict)
-    for k, v1, v2 in recursive_items(constrainer, unconstrainer):
-        assert isinstance(v1, tp.Callable)
-        assert isinstance(v2, tp.Callable)
+    assert isinstance(bijectors, dict)
+    for k, v1, v2 in recursive_items(bijectors, bijectors):
+        assert isinstance(v1.forward, tp.Callable)
+        assert isinstance(v2.inverse, tp.Callable)
 
-    unconstrained_params = transform(params, unconstrainer)
+    unconstrained_params = transform(params, bijectors, forward=False)
     assert (
         unconstrained_params["kernel"]["lengthscale"] != params["kernel"]["lengthscale"]
     )
-    backconstrained_params = transform(unconstrained_params, constrainer)
+    backconstrained_params = transform(unconstrained_params, bijectors, forward=True)
     for k, v1, v2 in recursive_items(params, unconstrained_params):
         assert v1.dtype == v2.dtype
 
@@ -250,8 +247,8 @@ def test_output(num_datapoints, likelihood):
 
     augmented_params = params
     augmented_params["test_param"] = jnp.array([1.0])
-    a_constrainers, a_unconstrainers = build_transforms(augmented_params)
-    assert "test_param" in list(a_constrainers.keys())
-    assert "test_param" in list(a_unconstrainers.keys())
-    assert a_constrainers["test_param"](jnp.array([1.0])) == 1.0
-    assert a_unconstrainers["test_param"](jnp.array([1.0])) == 1.0
+    a_bijectors = build_bijectors(augmented_params)
+
+    assert "test_param" in list(a_bijectors.keys())
+    assert a_bijectors["test_param"].forward(jnp.array([1.0])) == 1.0
+    assert a_bijectors["test_param"].inverse(jnp.array([1.0])) == 1.0

--- a/tests/test_variational_inference.py
+++ b/tests/test_variational_inference.py
@@ -62,19 +62,16 @@ def test_stochastic_vi(
     assert svgp.posterior.prior == post.prior
     assert svgp.posterior.likelihood == post.likelihood
 
-    params, _, constrainer, unconstrainer = gpx.initialise(
-        svgp, jr.PRNGKey(123)
-    ).unpack()
-    params = gpx.transform(params, unconstrainer)
+    params, _, _ = gpx.initialise(svgp, jr.PRNGKey(123)).unpack()
 
     assert svgp.prior == post.prior
     assert svgp.likelihood == post.likelihood
     assert svgp.num_inducing == n_inducing_points
 
     if jit_fns:
-        elbo_fn = jax.jit(svgp.elbo(D, constrainer))
+        elbo_fn = jax.jit(svgp.elbo(D))
     else:
-        elbo_fn = svgp.elbo(D, constrainer)
+        elbo_fn = svgp.elbo(D)
     assert isinstance(elbo_fn, tp.Callable)
     elbo_value = elbo_fn(params, D)
     assert isinstance(elbo_value, jnp.ndarray)
@@ -103,19 +100,16 @@ def test_collapsed_vi(n_datapoints, n_inducing_points, jit_fns, point_dim):
     assert sgpr.posterior.prior == post.prior
     assert sgpr.posterior.likelihood == post.likelihood
 
-    params, _, constrainer, unconstrainer = gpx.initialise(
-        sgpr, jr.PRNGKey(123)
-    ).unpack()
-    params = gpx.transform(params, unconstrainer)
+    params, _, _ = gpx.initialise(sgpr, jr.PRNGKey(123)).unpack()
 
     assert sgpr.prior == post.prior
     assert sgpr.likelihood == post.likelihood
     assert sgpr.num_inducing == n_inducing_points
 
     if jit_fns:
-        elbo_fn = jax.jit(sgpr.elbo(D, constrainer))
+        elbo_fn = jax.jit(sgpr.elbo(D))
     else:
-        elbo_fn = sgpr.elbo(D, constrainer)
+        elbo_fn = sgpr.elbo(D)
     assert isinstance(elbo_fn, tp.Callable)
     elbo_value = elbo_fn(params)
     assert isinstance(elbo_value, jnp.ndarray)


### PR DESCRIPTION
The PR refactors transformations #105.

Transformations have been removed from objective functions e.g. the marginal likelihood. So instead of e.g., `objective = posterior.mll(D, transformation, negative=True)`, we now do `objective = posterior.mll(D, negative=True)`. The transformations are instead placed with training loops.

To remove clutter, we remove the dictionary `constrainers` and `unconstrainers` notion, and instead define transformations via bijectors. In particular:

- The `ParameterState` dataclass now comprises `params`,` trainables `and `bijectors`. So e.g. calling `parameter_state = gpx.initialise(posterior, key)`and then `parameter_state.unpack()` returns a tuple `params, trainables, bijectors`.

- The function `gpx.transform` has been removed. To transform parameters to the constrained space, we now do `gpx.constrain(params, bijectors)` and likewise to transform to the unconstrained space, we do `gpx.unconstrain(params, bijectors)`.


Finally, we now define training loops in abstractions e.g. `fit` directly on a `ParameterState` dataclass (i.e., we don't pass through the params dictionary, trainables dictionary and the transformations, as we used to do).