### PR TITLE
fix: Parameters were never transformed when fitting

### DIFF
--- a/examples/heteroscedastic_inference.py
+++ b/examples/heteroscedastic_inference.py
@@ -357,8 +357,22 @@ ax.fill_between(
     alpha=0.3,
     label="One std. dev.",
 )
-ax.plot(xtest.squeeze(), predictive_mean - predictive_std, "--", color=cols[1], alpha=0.5, linewidth=0.75)
-ax.plot(xtest.squeeze(), predictive_mean + predictive_std, "--", color=cols[1], alpha=0.5, linewidth=0.75)
+ax.plot(
+    xtest.squeeze(),
+    predictive_mean - predictive_std,
+    "--",
+    color=cols[1],
+    alpha=0.5,
+    linewidth=0.75,
+)
+ax.plot(
+    xtest.squeeze(),
+    predictive_mean + predictive_std,
+    "--",
+    color=cols[1],
+    alpha=0.5,
+    linewidth=0.75,
+)
 ax.fill_between(
     xtest.squeeze(),
     predictive_mean - 2 * predictive_std,
@@ -367,8 +381,22 @@ ax.fill_between(
     alpha=0.1,
     label="Two std. dev.",
 )
-ax.plot(xtest.squeeze(), predictive_mean - 2 * predictive_std, "--", color=cols[1], alpha=0.5, linewidth=0.75)
-ax.plot(xtest.squeeze(), predictive_mean + 2 * predictive_std, "--", color=cols[1], alpha=0.5, linewidth=0.75)
+ax.plot(
+    xtest.squeeze(),
+    predictive_mean - 2 * predictive_std,
+    "--",
+    color=cols[1],
+    alpha=0.5,
+    linewidth=0.75,
+)
+ax.plot(
+    xtest.squeeze(),
+    predictive_mean + 2 * predictive_std,
+    "--",
+    color=cols[1],
+    alpha=0.5,
+    linewidth=0.75,
+)
 
 ax.set_title("Sparse Heteroscedastic Regression")
 ax.legend(loc="best", fontsize="small")

--- a/gpjax/parameters.py
+++ b/gpjax/parameters.py
@@ -44,6 +44,7 @@ def transform(
     Returns:
         State: A new nnx.State object containing the transformed parameters.
     """
+
     def _is_param(x):
         return isinstance(x, nnx.VariableState) and issubclass(x.type, Parameter)
 

--- a/uv.lock
+++ b/uv.lock
@@ -891,7 +891,7 @@ requires-dist = [
     { name = "mkdocs-jupyter", marker = "extra == 'docs'", specifier = ">=0.24.3" },
     { name = "mkdocs-literate-nav", marker = "extra == 'docs'", specifier = ">=0.6.0" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5.12" },
-    { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = "<0.31.0" },
+    { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = "<1.1.0" },
     { name = "mktestdocs", marker = "extra == 'dev'", specifier = ">=0.2.1" },
     { name = "nbconvert", marker = "extra == 'docs'", specifier = ">=7.16.2" },
     { name = "networkx", marker = "extra == 'dev'" },


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `uv run poe format` before committing.
- [ ] I've added tests for new code. [All tests passed]
- [ ] I've added docstrings for the new code. [Not done as expected behavior is restored]

## Description

I came across a bug while trying to implement the Bayesian GP-LVM model in GPJax: `Parameter`s were never transformed during `fit()` calls, and therefore positivity constrains were not applied.
This is because the leaves of `gp_params` are not `Parameters` but `nnx.VariableState`s whose `.type` is `Parameter`.

I might be missing something obvious here, so to double check, I'll share my model class code:
```
class BayesianGPLVM(nnx.Module):
    def __init__(
        self,
        kernel,
        X_mu,
        X_var,
        Z,
        sigma2=1.0,
        X_prior_mu=None,
        X_prior_var=None,
        jitter=1e-6,
    ):
        self.kernel = kernel
        self.jitter = jitter

        # trainables
        self.X_mu = Real(X_mu)
        self.X_var = PositiveReal(X_var)
        self.Z = Real(Z)
        self.sigma2 = PositiveReal(sigma2)

        # fixed priors
        if X_prior_mu is None:
            X_prior_mu = jnp.zeros_like(X_mu, shape=X_mu.shape)

        if X_prior_var is None:
            X_prior_var = jnp.ones_like(X_var, shape=X_var.shape)

        self.X_prior_mu = X_prior_mu
        self.X_prior_var = X_prior_var

# etc
```
The issue was that before this patch, the `X_var` and `sigma2` parameters were *not* transformed during `fit()` and therefore I got some errors in the ELBO computation.

By the way, if you are interested in me adding the algorithm to GPJax, I could do another pull request if this works well.

Issue Number: N/A