### PR TITLE
fix(state_space): review remediation — 9 findings resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (breaking)
 
-- **`gpjax.likelihoods.Gaussian.predict`** now returns
+- **`gpjax.likelihoods.Gaussian.predict` and
+  `gpjax.likelihoods.HeteroscedasticGaussian.predict`** now return
   `gpjax.distributions.GaussianDistribution` (was
-  `numpyro.distributions.MultivariateNormal`). The diagonal fast path
-  preserves a `lineax.DiagonalLinearOperator` scale; the dense path
-  wraps a `lineax.MatrixLinearOperator`. Callers relying on
+  `numpyro.distributions.MultivariateNormal`). For `Gaussian.predict`, the
+  diagonal fast path preserves a `lineax.DiagonalLinearOperator` scale; the
+  dense path wraps a `lineax.MatrixLinearOperator`.
+  `HeteroscedasticGaussian.predict` wraps its (always-dense) covariance in a
+  `lineax.MatrixLinearOperator`. Callers relying on
   `MultivariateNormal`-specific attributes (`scale_tril`,
   `precision_matrix`, etc.) must update; callers using `mean`,
   `variance`, `covariance_matrix` are unaffected.

--- a/gpjax/likelihoods.py
+++ b/gpjax/likelihoods.py
@@ -460,7 +460,7 @@ class HeteroscedasticGaussian(AbstractHeteroscedasticLikelihood):
         noise_dist: tp.Optional[
             tp.Union[npd.MultivariateNormal, GaussianDistribution]
         ] = None,
