### PR TITLE
Prevent f64 default

### DIFF
--- a/examples/barycentres.pct.py
+++ b/examples/barycentres.pct.py
@@ -23,16 +23,19 @@
 # %%
 import typing as tp
 
+import distrax as dx
 import jax
 import jax.numpy as jnp
 import jax.random as jr
 import jax.scipy.linalg as jsl
 import matplotlib.pyplot as plt
-import distrax as dx
 import optax as ox
+from jax.config import config
 
 import gpjax as gpx
 
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 key = jr.PRNGKey(123)
 
 # %% [markdown]

--- a/examples/classification.pct.py
+++ b/examples/classification.pct.py
@@ -28,10 +28,13 @@ import jax.random as jr
 import jax.scipy as jsp
 import matplotlib.pyplot as plt
 import optax as ox
+from jax.config import config
 from jaxtyping import Array, Float
 
 import gpjax as gpx
 
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 I = jnp.eye
 key = jr.PRNGKey(123)
 

--- a/examples/collapsed_vi.pct.py
+++ b/examples/collapsed_vi.pct.py
@@ -25,9 +25,12 @@ import jax.random as jr
 import matplotlib.pyplot as plt
 import optax as ox
 from jax import jit
+from jax.config import config
 
 import gpjax as gpx
 
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 key = jr.PRNGKey(123)
 
 # %% [markdown]
@@ -116,7 +119,7 @@ learned_params, training_history = inference_state.unpack()
 latent_dist = q.predict(D, learned_params)(xtest)
 predictive_dist = likelihood(latent_dist, learned_params)
 
-samples = latent_dist.sample(seed=key, sample_shape=(20, ))
+samples = latent_dist.sample(seed=key, sample_shape=(20,))
 
 predictive_mean = predictive_dist.mean()
 predictive_std = predictive_dist.stddev()

--- a/examples/graph_kernels.pct.py
+++ b/examples/graph_kernels.pct.py
@@ -28,9 +28,12 @@ import matplotlib.pyplot as plt
 import networkx as nx
 import optax as ox
 from jax import jit
+from jax.config import config
 
 import gpjax as gpx
 
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 key = jr.PRNGKey(123)
 
 # %% [markdown]

--- a/examples/haiku.pct.py
+++ b/examples/haiku.pct.py
@@ -29,11 +29,14 @@ import jax.random as jr
 import matplotlib.pyplot as plt
 import optax as ox
 from chex import dataclass
+from jax.config import config
 from scipy.signal import sawtooth
 
 import gpjax as gpx
-from gpjax.kernels import Kernel, DenseKernelComputation
+from gpjax.kernels import DenseKernelComputation, Kernel
 
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 key = jr.PRNGKey(123)
 
 # %% [markdown]

--- a/examples/kernels.pct.py
+++ b/examples/kernels.pct.py
@@ -26,11 +26,14 @@ import jax.numpy as jnp
 import jax.random as jr
 import matplotlib.pyplot as plt
 from jax import jit
+from jax.config import config
 from jaxtyping import Array, Float
 from optax import adam
 
 import gpjax as gpx
 
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 key = jr.PRNGKey(123)
 
 # %% [markdown]

--- a/examples/natgrads.pct.py
+++ b/examples/natgrads.pct.py
@@ -26,9 +26,12 @@ import jax.random as jr
 import matplotlib.pyplot as plt
 import optax as ox
 from jax import jit, lax
+from jax.config import config
 
 import gpjax as gpx
 
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 key = jr.PRNGKey(123)
 
 # %% [markdown]

--- a/examples/regression.pct.py
+++ b/examples/regression.pct.py
@@ -26,9 +26,12 @@ import jax.random as jr
 import matplotlib.pyplot as plt
 import optax as ox
 from jax import jit
+from jax.config import config
 
 import gpjax as gpx
 
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 pp = PrettyPrinter(indent=4)
 key = jr.PRNGKey(123)
 

