### PR TITLE
Move params to the first slot of each function, class, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ posterior = prior * likelihood
 Equipped with the posterior, we seek to learn the model's hyperparameters through gradient-optimisation of the marginal log-likelihood. We this below, adding Jax's [just-in-time (JIT)](https://jax.readthedocs.io/en/latest/jax-101/02-jitting.html) compilation to accelerate training. 
 
 ```python
-mll = jit(posterior.marginal_log_likelihood(training, negative=True))
+mll = jit(posterior.marginal_log_likelihood(D, negative=True))
 ```
 
 For purposes of optimisation, we'll use optax's Adam.
@@ -117,11 +117,11 @@ Using our learned hyperparameters, we can obtain the posterior distribution of t
 learned_params, _ = inference_state.unpack()
 xtest = jnp.linspace(-3., 3., 100).reshape(-1, 1)
 
-latent_distribution = posterior(training, learned_params)(xtest)
-predictive_distribution = likelihood(latent_distribution, params)
+latent_distribution = posterior(learned_params, D)(xtest)
+predictive_distribution = likelihood(params, latent_distribution)
 
 predictive_mean = predictive_distribution.mean
-predictive_cov = predictive_distribution.covariance_matrix
+predictive_cov = predictive_distribution.covariance
 ```
 
 # Installation

--- a/examples/barycentres.pct.py
+++ b/examples/barycentres.pct.py
@@ -117,7 +117,7 @@ def fit_gp(x: jnp.DeviceArray, y: jnp.DeviceArray) -> dx.MultivariateNormalTri:
     )
 
     learned_params, training_history = inference_state.unpack()
-    return likelihood(posterior(D, learned_params)(xtest), learned_params)
+    return likelihood(learned_params, posterior(learned_params, D)(xtest))
 
 
 posterior_preds = [fit_gp(x, i) for i in ys]

--- a/examples/collapsed_vi.pct.py
+++ b/examples/collapsed_vi.pct.py
@@ -8,7 +8,7 @@
 #       format_version: '1.3'
 #       jupytext_version: 1.11.2
 #   kernelspec:
-#     display_name: Python 3.9.7 ('gpjax')
+#     display_name: base
 #     language: python
 #     name: python3
 # ---
@@ -101,7 +101,7 @@ parameter_state = gpx.initialise(sgpr, key)
 
 negative_elbo = jit(sgpr.elbo(D, negative=True))
 
-optimiser = ox.adam(learning_rate=0.005)
+optimiser = ox.adam(learning_rate=5e-3)
 
 inference_state = gpx.fit(
     objective=negative_elbo,
@@ -116,8 +116,8 @@ learned_params, training_history = inference_state.unpack()
 # We show predictions of our model with the learned inducing points overlayed in grey.
 
 # %%
-latent_dist = q.predict(D, learned_params)(xtest)
-predictive_dist = likelihood(latent_dist, learned_params)
+latent_dist = q(learned_params, D)(xtest)
+predictive_dist = likelihood(learned_params, latent_dist)
 
 samples = latent_dist.sample(seed=key, sample_shape=(20,))
 

--- a/examples/graph_kernels.pct.py
+++ b/examples/graph_kernels.pct.py
@@ -9,7 +9,7 @@
 #       format_version: '1.3'
 #       jupytext_version: 1.11.2
 #   kernelspec:
-#     display_name: Python 3.9.7 ('gpjax')
+#     display_name: base
 #     language: python
 #     name: python3
 # ---
@@ -143,8 +143,8 @@ learned_params, training_history = inference_state.unpack()
 
 # %%
 initial_params = parameter_state.params
-initial_dist = likelihood(posterior(D, initial_params)(x), initial_params)
-predictive_dist = likelihood(posterior(D, learned_params)(x), learned_params)
+initial_dist = likelihood(initial_params, posterior(initial_params, D)(x))
+predictive_dist = likelihood(learned_params, posterior(learned_params, D)(x))
 
 initial_mean = initial_dist.mean()
 learned_mean = predictive_dist.mean()

--- a/examples/natgrads.pct.py
+++ b/examples/natgrads.pct.py
@@ -9,7 +9,7 @@
 #       format_version: '1.3'
 #       jupytext_version: 1.11.2
 #   kernelspec:
-#     display_name: Python 3.9.7 ('gpjax')
+#     display_name: base
 #     language: python
 #     name: python3
 # ---
@@ -108,7 +108,7 @@ learned_params, training_history = inference_state.unpack()
 
 # %%
 latent_dist = natural_q(learned_params)(xtest)
-predictive_dist = likelihood(latent_dist, learned_params)
+predictive_dist = likelihood(learned_params, latent_dist)
 
 meanf = predictive_dist.mean()
 sigma = predictive_dist.stddev()
@@ -212,5 +212,3 @@ print(loss_val)
 # %%
 # %reload_ext watermark
 # %watermark -n -u -v -iv -w -a 'Daniel Dodd'
-
-# %%

--- a/examples/regression.pct.py
+++ b/examples/regression.pct.py
@@ -8,7 +8,7 @@
 #       format_version: '1.3'
 #       jupytext_version: 1.11.2
 #   kernelspec:
-#     display_name: Python 3.9.7 ('gpjax')
+#     display_name: base
 #     language: python
 #     name: python3
 # ---
@@ -200,8 +200,8 @@ pp.pprint(learned_params)
 # Equipped with the posterior and a set of optimised hyperparameter values, we are now in a position to query our GP's predictive distribution at novel test inputs. To do this, we use our defined `posterior` and `likelihood` at our test inputs to obtain the predictive distribution as a `Distrax` multivariate Gaussian upon which `mean` and `stddev` can be used to extract the predictive mean and standard deviatation.
 
 # %%
-latent_dist = posterior(D, learned_params)(xtest)
-predictive_dist = likelihood(latent_dist, learned_params)
+latent_dist = posterior(learned_params, D)(xtest)
+predictive_dist = likelihood(learned_params, latent_dist)
 
 predictive_mean = predictive_dist.mean()
 predictive_std = predictive_dist.stddev()

--- a/examples/tfp_integration.pct.py
+++ b/examples/tfp_integration.pct.py
@@ -9,7 +9,7 @@
 #       format_version: '1.3'
 #       jupytext_version: 1.11.2
 #   kernelspec:
-#     display_name: Python 3.9.7 ('gpjax')
+#     display_name: base
 #     language: python
 #     name: python3
 # ---
@@ -95,7 +95,7 @@ array_to_dict(parray) == params
 # %% [markdown]
 # ### Specifying priors
 #
-# We can define Gamma priors on our hyperparameters through TensorFlow Probability's `Distributions` module.
+# We can define Gamma priors on our hyperparameters through TensorFlow Probability's `Distributions` module. We transform these to the unconstained space via `tfd.TransformedDistribution`.
 
 # %%
 import tensorflow_probability.substrates.jax as tfp
@@ -209,7 +209,7 @@ plt.tight_layout()
 xtest = jnp.linspace(-5.2, 5.2, 500).reshape(-1, 1)
 learned_params = array_to_dict([jnp.mean(i) for i in constrained_sample_list])
 
-predictive_dist = likelihood(posterior(D, learned_params)(xtest), learned_params)
+predictive_dist = likelihood(learned_params, posterior(learned_params, D)(xtest))
 
 mu = predictive_dist.mean()
 sigma = predictive_dist.stddev()

--- a/examples/uncollapsed_vi.pct.py
+++ b/examples/uncollapsed_vi.pct.py
@@ -9,7 +9,7 @@
 #       format_version: '1.3'
 #       jupytext_version: 1.11.2
 #   kernelspec:
-#     display_name: Python 3.9.7 ('gpjax')
+#     display_name: base
 #     language: python
 #     name: python3
 # ---
@@ -176,7 +176,7 @@ learned_params, training_history = inference_state.unpack()
 
 # %%
 latent_dist = q(learned_params)(xtest)
-predictive_dist = likelihood(latent_dist, learned_params)
+predictive_dist = likelihood(learned_params, latent_dist)
 
 meanf = predictive_dist.mean()
 sigma = predictive_dist.stddev()

--- a/examples/yacht.pct.py
+++ b/examples/yacht.pct.py
@@ -8,7 +8,7 @@
 #       format_version: '1.3'
 #       jupytext_version: 1.11.2
 #   kernelspec:
-#     display_name: Python 3.9.7 ('gpjax')
+#     display_name: base
 #     language: python
 #     name: python3
 # ---
@@ -150,8 +150,8 @@ learned_params, training_history = inference_state.unpack()
 # With an optimal set of parameters learned, we can make predictions on the set of data that we held back right at the start. We'll do this in the usual way by first computing the latent function's distribution before computing the predictive posterior distribution.
 
 # %%
-latent_dist = posterior(training_data, learned_params)(scaled_Xte)
-predictive_dist = likelihood(latent_dist, learned_params)
+latent_dist = posterior(learned_params, training_data, )(scaled_Xte)
+predictive_dist = likelihood(learned_params, latent_dist)
 
 predictive_mean = predictive_dist.mean()
 predictive_stddev = predictive_dist.stddev()

--- a/gpjax/mean_functions.py
+++ b/gpjax/mean_functions.py
@@ -31,12 +31,12 @@ class AbstractMeanFunction:
     name: Optional[str] = "Mean function"
 
     @abc.abstractmethod
-    def __call__(self, x: Float[Array, "N D"], params: Dict) -> Float[Array, "N Q"]:
+    def __call__(self, params: Dict, x: Float[Array, "N D"]) -> Float[Array, "N Q"]:
         """Evaluate the mean function at the given points. This method is required for all subclasses.
 
         Args:
-            x (Float[Array, "N D"]): The input points at which to evaluate the mean function.
             params (Dict): The parameters of the mean function.
+            x (Float[Array, "N D"]): The input points at which to evaluate the mean function.
 
         Returns:
             Float[Array, "N Q"]: The mean function evaluated point-wise on the inputs.
@@ -65,12 +65,12 @@ class Zero(AbstractMeanFunction):
     output_dim: Optional[int] = 1
     name: Optional[str] = "Zero mean function"
 
-    def __call__(self, x: Float[Array, "N D"], params: Dict) -> Float[Array, "N Q"]:
+    def __call__(self, params: Dict, x: Float[Array, "N D"]) -> Float[Array, "N Q"]:
         """Evaluate the mean function at the given points.
 
         Args:
-            x (Float[Array, "N D"]): The input points at which to evaluate the mean function.
             params (Dict): The parameters of the mean function.
+            x (Float[Array, "N D"]): The input points at which to evaluate the mean function.
 
         Returns:
             Float[Array, "N Q"]: A vector of zeros.
@@ -100,12 +100,12 @@ class Constant(AbstractMeanFunction):
     output_dim: Optional[int] = 1
     name: Optional[str] = "Constant mean function"
 
-    def __call__(self, x: Float[Array, "N D"], params: Dict) -> Float[Array, "N Q"]:
+    def __call__(self, params: Dict, x: Float[Array, "N D"]) -> Float[Array, "N Q"]:
         """Evaluate the mean function at the given points.
 
         Args:
-            x (Float[Array, "N D"]): The input points at which to evaluate the mean function.
             params (Dict): The parameters of the mean function.
+            x (Float[Array, "N D"]): The input points at which to evaluate the mean function.
 
         Returns:
             Float[Array, "N Q"]: A vector of repeated constant values.

--- a/gpjax/variational_families.py
+++ b/gpjax/variational_families.py
@@ -716,11 +716,14 @@ class CollapsedVariationalGaussian(AbstractVariationalFamily):
         )
 
     def predict(
-        self, train_data: Dataset, params: Dict
+        self, params: Dict, train_data: Dataset, 
     ) -> Callable[[Float[Array, "N D"]], dx.MultivariateNormalFullCovariance]:
         """Compute the predictive distribution of the GP at the test inputs.
+        
         Args:
             params (Dict): The set of parameters that are to be used to parameterise our variational approximation and GP.
+            train_data (Dataset): The training data that was used to fit the GP.
+
         Returns:
             Callable[[Float[Array, "N D"]], dx.MultivariateNormalTri]: A function that accepts a set of test points and will return the predictive distribution at those points.
         """

--- a/gpjax/variational_inference.py
+++ b/gpjax/variational_inference.py
@@ -192,7 +192,7 @@ class CollapsedVI(AbstractVariationalInference):
             Kzz = gram(kernel, params["kernel"], z)
             Kzz += I(m) * jitter
             Kzx = cross_covariance(kernel, params["kernel"], z, x)
-            Kxx_diag = vmap(kernel, in_axes=(0, 0, None))(params["kernel"], x, x)
+            Kxx_diag = vmap(kernel, in_axes=(None, 0, 0))(params["kernel"], x, x)
             μx = mean_function(params["mean_function"], x)
 
             Lz = Kzz.triangular_lower()

--- a/tests/test_gps.py
+++ b/tests/test_gps.py
@@ -79,7 +79,7 @@ def test_conjugate_posterior(num_datapoints):
     assert isinstance(post2, AbstractPrior)
 
     parameter_state = initialise(post, key)
-    params, _, bijectors = parameter_state.unpack()
+    params, *_ = parameter_state.unpack()
 
     # Marginal likelihood
     mll = post.marginal_log_likelihood(train_data=D)
@@ -88,7 +88,7 @@ def test_conjugate_posterior(num_datapoints):
     assert objective_val.shape == ()
 
     # Prediction
-    predictive_dist_fn = post(D, params)
+    predictive_dist_fn = post(params, D)
     assert isinstance(predictive_dist_fn, tp.Callable)
 
     x = jnp.linspace(-3.0, 3.0, num_datapoints).reshape(-1, 1)
@@ -130,7 +130,7 @@ def test_nonconjugate_posterior(num_datapoints, likel):
     assert objective_val.shape == ()
 
     # Prediction
-    predictive_dist_fn = post(D, params)
+    predictive_dist_fn = post(params, D)
     assert isinstance(predictive_dist_fn, tp.Callable)
 
     x = jnp.linspace(-3.0, 3.0, num_datapoints).reshape(-1, 1)

--- a/tests/test_mean_functions.py
+++ b/tests/test_mean_functions.py
@@ -13,36 +13,57 @@
 # limitations under the License.
 # ==============================================================================
 
-import typing as tp
+from typing import Dict
 
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
 from jax.config import config
+from jaxtyping import Array, Float
 
-from gpjax.mean_functions import Constant, Zero
-from gpjax.parameters import initialise
+from gpjax.mean_functions import AbstractMeanFunction, Constant, Zero
+from gpjax.types import PRNGKeyType
 
 # Enable Float64 for more stable matrix inversions.
 config.update("jax_enable_x64", True)
+_initialise_key = jr.PRNGKey(123)
 
 
-@pytest.mark.parametrize("meanf", [Zero, Constant])
+def test_abstract_mean_function() -> None:
+    # Test that the abstract mean function cannot be instantiated.
+    with pytest.raises(TypeError):
+        AbstractMeanFunction()
+
+    # Create a dummy mean funcion class with abstract methods implemented.
+    class DummyMeanFunction(AbstractMeanFunction):
+        def __call__(self, params: Dict, x: Float[Array, "N D"]) ->  Float[Array, "N 1"]:
+            return jnp.ones((x.shape[0], 1))
+        
+        def _initialise_params(self, key: PRNGKeyType) -> Dict:
+            return {}
+
+    # Test that the dummy mean function can be instantiated.
+    dummy_mean_function = DummyMeanFunction()
+    assert isinstance(dummy_mean_function, AbstractMeanFunction)
+
+
+@pytest.mark.parametrize("mean_function", [Zero, Constant])
 @pytest.mark.parametrize("dim", [1, 2, 5])
-def test_shape(meanf, dim):
-    key = jr.PRNGKey(123)
-    meanf = meanf(output_dim=dim)
-    x = jnp.linspace(-1.0, 1.0, num=10).reshape(-1, 1)
-    if dim > 1:
-        x = jnp.hstack([x] * dim)
-    params, _, _ = initialise(meanf, key).unpack()
-    mu = meanf(x, params)
+@pytest.mark.parametrize("n", [1, 2])
+def test_shape(mean_function: AbstractMeanFunction, n:int, dim: int) -> None:
+    key = _initialise_key
+
+    # Create test inputs.
+    x = jnp.linspace(-1.0, 1.0, num=n * dim).reshape(n, dim)
+
+    # Initialise mean function.
+    mf = mean_function(output_dim=dim)
+
+    # Initialise parameters.
+    params = mf._initialise_params(key)
+    assert isinstance(params, dict)
+
+    # Test shape of mean function.
+    mu = mf(params, x)
     assert mu.shape[0] == x.shape[0]
     assert mu.shape[1] == dim
-
-
-@pytest.mark.parametrize("meanf", [Zero, Constant])
-def test_initialisers(meanf):
-    key = jr.PRNGKey(123)
-    params, _, _ = initialise(meanf(), key).unpack()
-    assert isinstance(params, tp.Dict)


### PR DESCRIPTION
This PR moves the `params` argument to the first slot of each function, to match the convention of `Haiku` and `Flax`.

Also, cleans up some of the tests, add typing, for readability and adds testing of abstract classes. Some test files e.g. 'test_gps.py` need cleaning up, in future.

- [ ] Bugfix
- [ ] Feature
- [ X] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):