-    ) -> npd.MultivariateNormal:
+    ) -> GaussianDistribution:
         if noise_dist is None:
             raise ValueError(
                 "noise_dist must be provided for heteroscedastic prediction."
@@ -476,7 +476,7 @@ class HeteroscedasticGaussian(AbstractHeteroscedasticLikelihood):
         cov = dist.covariance_matrix
         noisy_cov = cov.at[jnp.diag_indices(n_data)].add(noise_stats.variance.squeeze())
 
-        return npd.MultivariateNormal(dist.mean, noisy_cov)
+        return GaussianDistribution(dist.mean, lx.MatrixLinearOperator(noisy_cov))
 
     def link_function(self, f: Float[Array, ...]) -> npd.Normal:
         sigma2 = self.noise_transform(jnp.zeros_like(f))

--- a/gpjax/state_space/_bessel.py
+++ b/gpjax/state_space/_bessel.py
@@ -28,9 +28,11 @@ def _large_c_scaled_ive(c, truncation_order: int):
         Ĩ_{k+1}(c) = Ĩ_{k-1}(c) - (2k/c) Ĩ_k(c)
 
     inherits stability from the unscaled identity since the e^{-c} factor
-    cancels. Forward recurrence is the correct direction for large `c` because
-    `I_k(c)` is the minimal solution there; backward recurrence would amplify
-    the exponentially-large `K_k(c)` contamination of the seed values.
+    cancels. For ``c > truncation_order`` the values ``I_k(c)`` are comparable
+    in magnitude across ``k``, so upward (forward) recurrence is numerically
+    stable here; downward (Miller) recurrence is reserved for
+    ``c <= truncation_order``, where ``I_k(c)`` decays in ``k`` and forward
+    recurrence would amplify round-off.
     """
     c = jnp.asarray(c)
     bessel_at_order_0 = jsp.i0e(c)

--- a/gpjax/state_space/_validation.py
+++ b/gpjax/state_space/_validation.py
@@ -28,6 +28,12 @@ def _validate_temporal_kernel(kernel) -> None:
             f"Got n_dims={n_dims}."
         )
 
+    # GPJax constrains active_dims to list | slice at construction
+    # (kernels.base._check_active_dims rejects tuples/ndarrays with TypeError;
+    # the jaxtyping/beartype annotation list[int] | slice | None rejects them too
+    # when the import hook is active), and a slice selects a single contiguous
+    # axis given 1-D temporal data, so the only multi-axis selector that can
+    # reach here is a length>1 list.
     active_dims = getattr(kernel, "active_dims", None)
     if isinstance(active_dims, list) and len(active_dims) > 1:
         raise ValueError(

--- a/gpjax/state_space/fit.py
+++ b/gpjax/state_space/fit.py
@@ -91,7 +91,6 @@ def fit_lbfgs(
     train_data: Dataset,
     observation_mask=None,
     max_iters: int = 500,
-    verbose: bool = True,
     safe: bool = True,
 ):
     """Fit a state-space posterior with Optax's L-BFGS (``while_loop`` driver).
@@ -115,7 +114,6 @@ def fit_lbfgs(
         ...     model=posterior,
         ...     train_data=gpx.Dataset(X=X, y=y),
         ...     max_iters=2,
-        ...     verbose=False,
         ... )
         >>> fitted is not None
         True

--- a/gpjax/state_space/gps.py
+++ b/gpjax/state_space/gps.py
@@ -21,6 +21,12 @@ class StateSpacePrior(Prior):
     (the prior is stationary in time, so off-diagonal covariance carries no
     extra information for v1's diagonal-only predictive contract).
 
+    **Predictive contract (v1):** prediction returns diagonal (marginal)
+    covariance only; the marginals are exact. A dense joint predictive is not
+    implemented in v1 and is tracked as a follow-up. This predictive is
+    therefore not Liskov-substitutable for a dense
+    ``gpjax.gps.ConjugatePosterior`` predictive.
+
     Example:
     ```python
         >>> import gpjax as gpx
@@ -40,7 +46,10 @@ class StateSpacePrior(Prior):
     def predict(self, test_inputs, *, return_covariance_type="diagonal"):
         if return_covariance_type != "diagonal":
             raise NotImplementedError(
-                "State-space prior predict only supports return_covariance_type='diagonal' in v1."
+                "State-space prior prediction returns diagonal (marginal) covariance "
+                "only; a dense joint predictive is not implemented in v1 and is "
+                "tracked as a follow-up. The marginal variances returned are exact, "
+                "so for diagonal-only use pass return_covariance_type='diagonal'."
             )
         from gpjax.state_space.kernels import to_sde
 
@@ -70,6 +79,12 @@ class StateSpaceConjugatePosterior(ConjugatePosterior):
       - ``__call__``       : delegates to ``predict``
     Both ``predict`` and ``predict_filter`` reject ``return_covariance_type="dense"``
     in favour of v1's diagonal-only contract before any further dispatch.
+
+    **Predictive contract (v1):** prediction returns diagonal (marginal)
+    covariance only; the marginals are exact. A dense joint predictive is not
+    implemented in v1 and is tracked as a follow-up. This predictive is
+    therefore not Liskov-substitutable for a dense
+    ``gpjax.gps.ConjugatePosterior`` predictive.
 
     Example:
     ```python
@@ -111,7 +126,11 @@ class StateSpaceConjugatePosterior(ConjugatePosterior):
     ):
         if return_covariance_type != "diagonal":
             raise NotImplementedError(
-                "State-space posterior predict only supports return_covariance_type='diagonal' in v1."
+                "State-space posterior predict returns diagonal (marginal) "
+                "covariance only; a dense joint predictive is not implemented in v1 "
+                "and is tracked as a follow-up. The marginal variances returned are "
+                "exact, so for diagonal-only use pass "
+                "return_covariance_type='diagonal'."
             )
         from gpjax.state_space.prediction import predict_smoothed
 
@@ -129,7 +148,11 @@ class StateSpaceConjugatePosterior(ConjugatePosterior):
     ):
         if return_covariance_type != "diagonal":
             raise NotImplementedError(
-                "State-space posterior predict_filter only supports return_covariance_type='diagonal' in v1."
+                "State-space posterior predict_filter returns diagonal (marginal) "
+                "covariance only; a dense joint predictive is not implemented in v1 "
+                "and is tracked as a follow-up. The marginal variances returned are "
+                "exact, so for diagonal-only use pass "
+                "return_covariance_type='diagonal'."
             )
         from gpjax.state_space.prediction import predict_filtered
 

