### PR TITLE
Kronecker mv fix

### DIFF
--- a/gpjax/linalg/custom_operators.py
+++ b/gpjax/linalg/custom_operators.py
@@ -51,8 +51,8 @@ class Kronecker(lx.AbstractLinearOperator):
         # C-order vec trick: (A kron B)x = vec_C(A @ X @ B^T)
         # where X = x.reshape(n, m) in C (row-major) order.
         # Note: row @ B^T = B @ row (as 1D vectors), so we use B.mv on rows.
-        n = self.A.out_structure().shape[0]
-        m = self.B.out_structure().shape[0]
+        n = self.A.in_structure().shape[0]
+        m = self.B.in_structure().shape[0]
         X = x.reshape(n, m)  # n x m, C-order
         # Compute A @ X by applying A.mv to each column of X
         AX = jax.vmap(self.A.mv, in_axes=1, out_axes=1)(X)

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -116,14 +116,16 @@ def test_kronecker_mv():
     result = kron.mv(x)
     assert jnp.allclose(result, expected, atol=1e-5)
 
+
 def test_kronecker_mv_rectangular():
-    A = lx.MatrixLinearOperator(jnp.array([[1., 2., 3.], [3., 4., 5.]]))
+    A = lx.MatrixLinearOperator(jnp.array([[1.0, 2.0, 3.0], [3.0, 4.0, 5.0]]))
     B = lx.MatrixLinearOperator(jnp.array([[5.0, 6.0], [7.0, 8.0]]))
     kron = Kronecker(A=A, B=B)
     x = jnp.ones(6)
     expected = jnp.kron(A.as_matrix(), B.as_matrix()) @ x
     result = kron.mv(x)
     assert jnp.allclose(result, expected, atol=1e-5)
+
 
 def test_kronecker_as_matrix():
     A = lx.MatrixLinearOperator(jnp.array([[1.0, 0.0], [0.0, 2.0]]))

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -116,6 +116,14 @@ def test_kronecker_mv():
     result = kron.mv(x)
     assert jnp.allclose(result, expected, atol=1e-5)
 
+def test_kronecker_mv_rectangular():
+    A = lx.MatrixLinearOperator(jnp.array([[1., 2., 3.], [3., 4., 5.]]))
+    B = lx.MatrixLinearOperator(jnp.array([[5.0, 6.0], [7.0, 8.0]]))
+    kron = Kronecker(A=A, B=B)
+    x = jnp.ones(6)
+    expected = jnp.kron(A.as_matrix(), B.as_matrix()) @ x
+    result = kron.mv(x)
+    assert jnp.allclose(result, expected, atol=1e-5)
 
 def test_kronecker_as_matrix():
     A = lx.MatrixLinearOperator(jnp.array([[1.0, 0.0], [0.0, 2.0]]))


### PR DESCRIPTION
## Checklist

- [✓] I've formatted the new code by running `uv run poe format` before committing.
- [✓] I've added tests for new code.
- [] I've added docstrings for the new code.

## Description
While using GPJax I encountered a bug in the Kronecker linear operator in /linalg/custom_operators.py: 
When the passed linear operators are not square, the matrix vector product will fail with a TypeError. This is because the function tries to reshape the input vector to the shape of the output. This PR adresses this by reshaping the input to the expected input shapes instead.

I have added a test for this case and have run poe format.