--- a/examples/tfp_integration.pct.py
+++ b/examples/tfp_integration.pct.py
@@ -25,10 +25,13 @@ import jax
 import jax.numpy as jnp
 import jax.random as jr
 import matplotlib.pyplot as plt
+from jax.config import config
 
 import gpjax as gpx
 from gpjax.utils import dict_array_coercion
 
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 pp = PrettyPrinter(indent=4)
 key = jr.PRNGKey(123)
 

--- a/examples/uncollapsed_vi.pct.py
+++ b/examples/uncollapsed_vi.pct.py
@@ -25,9 +25,12 @@ import jax.random as jr
 import matplotlib.pyplot as plt
 import optax as ox
 from jax import jit
+from jax.config import config
 
 import gpjax as gpx
 
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 key = jr.PRNGKey(123)
 
 # %% [markdown]

--- a/examples/yacht.pct.py
+++ b/examples/yacht.pct.py
@@ -19,7 +19,10 @@ import jax.random as jr
 import matplotlib.pyplot as plt
 import numpy as np
 import optax as ox
+from jax.config import config
 
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 # %% [markdown]
 # # UCI Data Benchmarking
 #

--- a/gpjax/__init__.py
+++ b/gpjax/__init__.py
@@ -13,11 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-from jax.config import config
-
-# Enable Float64 for more stable matrix inversions.
-config.update("jax_enable_x64", True)
-
 from .abstractions import fit, fit_batches, fit_natgrads
 from .gps import Prior, construct_posterior
 from .kernels import (

--- a/tests/test_abstractions.py
+++ b/tests/test_abstractions.py
@@ -17,11 +17,15 @@ import jax.numpy as jnp
 import jax.random as jr
 import optax
 import pytest
+from jax.config import config
 
 import gpjax as gpx
 from gpjax import RBF, Dataset, Gaussian, Prior, initialise
 from gpjax.abstractions import InferenceState, fit, fit_batches, fit_natgrads, get_batch
 from gpjax.parameters import ParameterState, build_bijectors
+
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 
 
 @pytest.mark.parametrize("n_iters", [1, 5])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,9 +13,14 @@
 # limitations under the License.
 # ==============================================================================
 
-from ml_collections import ConfigDict
-from gpjax.config import add_parameter, get_defaults, Identity
 import distrax as dx
+from jax.config import config
+from ml_collections import ConfigDict
+
+from gpjax.config import Identity, add_parameter, get_defaults
+
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 
 
 def test_add_parameter():

--- a/tests/test_covariance_operator.py
+++ b/tests/test_covariance_operator.py
@@ -17,7 +17,10 @@
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
+from jax.config import config
 
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 from gpjax.covariance_operator import (
     CovarianceOperator,
     DenseCovarianceOperator,

--- a/tests/test_gps.py
+++ b/tests/test_gps.py
@@ -15,10 +15,11 @@
 
 import typing as tp
 
+import distrax as dx
 import jax.numpy as jnp
 import jax.random as jr
-import distrax as dx
 import pytest
+from jax.config import config
 
 from gpjax import Dataset, initialise
 from gpjax.gps import (
@@ -32,6 +33,8 @@ from gpjax.kernels import RBF, Matern12, Matern32, Matern52
 from gpjax.likelihoods import Bernoulli, Gaussian
 from gpjax.parameters import ParameterState
 
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 NonConjugateLikelihoods = [Bernoulli]
 
 

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -22,6 +22,7 @@ import jax.random as jr
 import networkx as nx
 import numpy as np
 import pytest
+from jax.config import config
 from jaxtyping import Array, Float
 
 from gpjax.covariance_operator import (
@@ -47,6 +48,8 @@ from gpjax.kernels import (
 from gpjax.parameters import initialise
 from gpjax.types import PRNGKeyType
 
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 """Default values for tests"""
 _initialise_key = jr.PRNGKey(123)
 _jitter = 100

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -15,11 +15,12 @@
 
 import typing as tp
 
-import jax.numpy as jnp
-import numpy as np
-import jax.random as jr
-import pytest
 import distrax as dx
+import jax.numpy as jnp
+import jax.random as jr
+import numpy as np
+import pytest
+from jax.config import config
 
 from gpjax.likelihoods import (
     AbstractLikelihood,
@@ -30,6 +31,8 @@ from gpjax.likelihoods import (
 )
 from gpjax.parameters import initialise
 
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 true_initialisation = {
     "Gaussian": ["obs_noise"],
     "Bernoulli": [],

--- a/tests/test_mean_functions.py
+++ b/tests/test_mean_functions.py
@@ -18,9 +18,13 @@ import typing as tp
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
+from jax.config import config
 
 from gpjax.mean_functions import Constant, Zero
 from gpjax.parameters import initialise
+
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 
 
 @pytest.mark.parametrize("meanf", [Zero, Constant])

--- a/tests/test_natural_gradients.py
+++ b/tests/test_natural_gradients.py
@@ -19,6 +19,7 @@ import jax
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
+from jax.config import config
 
 import gpjax as gpx
 from gpjax.abstractions import get_batch
@@ -31,6 +32,8 @@ from gpjax.natural_gradients import (
 )
 from gpjax.parameters import recursive_items
 
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 key = jr.PRNGKey(123)
 
 

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -15,10 +15,11 @@
 
 import typing as tp
 
-import jax.numpy as jnp
 import distrax as dx
+import jax.numpy as jnp
 import jax.random as jr
 import pytest
+from jax.config import config
 
 from gpjax.gps import Prior
 from gpjax.kernels import RBF
@@ -38,6 +39,8 @@ from gpjax.parameters import (
     unconstrain,
 )
 
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 
 #########################
 # Test base functionality

--- a/tests/test_quadrature.py
+++ b/tests/test_quadrature.py
@@ -17,8 +17,12 @@
 import jax
 import jax.numpy as jnp
 import pytest
+from jax.config import config
 
 from gpjax.quadrature import gauss_hermite_quadrature
+
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 
 
 @pytest.mark.parametrize("jit", [True, False])

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -15,8 +15,12 @@
 
 import jax.numpy as jnp
 import pytest
+from jax.config import config
 
 from gpjax.types import Dataset, NoneType, verify_dataset
+
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 
 
 def test_nonetype():

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -15,6 +15,7 @@
 
 import jax.numpy as jnp
 import pytest
+from jax.config import config
 
 from gpjax.utils import (
     concat_dictionaries,
@@ -22,6 +23,9 @@ from gpjax.utils import (
     merge_dictionaries,
     sort_dictionary,
 )
+
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 
 
 def test_concat_dict():

--- a/tests/test_variational_families.py
+++ b/tests/test_variational_families.py
@@ -19,6 +19,7 @@ import distrax as dx
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
+from jax.config import config
 
 import gpjax as gpx
 from gpjax.variational_families import (
@@ -29,6 +30,9 @@ from gpjax.variational_families import (
     VariationalGaussian,
     WhitenedVariationalGaussian,
 )
+
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 
 
 def test_abstract_variational_family():

--- a/tests/test_variational_inference.py
+++ b/tests/test_variational_inference.py
@@ -19,6 +19,7 @@ import jax
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
+from jax.config import config
 
 import gpjax as gpx
 from gpjax.variational_families import (
@@ -28,6 +29,9 @@ from gpjax.variational_families import (
     VariationalGaussian,
     WhitenedVariationalGaussian,
 )
+
+# Enable Float64 for more stable matrix inversions.
+config.update("jax_enable_x64", True)
 
 
 def test_abstract_variational_inference():


### PR DESCRIPTION
Make float32 the default type, not f64.

## Pull request type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ x ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently we enforce float 64. However, despite giving more stable matrix inversions, this limits reproducibility. 

Issue Number: #128 

## What is the new behavior?

Default to float32 and set float64 in notebooks.

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