--- a/gpjax/state_space/inference.py
+++ b/gpjax/state_space/inference.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 
+from gpjax.state_space.sde import _psd_sqrt
+
 
 def _sign_normalise(R):
     """Flip row signs so the diagonal of R is non-negative without changing R.T @ R.
@@ -315,8 +317,10 @@ def rts_smoother(sde, forward_outputs, time_steps):
 
     Runs the standard Särkkä & Solin (2019) §10.7 backward recursion on the
     forward filter trajectory. Internally materialises ``P = L @ L.T`` for the
-    smoother gain computation and re-Choleskies after each backward step.
-    The recursion is
+    smoother gain computation and re-roots the smoothed covariance after each
+    backward step with :func:`gpjax.state_space.sde._psd_sqrt`. The returned
+    ``Ls`` are therefore non-triangular ``V·Λ^½`` square roots (neither Cholesky
+    nor symmetric); consumers must rely only on ``L @ Lᵀ``. The recursion is
 
     .. math::
 
@@ -382,9 +386,13 @@ def rts_smoother(sde, forward_outputs, time_steps):
             P_filtered
             + smoother_gain @ (P_smoothed_next - P_predicted_next) @ smoother_gain.T
         )
-        # Symmetrise to kill round-off antisymmetric error before Cholesky.
+        # Symmetrise to kill round-off antisymmetric error, then take a
+        # gradient-safe PSD square root (cholesky NaNs on marginally-indefinite
+        # round-off; _psd_sqrt clips negative eigenvalues to zero). _psd_sqrt
+        # returns V·Λ^½ — a non-triangular root that is neither Cholesky nor
+        # symmetric; this is fine because every consumer uses L @ L.T.
         P_smoothed = 0.5 * (P_smoothed + P_smoothed.T)
-        L_smoothed = jnp.linalg.cholesky(P_smoothed)
+        L_smoothed = _psd_sqrt(P_smoothed)
 
         return (mean_smoothed, L_smoothed), (mean_smoothed, L_smoothed)
 

--- a/gpjax/state_space/objectives.py
+++ b/gpjax/state_space/objectives.py
@@ -24,8 +24,14 @@ def state_space_mll(
       4. Computes ``sigma_eff = sqrt(obs_stddev² + prior.jitter)``.
       5. Delegates to ``kalman_filter``.
 
-    Pure-JAX; assumes prevalidated, sorted data. Validation belongs upstream
-    in the ``state_space.fit*`` wrappers.
+    Pure-JAX. **Assumes time-sorted input.** Unsorted times yield negative Δt and
+    silently incorrect (NaN/garbage) results — there is no internal sort, because
+    a data-dependent reorder inside this traced objective is avoided to keep it
+    jit/grad/MCMC-clean. Sorting and validation are the responsibility of the
+    eager ``state_space.fit*`` wrappers (``sort_state_space_data`` warns and
+    reorders; ``validate_state_space_data`` checks finiteness/shape). Callers
+    invoking this objective directly (e.g. custom MCMC/optimisers) must pre-sort
+    by time, e.g. via ``sort_state_space_data(X, y, mask)``.
 
     See plans/2026-04-21-state-space-gps-design.md §Stage 1.
 

--- a/gpjax/state_space/prediction.py
+++ b/gpjax/state_space/prediction.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 import lineax as lx
+import paramax
 
 from gpjax.distributions import GaussianDistribution
 from gpjax.state_space.inference import _sqrt_filter_forward, rts_smoother
@@ -65,8 +66,6 @@ def predict_smoothed(posterior, train_data, test_inputs, *, observation_mask=Non
 
     See plans/2026-04-21-state-space-gps-design.md §Stage 4.
     """
-    import paramax
-
     posterior = paramax.unwrap(posterior)
     prior = posterior.prior
     likelihood = posterior.likelihood
