### PR TITLE
fix: upper-bound jax and jaxlib to <0.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,8 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "jax>=0.5.0",
-  "jaxlib>=0.5.0",
+  "jax>=0.5.0,<0.10",
+  "jaxlib>=0.5.0,<0.10",
   "optax>0.2.1",
   "numpyro>=0.19.0",
   "jaxtyping>0.2.10",


### PR DESCRIPTION
## Summary
- jax 0.10.0 removed `xla_pmap_p` from `jax.extend.core.primitives`, which `numpyro 0.20.1` still imports, causing `ImportError` at import time.
- The v0.14.0 release workflow failed all four "Multi-Platform Testing / Test installation" matrix jobs because that step does a plain `pip install *.whl`, which bypasses `uv.lock` and resolves the latest unbounded versions — pulling the broken `jax 0.10.0` + `numpyro 0.20.1` pair.
- PR/main CI passed because it uses `uv sync --frozen` against the lockfile (`jax==0.9.0`).
- Upper-bounding `jax` and `jaxlib` to `<0.10` pins users to the last known-good major. When numpyro publishes a jax-0.10-compatible release, the bound can be relaxed.

## Test plan
- [ ] PR CI (`tests`, `lint`, `integration`, `docs`) passes
- [ ] After merge, re-tag `v0.14.0` on the new main HEAD and confirm the release workflow — specifically the `Test installation` step — now completes, and `build-package` / `create-release` / `publish-pypi` proceed

Fixes the broken v0.14.0 release ([run 24708701888](https://github.com/thomaspinder/GPJax/actions/runs/24708701888)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)