@@ -140,8 +139,6 @@ def predict_filtered(posterior, train_data, test_inputs, *, observation_mask=Non
 
     See plans/2026-04-21-state-space-gps-design.md §Stage 4.
     """
-    import paramax
-
     posterior = paramax.unwrap(posterior)
     prior = posterior.prior
     likelihood = posterior.likelihood

--- a/gpjax/state_space/sde.py
+++ b/gpjax/state_space/sde.py
@@ -22,6 +22,11 @@ class LinearSDE(eqx.Module):
 
     Kernel-specific closed-form discretisations override ``discretise``; the
     base implementation returns the algebraic Δt = 0 result (A = I, L_Q = 0).
+
+    ``process_noise_spectral_density`` (``Q_c``) defines the continuous-time
+    model and is validated by the Lyapunov identity ``F P∞ + P∞ Fᵀ + L Q_c Lᵀ
+    = 0`` in the tests; it is **not** consumed by ``discretise``, which uses
+    the closed-form stationary identity ``Q(Δt) = P∞ − A(Δt) P∞ A(Δt)ᵀ``.
     """
 
     drift_matrix: Float[Array, "state_dim state_dim"]

--- a/gpjax/state_space/sde.py
+++ b/gpjax/state_space/sde.py
@@ -129,20 +129,22 @@ def _psd_sqrt(matrix):
     return eigvecs * sqrt_eigvals
 
 
-def _matern32_discrete_q(dt, lengthscale, variance):
-    """Discrete process-noise covariance Q(Δt) via stationary identity, symmetrised."""
-    lam = jnp.sqrt(3.0) / lengthscale
-    dtl = dt * lam
-    exp_neg_dtl = jnp.exp(-dtl)
-    A = exp_neg_dtl * jnp.array(
+def _matern32_discrete_transition_and_q(time_step, lengthscale, variance):
+    """Return (A(Δt), Q(Δt)) for Matern-3/2 via the stationary identity."""
+    decay_rate = jnp.sqrt(3.0) / lengthscale
+    scaled_time = time_step * decay_rate
+    exp_neg_scaled_time = jnp.exp(-scaled_time)
+    transition_matrix = exp_neg_scaled_time * jnp.array(
         [
-            [1.0 + dtl, dt],
-            [-(lam**2) * dt, 1.0 - dtl],
+            [1.0 + scaled_time, time_step],
+            [-(decay_rate**2) * time_step, 1.0 - scaled_time],
         ]
     )
-    P_inf = jnp.diag(jnp.stack([variance, 3.0 * variance / lengthscale**2]))
-    Q = P_inf - A @ P_inf @ A.T
-    return 0.5 * (Q + Q.T)
+    stationary_cov = jnp.diag(jnp.stack([variance, 3.0 * variance / lengthscale**2]))
+    process_noise_cov = (
+        stationary_cov - transition_matrix @ stationary_cov @ transition_matrix.T
+    )
+    return transition_matrix, 0.5 * (process_noise_cov + process_noise_cov.T)
 
 
 class Matern32SDE(LinearSDE):
@@ -180,50 +182,53 @@ class Matern32SDE(LinearSDE):
             return eye, zeros
 
         def positive_dt(dt):
-            lam = jnp.sqrt(3.0) / self.lengthscale
-            dtl = dt * lam
-            exp_neg_dtl = jnp.exp(-dtl)
-            A = exp_neg_dtl * jnp.array(
-                [
-                    [1.0 + dtl, dt],
-                    [-(lam**2) * dt, 1.0 - dtl],
-                ]
+            transition_matrix, process_noise_cov = _matern32_discrete_transition_and_q(
+                dt, self.lengthscale, self.variance
             )
-            Q = _matern32_discrete_q(dt, self.lengthscale, self.variance)
-            L_Q = _psd_sqrt(Q)
-            return A, L_Q
+            return transition_matrix, _psd_sqrt(process_noise_cov)
 
         return jax.lax.cond(time_step == 0.0, zero_dt, positive_dt, time_step)
 
 
-def _matern52_discrete_q(dt, lengthscale, variance):
-    lam = jnp.sqrt(5.0) / lengthscale
-    dtlam = dt * lam
-    A = jnp.exp(-dtlam) * (
-        dt
+def _matern52_discrete_transition_and_q(time_step, lengthscale, variance):
+    """Return (A(Δt), Q(Δt)) for Matern-5/2 via the stationary identity."""
+    decay_rate = jnp.sqrt(5.0) / lengthscale
+    scaled_time = time_step * decay_rate
+    transition_matrix = jnp.exp(-scaled_time) * (
+        time_step
         * jnp.array(
             [
-                [lam * (0.5 * dtlam + 1.0), dtlam + 1.0, 0.5 * dt],
-                [-0.5 * dtlam * lam**2, lam * (1.0 - dtlam), 1.0 - 0.5 * dtlam],
                 [
-                    lam**3 * (0.5 * dtlam - 1.0),
-                    lam**2 * (dtlam - 3.0),
-                    lam * (0.5 * dtlam - 2.0),
+                    decay_rate * (0.5 * scaled_time + 1.0),
+                    scaled_time + 1.0,
+                    0.5 * time_step,
+                ],
+                [
+                    -0.5 * scaled_time * decay_rate**2,
+                    decay_rate * (1.0 - scaled_time),
+                    1.0 - 0.5 * scaled_time,
+                ],
+                [
+                    decay_rate**3 * (0.5 * scaled_time - 1.0),
+                    decay_rate**2 * (scaled_time - 3.0),
+                    decay_rate * (0.5 * scaled_time - 2.0),
                 ],
             ]
         )
         + jnp.eye(3)
     )
     kappa = 5.0 / 3.0 * variance / lengthscale**2
-    P_inf = jnp.array(
+    stationary_cov = jnp.array(
         [
             [variance, 0.0, -kappa],
             [0.0, kappa, 0.0],
             [-kappa, 0.0, 25.0 * variance / lengthscale**4],
         ]
     )
-    Q = P_inf - A @ P_inf @ A.T
-    return 0.5 * (Q + Q.T)
+    process_noise_cov = (
+        stationary_cov - transition_matrix @ stationary_cov @ transition_matrix.T
+    )
+    return transition_matrix, 0.5 * (process_noise_cov + process_noise_cov.T)
 
 
 class Matern52SDE(LinearSDE):
@@ -274,29 +279,10 @@ class Matern52SDE(LinearSDE):
             return eye, zeros
 
         def positive_dt(dt):
-            lam = jnp.sqrt(5.0) / self.lengthscale
-            dtlam = dt * lam
-            A = jnp.exp(-dtlam) * (
-                dt
-                * jnp.array(
-                    [
-                        [lam * (0.5 * dtlam + 1.0), dtlam + 1.0, 0.5 * dt],
-                        [
-                            -0.5 * dtlam * lam**2,
-                            lam * (1.0 - dtlam),
-                            1.0 - 0.5 * dtlam,
-                        ],
-                        [
-                            lam**3 * (0.5 * dtlam - 1.0),
-                            lam**2 * (dtlam - 3.0),
-                            lam * (0.5 * dtlam - 2.0),
-                        ],
-                    ]
-                )
-                + jnp.eye(3)
+            transition_matrix, process_noise_cov = _matern52_discrete_transition_and_q(
+                dt, self.lengthscale, self.variance
             )
-            Q = _matern52_discrete_q(dt, self.lengthscale, self.variance)
-            return A, _psd_sqrt(Q)
+            return transition_matrix, _psd_sqrt(process_noise_cov)
 
         return jax.lax.cond(time_step == 0.0, zero_dt, positive_dt, time_step)
 

--- a/tests/test_likelihoods_diagonal_fast_path.py
+++ b/tests/test_likelihoods_diagonal_fast_path.py
@@ -1,12 +1,20 @@
 """Tests for the _diagonal_scale helper in gpjax.likelihoods."""
 
+import gpjax as gpx
 from gpjax.distributions import GaussianDistribution
+from gpjax.gps import Prior
+from gpjax.kernels import RBF
 from gpjax.likelihoods import (
     Gaussian,
+    HeteroscedasticGaussian,
+    MultiOutputGaussian,
     _diagonal_scale,
 )
+from gpjax.mean_functions import Zero
 import jax.numpy as jnp
+import jax.random as jr
 import lineax as lx
+import pytest
 
 
 def test_diagonal_scale_plain_diagonal_returns_inner():
@@ -70,7 +78,7 @@ def test_gaussian_predict_tagged_diagonal_preserves_diagonal_scale():
 
 
 def test_gaussian_predict_dense_returns_gaussian_distribution_with_matrix_scale():
-    """Dense-covariance input widens to GaussianDistribution with MatrixLinearOperator scale."""
+    """Dense input widens to GaussianDistribution with MatrixLinearOperator scale."""
     mean = jnp.array([0.0, 1.0])
     cov = jnp.array([[2.0, 0.5], [0.5, 3.0]])
     dense = lx.MatrixLinearOperator(cov)
@@ -84,3 +92,51 @@ def test_gaussian_predict_dense_returns_gaussian_distribution_with_matrix_scale(
     assert isinstance(dist_out.scale, lx.MatrixLinearOperator)
     expected_cov = cov + jnp.eye(2) * 0.01
     assert jnp.allclose(dist_out.covariance_matrix, expected_cov)
+
+
+def test_gaussian_predict_is_numpyro_compatible():
+    """Compatibility smoke-test: predictive supports sample + log_prob."""
+    latent = GaussianDistribution(
+        loc=jnp.zeros(4), scale=lx.DiagonalLinearOperator(jnp.ones(4))
+    )
+    predictive = gpx.likelihoods.Gaussian(num_datapoints=4, obs_stddev=0.1).predict(
+        latent
+    )
+    assert predictive.mean.shape == (4,)
+    assert bool(jnp.all(predictive.variance > 0))
+    sample = predictive.sample(jr.key(0))
+    assert sample.shape == (4,)
+    assert jnp.isfinite(predictive.log_prob(sample))
+
+
+@pytest.mark.parametrize("likelihood_cls", [Gaussian, MultiOutputGaussian])
+def test_gaussian_family_predict_returns_gaussian_distribution(likelihood_cls):
+    """Lock the return-type contract for Gaussian and MultiOutputGaussian."""
+    n_points = 3
+    latent = GaussianDistribution(
+        loc=jnp.zeros(n_points),
+        scale=lx.DiagonalLinearOperator(jnp.ones(n_points)),
+    )
+    if likelihood_cls is MultiOutputGaussian:
+        likelihood = likelihood_cls(
+            num_datapoints=n_points, num_outputs=1, obs_stddev=0.5
+        )
+    else:
+        likelihood = likelihood_cls(num_datapoints=n_points, obs_stddev=0.5)
+    predictive = likelihood.predict(latent)
+    assert isinstance(predictive, GaussianDistribution)
+
+
+def test_heteroscedastic_predict_returns_gaussian_distribution():
+    """Lock the return-type contract for HeteroscedasticGaussian.predict."""
+    noise_prior = Prior(kernel=RBF(), mean_function=Zero())
+    likelihood = HeteroscedasticGaussian(num_datapoints=2, noise_prior=noise_prior)
+
+    signal_dist = GaussianDistribution(
+        loc=jnp.zeros(2), scale=lx.MatrixLinearOperator(jnp.eye(2))
+    )
+    noise_dist = GaussianDistribution(
+        loc=jnp.zeros(2), scale=lx.MatrixLinearOperator(jnp.eye(2))
+    )
+    predictive = likelihood.predict(signal_dist, noise_dist=noise_dist)
+    assert isinstance(predictive, GaussianDistribution)

--- a/tests/test_state_space/test_fit.py
+++ b/tests/test_state_space/test_fit.py
@@ -122,6 +122,15 @@ def test_fit_scipy_warns_on_unsorted_input_and_sorts_internally():
         fit_scipy(model=posterior, train_data=train_data, max_iters=10, verbose=False)
 
 
+def test_fit_lbfgs_does_not_expose_verbose():
+    """fit_lbfgs must not advertise a verbose flag the optimiser ignores."""
+    import inspect
+
+    from gpjax.state_space import fit_lbfgs
+
+    assert "verbose" not in inspect.signature(fit_lbfgs).parameters
+
+
 def test_fit_lbfgs_returns_state_space_posterior_type():
     n = 50
     X, y = _build_matern52_synthetic(n=n, seed=3)
@@ -138,7 +147,6 @@ def test_fit_lbfgs_returns_state_space_posterior_type():
         model=posterior,
         train_data=train_data,
         max_iters=10,
-        verbose=False,
     )
     assert isinstance(fitted_posterior, StateSpaceConjugatePosterior)
 

--- a/tests/test_state_space/test_gps.py
+++ b/tests/test_state_space/test_gps.py
@@ -128,3 +128,19 @@ def test_state_space_prior_times_gaussian_with_array_obs_stddev_raises():
     likelihood = gpx.likelihoods.Gaussian(num_datapoints=3, obs_stddev=jnp.ones(3))
     with pytest.raises(ValueError, match=r"scalar|obs_stddev"):
         prior * likelihood
+
+
+def test_state_space_predict_rejects_dense_with_actionable_message():
+    data = gpx.Dataset(
+        X=jnp.linspace(0, 5, 10).reshape(-1, 1),
+        y=jnp.sin(jnp.linspace(0, 5, 10)).reshape(-1, 1),
+    )
+    posterior = StateSpacePrior(
+        mean_function=gpx.mean_functions.Zero(),
+        kernel=gpx.kernels.Matern32(lengthscale=1.0, variance=1.0),
+    ) * gpx.likelihoods.Gaussian(num_datapoints=10, obs_stddev=0.1)
+
+    with pytest.raises(NotImplementedError, match=r"diagonal-only|follow-up|v1"):
+        posterior.predict(
+            jnp.linspace(0, 5, 4).reshape(-1, 1), data, return_covariance_type="dense"
+        )

--- a/tests/test_state_space/test_sde.py
+++ b/tests/test_state_space/test_sde.py
@@ -398,3 +398,22 @@ def test_matern_sde_gradient_through_lengthscale_at_realistic_N(sde_cls, n):
 
     grad_value = jax.grad(loss)(jnp.asarray(1.0))
     assert jnp.isfinite(grad_value)
+
+
+@pytest.mark.parametrize("sde_name", ["Matern12SDE", "Matern32SDE", "Matern52SDE"])
+def test_continuous_lyapunov_stationarity(sde_name):
+    """F P∞ + P∞ Fᵀ + L Qc Lᵀ = 0 ties the stored Qc to the drift and P∞."""
+    import gpjax.state_space.sde as sde_module
+
+    sde = getattr(sde_module, sde_name)(lengthscale=0.7, variance=1.3)
+    drift = sde.drift_matrix
+    diffusion = sde.diffusion_matrix
+    spectral_density = sde.process_noise_spectral_density
+    stationary_cov = sde.stationary_state_cov_sqrt @ sde.stationary_state_cov_sqrt.T
+
+    residual = (
+        drift @ stationary_cov
+        + stationary_cov @ drift.T
+        + diffusion @ spectral_density @ diffusion.T
+    )
+    assert jnp.allclose(residual, 0.0, atol=1e-9)

--- a/tests/test_state_space/test_sde.py
+++ b/tests/test_state_space/test_sde.py
@@ -14,6 +14,7 @@ from gpjax.state_space.sde import (
 )
 import jax
 import jax.numpy as jnp
+import jax.scipy.linalg as jsl
 import numpy as np
 import pytest
 import scipy.linalg
@@ -34,6 +35,17 @@ def _trivial_matern12_sde(lengthscale=1.0, variance=1.0):
         stationary_state_cov_sqrt=L_inf,
         state_dim=1,
     )
+
+
+@pytest.mark.parametrize("nu_name", ["Matern12SDE", "Matern32SDE", "Matern52SDE"])
+def test_discrete_transition_equals_matrix_exponential(nu_name):
+    import gpjax.state_space.sde as sde_module
+
+    sde = getattr(sde_module, nu_name)(lengthscale=0.7, variance=1.3)
+    time_step = jnp.asarray(0.37)
+    transition_matrix, _ = sde.discretise(time_step)
+    expected = jsl.expm(sde.drift_matrix * time_step)
+    assert jnp.allclose(transition_matrix, expected, atol=1e-8)
 
 
 def test_linear_sde_discretise_zero_dt_is_identity_transition():

--- a/tests/test_state_space/test_smoother.py
+++ b/tests/test_state_space/test_smoother.py
@@ -4,8 +4,9 @@ See plans/2026-04-21-state-space-gps-design.md §Stage 3.
 """
 
 import gpjax as gpx
+from gpjax.state_space import StateSpacePrior
 from gpjax.state_space.inference import _sqrt_filter_forward, rts_smoother
-from gpjax.state_space.sde import Matern12SDE
+from gpjax.state_space.sde import Matern12SDE, _psd_sqrt
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -164,3 +165,57 @@ def test_rts_smoother_matches_numpy_reference_to_machine_precision():
     np.testing.assert_allclose(
         np.asarray(smoothed_covs), covs_reference, atol=1e-12, rtol=1e-12
     )
+
+
+def test_smoother_is_finite_under_near_noiseless_dense_sampling():
+    """Robustness guard: stiff regime (tiny obs noise, dense Matern-5/2 grid)
+    must stay finite.
+
+    Green both before and after the _psd_sqrt swap — documents the contract, not
+    a red→green reproduction.
+    """
+    dense_times = jnp.linspace(0.0, 1.0, 200).reshape(-1, 1)
+    targets = jnp.sin(20.0 * dense_times)
+    data = gpx.Dataset(X=dense_times, y=targets)
+
+    prior = StateSpacePrior(
+        mean_function=gpx.mean_functions.Zero(),
+        kernel=gpx.kernels.Matern52(lengthscale=0.05, variance=1.0),
+    )
+    likelihood = gpx.likelihoods.Gaussian(num_datapoints=200, obs_stddev=1e-4)
+    posterior = prior * likelihood
+
+    test_times = jnp.linspace(0.0, 1.0, 50).reshape(-1, 1)
+    predictive = posterior.predict(test_times, data)
+
+    assert bool(jnp.all(jnp.isfinite(predictive.mean)))
+    assert bool(jnp.all(jnp.isfinite(predictive.variance)))
+    assert bool(jnp.all(predictive.variance >= 0.0))
+
+
+def test_psd_sqrt_handles_marginally_indefinite_where_cholesky_nans():
+    """The smoother's PSD-difference P can be marginally indefinite from round-off.
+
+    jnp.linalg.cholesky NaNs on such a matrix; _psd_sqrt (used by rts_smoother
+    after this fix) clips the tiny negative eigenvalue and stays finite,
+    reconstructing the PSD part via L @ L.T. This is the failure mode Issue #3
+    fixes — green on _psd_sqrt, red on cholesky.
+    """
+    # Fixed orthogonal basis (QR of a deterministic matrix; no RNG).
+    basis, _ = jnp.linalg.qr(
+        jnp.array([[1.0, 2.0, 3.0], [0.0, 1.0, 4.0], [5.0, 6.0, 0.0]])
+    )
+    eigenvalues = jnp.array([1.0, 1e-3, -2e-16])  # tiny negative from "round-off"
+    marginally_indefinite = basis @ jnp.diag(eigenvalues) @ basis.T
+    symmetrised = 0.5 * (marginally_indefinite + marginally_indefinite.T)
+
+    # RED path: cholesky NaNs on the (marginally) non-PSD matrix.
+    cholesky_factor = jnp.linalg.cholesky(symmetrised)
+    assert bool(jnp.any(jnp.isnan(cholesky_factor)))
+
+    # GREEN path: _psd_sqrt stays finite and reconstructs the PSD part.
+    psd_root = _psd_sqrt(symmetrised)
+    assert bool(jnp.all(jnp.isfinite(psd_root)))
+    psd_part = basis @ jnp.diag(jnp.clip(eigenvalues, 0.0)) @ basis.T
+    # float64 round-trip; conftest enables x64
+    assert jnp.allclose(psd_root @ psd_root.T, psd_part, atol=1e-10)

--- a/tests/test_state_space/test_validation.py
+++ b/tests/test_state_space/test_validation.py
@@ -30,6 +30,21 @@ def test_validate_temporal_kernel_rejects_active_dims_list():
         _validate_temporal_kernel(kernel)
 
 
+def test_kernel_construction_rejects_tuple_active_dims_upstream():
+    """active_dims is constrained to list|slice at construction, so non-list
+    multi-axis selectors (tuple/ndarray) can never reach _validate_temporal_kernel.
+    This pins the upstream contract that makes the list-only check sufficient.
+
+    Construction rejects a tuple either via ``_check_active_dims`` (a manual
+    ``TypeError`` reading "list or slice") or, when the beartype import hook is
+    active (as in this test suite), via a jaxtyping/beartype type-check whose
+    message names the ``list[int], slice`` annotation. Either way the tuple
+    cannot reach ``_validate_temporal_kernel``.
+    """
+    with pytest.raises(Exception, match=r"list or slice|list\[int\], slice"):
+        gpx.kernels.Matern32(active_dims=(0, 1))
+
+
 def test_validate_temporal_kernel_rejects_n_dims_greater_than_one():
     kernel = gpx.kernels.Matern12(lengthscale=jnp.ones(2), n_dims=2)
     with pytest.raises(ValueError, match=r"n_dims|1-D"):


### PR DESCRIPTION
Resolves the nine findings from the `feat/state-space` code review **without regressing** the (empirically verified) correctness of the state-space filter, smoother, and SDE representations. The headline invariant holds throughout: state-space MLL == `conjugate_mll` (~1e-14) and the smoothed predictive == dense GP latent predictive (~1e-15) for Matérn-1/2, 3/2, 5/2.

One commit per finding; full gate green (`uv run poe all-tests`: **2411 passed, 1 skipped**).

## Findings resolved

| # | Issue | Resolution | Kind |
|---|---|---|---|
| 1 | `Gaussian.predict` return type | Keep `GaussianDistribution`; **also migrate `HeteroscedasticGaussian.predict`** for consistency; pin the Gaussian-family return type with a contract test | **breaking** |
| 2 | `state_space_mll` unsorted input | Keep the objective pure (jit-first); document the pre-sorted contract + silent failure mode; sorting stays in the eager `fit*` wrappers | docs |
| 3 | Smoother stability | Swap `jnp.linalg.cholesky` → gradient-safe `_psd_sqrt` in the RTS smoother; primitive red→green test + e2e robustness guard | fix |
| 4 | Diagonal-only predictive | Make the v1 contract explicit with actionable `NotImplementedError`s + docstrings; dense joint predictive tracked as #651 | docs |
| 5 | `active_dims` validation | Investigated: not a bug — kernels constrain `active_dims` to `list\|slice` at construction, so the existing list-check is sufficient. Documented + characterization test | docs |
| 6 | `Qc` field | Document `process_noise_spectral_density`; verify via a continuous Lyapunov stationarity test (`F P∞ + P∞ Fᵀ + L Qc Lᵀ = 0`, residual ≤ 4.5e-13) | test |
| 7 | `fit_lbfgs` `verbose` | Drop the dead no-op `verbose` param (underlying optimiser ignores it); `fit`/`fit_scipy` keep it | fix |
| 8 | Duplicated transition matrix | De-duplicate discrete `A(Δt)` for Matérn-3/2 & 5/2 (helper returns `(A, Q)`); numerics unchanged (max diff 0.0), guarded by `A == expm(F·Δt)` | refactor |
| 9 | Nits | Hoist `paramax` import; correct the Bessel recurrence-stability docstring | style |

## ⚠️ Reviewer attention — Phase 7 is a library-wide breaking change

`gpjax.likelihoods.Gaussian.predict` **and** `gpjax.likelihoods.HeteroscedasticGaussian.predict` now return `gpjax.distributions.GaussianDistribution` (was `numpyro.distributions.MultivariateNormal`). `.sample`/`.log_prob`/`.mean`/`.variance`/`.covariance_matrix` are unchanged; code relying on `MultivariateNormal`-only attributes (`.scale_tril`, `.precision_matrix`) must update. CHANGELOG updated. Consumer audit was clean.

## Notes

- Three findings (#2, #5, #6) were resolved by **documentation/verification after investigation** rather than code change — in each case the suspected defect did not exist (jit-ability constraint; upstream construction guard; correct `Qc` values). Rationale captured in the commits.
- Issue #3's end-to-end NaN could not be reproduced; the swap is justified on **robustness + consistency** grounds (the codebase already standardizes on `_psd_sqrt` for PSD roots), with a primitive-level red→green test demonstrating the failure mode.
- Follow-up: dense joint state-space predictive via smoother cross-covariances → #651.

🤖 Generated with [Claude Code](https://claude.com/claude-code)