### PR TITLE
feat: add gpx.summarise() model summary tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to GPJax are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.16.0] — 2026-06-28
 
 ### Added
 
@@ -108,5 +108,6 @@ See [`docs/migration.md`](docs/migration.md) for full upgrade instructions.
 - Added: `equinox>=0.11`, `paramax>=0.0.5`, `lineax`.
 - Removed: `flax`, `cola-ml`.
 
+[0.16.0]: https://github.com/thomaspinder/GPJax/releases/tag/v0.16.0
 [0.15.0]: https://github.com/thomaspinder/GPJax/releases/tag/v0.15.0
 [0.14.0]: https://github.com/thomaspinder/GPJax/releases/tag/v0.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to GPJax are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`gpjax.summarise(model)`**: render any GPJax pytree (kernel, prior,
+  posterior, likelihood, variational family, ...) as a flat `rich` table —
+  one row per parameter — showing parameter path, class, constrained value,
+  bijector, trainability, shape, and dtype. User-facing abstract bases gain
+  `__rich__` and `_repr_mimebundle_` hooks for `rich.print(model)` and
+  Jupyter auto-rendering; `repr()` is unchanged. `rich` is now a core
+  runtime dependency.
+
 ## [0.15.0] — 2026-06-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bijector, trainability, shape, and dtype. User-facing abstract bases gain
   `__rich__` and `_repr_mimebundle_` hooks for `rich.print(model)` and
   Jupyter auto-rendering; `repr()` is unchanged. `rich` is now a core
-  runtime dependency.
+  runtime dependency. An optional `priors` mapping (parameter name → prior,
+  e.g. a NumPyro distribution) populates the otherwise-empty Prior column.
 
 ## [0.15.0] — 2026-06-03
 

--- a/docs/scripts/gen_examples.py
+++ b/docs/scripts/gen_examples.py
@@ -15,7 +15,7 @@ import subprocess
 EXCLUDE = ["utils.py"]
 
 # Notebooks that should get the consulting CTA appended. Mirrors the
-# "Tutorials" and "Experimental" sections of mkdocs.yml.
+# "Tutorials" section of mkdocs.yml.
 CTA_NOTEBOOKS = {
     "regression",
     "classification",

--- a/examples/backend.py
+++ b/examples/backend.py
@@ -151,6 +151,25 @@ posterior = likelihood * prior
 print(posterior)
 
 # %% [markdown]
+# ### Summarising a model
+#
+# The `print(posterior)` output above is Equinox's representation: it exposes each
+# parameter's *unconstrained* internal storage and conveys nothing about bijectors or
+# trainability. For a human-readable overview, use `gpx.summarise`, which renders a flat
+# table — one row per parameter — showing the constrained value, the bijector, whether
+# the parameter is trainable, and its shape and dtype. It works on any GPJax model: a
+# kernel, prior, posterior, likelihood, or variational family.
+
+# %%
+gpx.summarise(posterior)
+
+# %% [markdown]
+# `summarise` traverses the model as a PyTree, so composite objects (e.g. sum kernels)
+# and frozen parameters are handled automatically — frozen rows are dimmed and reported
+# as non-trainable. The same table backs `rich.print(posterior)` and Jupyter's automatic
+# display, while `repr(posterior)` is left untouched.
+
+# %% [markdown]
 # Now contained within the posterior there are four parameters: the kernel's lengthscale
 # and variance, the noise variance of the likelihood, and the constant of the mean
 # function. With Equinox, we can partition the model into its array leaves and static

--- a/examples/numpyro_integration.py
+++ b/examples/numpyro_integration.py
@@ -174,6 +174,36 @@ def model(X, Y, X_new=None):
         numpyro.deterministic("y_pred", total_prediction)
         return total_prediction
 
+# %% [markdown]
+# ### Inspecting the model and its priors
+#
+# Before running inference it is helpful to lay out the model's parameters alongside the
+# priors we placed on them. Because the priors are sampled *by name* inside ``model`` and
+# passed into the GPJax constructors, they are not stored on the parameter objects -- so
+# `gpx.summarise` cannot infer them automatically. We can still display them by passing a
+# ``priors`` mapping keyed by each parameter's name (the entries in the *Parameter*
+# column; call ``gpx.summarise(example_posterior)`` without the mapping to discover them).
+# The parameter *values* shown are placeholders -- they are resampled from these priors at
+# every step of MCMC.
+
+# %%
+example_kernel = gpx.kernels.RBF(lengthscale=1.0, variance=1.0) * gpx.kernels.Periodic(
+    lengthscale=1.0, period=1.0
+)
+example_posterior = gpx.gps.Prior(
+    mean_function=gpx.mean_functions.Constant(), kernel=example_kernel
+) * gpx.likelihoods.Gaussian(num_datapoints=N, obs_stddev=1.0)
+
+parameter_priors = {
+    "prior.kernel.kernels[0].lengthscale": dist.LogNormal(0.0, 1.0),
+    "prior.kernel.kernels[0].variance": dist.LogNormal(0.0, 1.0),
+    "prior.kernel.kernels[1].lengthscale": dist.LogNormal(0.0, 1.0),
+    "prior.kernel.kernels[1].period": dist.LogNormal(0.0, 0.5),
+    "likelihood.obs_stddev": dist.LogNormal(0.0, 1.0),
+}
+
+gpx.summarise(example_posterior, priors=parameter_priors)
+
 
 # %% [markdown]
 # ## Running MCMC

--- a/examples/numpyro_integration.py
+++ b/examples/numpyro_integration.py
@@ -106,13 +106,10 @@ ax.legend()
 # as its support matches that of our lengthscale parameter. Priors are standard
 # [NumPyro distributions](https://num.pyro.ai/en/stable/distributions.html) sampled directly
 # inside the model function with ``numpyro.sample``.
-
-# %%
+#
 # Priors are defined as NumPyro distributions and sampled directly inside the model
 # function below. GPJax parameter constructors accept raw JAX arrays from
 # numpyro.sample, so no special registration step is needed.
-
-# %% [markdown]
 #
 # We'll construct the Gaussian process inside the NumPyro model function, passing
 # sampled hyperparameters directly to the GPJax constructors. For a deeper look at
@@ -142,12 +139,8 @@ def model(X, Y, X_new=None):
     period = numpyro.sample("period", dist.LogNormal(0.0, 0.5))
     obs_noise = numpyro.sample("obs_noise", dist.LogNormal(0.0, 1.0))
 
-    stationary_component = gpx.kernels.RBF(
-        lengthscale=lengthscale, variance=variance
-    )
-    periodic_component = gpx.kernels.Periodic(
-        lengthscale=lengthscale, period=period
-    )
+    stationary_component = gpx.kernels.RBF(lengthscale=lengthscale, variance=variance)
+    periodic_component = gpx.kernels.Periodic(lengthscale=lengthscale, period=period)
     kernel = stationary_component * periodic_component
 
     meanf = gpx.mean_functions.Constant()
@@ -173,6 +166,7 @@ def model(X, Y, X_new=None):
         total_prediction = slope * X_new + intercept + f_new + y_noise
         numpyro.deterministic("y_pred", total_prediction)
         return total_prediction
+
 
 # %% [markdown]
 # ### Inspecting the model and its priors

--- a/examples/regression.py
+++ b/examples/regression.py
@@ -208,6 +208,14 @@ opt_posterior, history = gpx.fit_scipy(
 print(-gpx.objectives.conjugate_mll(opt_posterior, D))
 
 # %% [markdown]
+# To inspect the learned hyperparameters, we can render a summary table of the optimised
+# posterior with `gpx.summarise`. This shows each parameter's constrained value, its
+# bijector, and whether it is trainable — a quick sanity check after optimisation.
+
+# %%
+gpx.summarise(opt_posterior)
+
+# %% [markdown]
 # ## Prediction
 #
 # Equipped with the posterior and a set of optimised hyperparameter values, we are now

--- a/gpjax/__init__.py
+++ b/gpjax/__init__.py
@@ -39,6 +39,7 @@ from gpjax.fit import (
     fit_lbfgs,
     fit_scipy,
 )
+from gpjax.summary import summarise
 
 __license__ = "MIT"
 __description__ = "Gaussian processes in JAX"
@@ -62,6 +63,7 @@ __all__ = [
     "objectives",
     "parameters",
     "state_space",
+    "summarise",
     "typing",
     "variational_families",
 ]

--- a/gpjax/__init__.py
+++ b/gpjax/__init__.py
@@ -45,7 +45,7 @@ __license__ = "MIT"
 __description__ = "Gaussian processes in JAX"
 __url__ = "https://github.com/thomaspinder/GPJax"
 __contributors__ = "https://github.com/thomaspinder/GPJax/graphs/contributors"
-__version__ = "0.15.0"
+__version__ = "0.16.0"
 
 __all__ = [
     "Dataset",

--- a/gpjax/gps.py
+++ b/gpjax/gps.py
@@ -45,6 +45,7 @@ from gpjax.mean_functions import AbstractMeanFunction
 from gpjax.parameters import (
     Real,
 )
+from gpjax.summary import _SummaryMixin
 from gpjax.typing import (
     Array,
     FunctionalSample,
@@ -64,7 +65,7 @@ def _val(x):
     return x.unwrap() if isinstance(x, AbstractUnwrappable) else x
 
 
-class AbstractPrior(eqx.Module, tp.Generic[M, K]):
+class AbstractPrior(_SummaryMixin, eqx.Module, tp.Generic[M, K]):
     r"""Abstract Gaussian process prior."""
 
     kernel: K
@@ -377,7 +378,7 @@ P = tp.TypeVar("P", bound=AbstractPrior)
 #######################
 # GP Posteriors
 #######################
-class AbstractPosterior(eqx.Module, tp.Generic[P, L]):
+class AbstractPosterior(_SummaryMixin, eqx.Module, tp.Generic[P, L]):
     r"""Abstract Gaussian process posterior.
 
     The base GP posterior object conditioned on an observed dataset. All

--- a/gpjax/kernels/base.py
+++ b/gpjax/kernels/base.py
@@ -30,13 +30,14 @@ from gpjax.kernels.computations import (
     DenseKernelComputation,
 )
 from gpjax.parameters import Real
+from gpjax.summary import _SummaryMixin
 from gpjax.typing import (
     Array,
     ScalarFloat,
 )
 
 
-class AbstractKernel(eqx.Module):
+class AbstractKernel(_SummaryMixin, eqx.Module):
     r"""Base kernel class.
 
     This class is the base class for all kernels in GPJax. It provides the basic

--- a/gpjax/likelihoods.py
+++ b/gpjax/likelihoods.py
@@ -38,6 +38,7 @@ from gpjax.integrators import (
 from gpjax.parameters import (
     NonNegativeReal,
 )
+from gpjax.summary import _SummaryMixin
 from gpjax.typing import (
     Array,
     ScalarFloat,
@@ -82,7 +83,7 @@ jax.tree_util.register_pytree_node(
 )
 
 
-class AbstractLikelihood(eqx.Module):
+class AbstractLikelihood(_SummaryMixin, eqx.Module):
     r"""Abstract base class for likelihoods.
 
     All likelihoods must inherit from this class and implement the `predict` and

--- a/gpjax/mean_functions.py
+++ b/gpjax/mean_functions.py
@@ -26,6 +26,7 @@ from jaxtyping import (
 )
 from paramax import AbstractUnwrappable
 
+from gpjax.summary import _SummaryMixin
 from gpjax.typing import (
     Array,
     ScalarFloat,
@@ -37,7 +38,7 @@ def _val(x):
     return x.unwrap() if isinstance(x, AbstractUnwrappable) else x
 
 
-class AbstractMeanFunction(eqx.Module):
+class AbstractMeanFunction(_SummaryMixin, eqx.Module):
     r"""Mean function that is used to parameterise the Gaussian process."""
 
     @abc.abstractmethod

--- a/gpjax/summary.py
+++ b/gpjax/summary.py
@@ -67,3 +67,14 @@ def _is_frozen(leaf: tp.Any) -> bool:
         leaf, is_leaf=lambda y: isinstance(y, paramax.NonTrainable)
     )
     return any(isinstance(x, paramax.NonTrainable) for x in leaves)
+
+
+def _bijector_name(leaf: tp.Any) -> str:
+    """Friendly bijector label for a parameter leaf."""
+    if isinstance(leaf, SigmoidBounded):
+        return f"Sigmoid[{leaf.low:g}, {leaf.high:g}]"
+    constraint = getattr(leaf, "_constraint", None)
+    if constraint is None:
+        return "Identity"
+    raw = type(biject_to(constraint)).__name__
+    return _BIJECTOR_NAMES.get(raw, raw)

--- a/gpjax/summary.py
+++ b/gpjax/summary.py
@@ -216,11 +216,6 @@ def summarise(
     >>> kernel = gpx.kernels.RBF()
     >>> gpx.summarise(kernel)  # doctest: +SKIP
     """
-    records = _collect(model)
-    target = console if console is not None else Console()
-    if not records:
-        target.print("no trainable parameters")
-        return
     cols = tuple(columns) if columns is not None else _DEFAULT_COLUMNS
     unknown = [c for c in cols if c not in _DEFAULT_COLUMNS]
     if unknown:
@@ -228,12 +223,13 @@ def summarise(
             f"unknown column(s) {unknown}; valid columns are {list(_DEFAULT_COLUMNS)}"
         )
     table = _render(
-        records,
+        _collect(model),
         columns=cols,
         title=title if title is not None else type(model).__name__,
         max_array=max_array,
         precision=precision,
     )
+    target = console if console is not None else Console()
     target.print(table)
 
 

--- a/gpjax/summary.py
+++ b/gpjax/summary.py
@@ -179,3 +179,52 @@ def _render(
     table.caption = f"{len(records)} parameters, {n_trainable} trainable"
     table.caption_justify = "left"
     return table
+
+
+def summarise(
+    model: tp.Any,
+    *,
+    columns: tp.Sequence[str] | None = None,
+    console: Console | None = None,
+    max_array: int = 4,
+    precision: int = 3,
+    title: str | None = None,
+) -> None:
+    """Print a ``rich`` table summarising a GPJax model's parameters.
+
+    Parameters
+    ----------
+    model
+        Any GPJax pytree (kernel, prior, posterior, likelihood, variational
+        family, ...).
+    columns
+        Subset/ordering of columns to show. Defaults to the full GPflow-style
+        column set.
+    console
+        Target ``rich.Console``; defaults to a fresh one.
+    max_array
+        Maximum number of array elements shown per value.
+    precision
+        Significant figures for numeric values.
+    title
+        Table title; defaults to the model's class name.
+
+    Examples
+    --------
+    >>> import gpjax as gpx
+    >>> kernel = gpx.kernels.RBF()
+    >>> gpx.summarise(kernel)  # doctest: +SKIP
+    """
+    records = _collect(model)
+    target = console if console is not None else Console()
+    if not records:
+        target.print("no trainable parameters")
+        return
+    table = _render(
+        records,
+        columns=tuple(columns) if columns is not None else _DEFAULT_COLUMNS,
+        title=title if title is not None else type(model).__name__,
+        max_array=max_array,
+        precision=precision,
+    )
+    target.print(table)

--- a/gpjax/summary.py
+++ b/gpjax/summary.py
@@ -54,3 +54,16 @@ class ParamRecord(tp.NamedTuple):
     trainable: bool
     shape: tuple[int, ...]
     dtype: str
+
+
+def _is_param_leaf(x: tp.Any) -> bool:
+    """Stop pytree traversal at parameter objects."""
+    return isinstance(x, AbstractUnwrappable)
+
+
+def _is_frozen(leaf: tp.Any) -> bool:
+    """True iff ``leaf``'s subtree contains a ``paramax.NonTrainable``."""
+    leaves = jax.tree_util.tree_leaves(
+        leaf, is_leaf=lambda y: isinstance(y, paramax.NonTrainable)
+    )
+    return any(isinstance(x, paramax.NonTrainable) for x in leaves)

--- a/gpjax/summary.py
+++ b/gpjax/summary.py
@@ -103,3 +103,29 @@ def _format_value(value: tp.Any, *, max_array: int, precision: int) -> str:
     if flat.size > max_array:
         shown += ", ..."
     return f"[{shown}]"
+
+
+def _collect(model: tp.Any) -> list[ParamRecord]:
+    """Walk ``model`` and produce one :class:`ParamRecord` per parameter."""
+    records: list[ParamRecord] = []
+    paths_leaves, _ = jax.tree_util.tree_flatten_with_path(
+        model, is_leaf=_is_param_leaf
+    )
+    for path, leaf in paths_leaves:
+        is_param = _is_param_leaf(leaf)
+        if not (is_param or isinstance(leaf, (jax.Array, np.ndarray))):
+            continue
+        value = paramax.unwrap(leaf) if is_param else leaf
+        records.append(
+            ParamRecord(
+                name=jax.tree_util.keystr(path).lstrip("."),
+                cls=type(leaf).__name__ if is_param else "Array",
+                value=value,
+                bijector=_bijector_name(leaf) if is_param else "Identity",
+                prior="-",
+                trainable=not _is_frozen(leaf),
+                shape=tuple(getattr(value, "shape", ())),
+                dtype=_short_dtype(value.dtype) if hasattr(value, "dtype") else "?",
+            )
+        )
+    return records

--- a/gpjax/summary.py
+++ b/gpjax/summary.py
@@ -1,0 +1,56 @@
+"""Human-readable model summaries for GPJax pytrees.
+
+Render any GPJax model (kernel, prior, posterior, likelihood, variational
+family, ...) as a flat ``rich`` table -- one row per parameter -- in the
+spirit of GPflow's ``print_summary``. Use the free function :func:`summarise`,
+or rely on the ``__rich__`` / ``_repr_mimebundle_`` hooks attached to the
+user-facing abstract bases for ``rich.print`` and notebook auto-rendering.
+"""
+
+import io
+
+import beartype.typing as tp
+import jax
+import numpy as np
+import paramax
+from numpyro.distributions import biject_to
+from paramax import AbstractUnwrappable
+from rich import box
+from rich.console import Console
+from rich.table import Table
+
+from gpjax.parameters import SigmoidBounded
+
+__all__ = ["summarise"]
+
+# Default GPflow-style column set, in display order.
+_DEFAULT_COLUMNS: tuple[str, ...] = (
+    "Parameter",
+    "Class",
+    "Value",
+    "Bijector",
+    "Prior",
+    "Trainable",
+    "Shape",
+    "Dtype",
+)
+
+# Friendly labels for the numpyro transforms returned by ``biject_to``.
+_BIJECTOR_NAMES: dict[str, str] = {
+    "SoftplusTransform": "Softplus",
+    "IdentityTransform": "Identity",
+    "SoftplusLowerCholeskyTransform": "LowerCholesky",
+}
+
+
+class ParamRecord(tp.NamedTuple):
+    """A single rendered parameter row (rendering-agnostic)."""
+
+    name: str
+    cls: str
+    value: tp.Any
+    bijector: str
+    prior: str
+    trainable: bool
+    shape: tuple[int, ...]
+    dtype: str

--- a/gpjax/summary.py
+++ b/gpjax/summary.py
@@ -50,7 +50,7 @@ class ParamRecord(tp.NamedTuple):
     cls: str
     value: tp.Any
     bijector: str
-    prior: str
+    prior: tp.Any
     trainable: bool
     shape: tuple[int, ...]
     dtype: str
@@ -110,8 +110,41 @@ def _format_value(value: tp.Any, *, max_array: int, precision: int) -> str:
     return f"[{shown}]"
 
 
-def _collect(model: tp.Any) -> list[ParamRecord]:
-    """Walk ``model`` and produce one :class:`ParamRecord` per parameter."""
+def _format_prior(prior: tp.Any, *, precision: int) -> str:
+    """Friendly label for a parameter's prior (or ``-`` when absent).
+
+    Accepts ``None`` (renders ``-``), a pre-formatted string, or any object
+    exposing NumPyro-style ``arg_constraints`` (e.g. a ``numpyro`` distribution),
+    which is rendered as ``Name(arg=value, ...)``.
+    """
+    if prior is None:
+        return "-"
+    if isinstance(prior, str):
+        return prior
+    arg_constraints = getattr(type(prior), "arg_constraints", None)
+    if isinstance(arg_constraints, dict) and arg_constraints:
+        parts = []
+        for arg in arg_constraints:
+            try:
+                value = float(np.asarray(getattr(prior, arg)))
+            except (TypeError, ValueError, AttributeError):
+                parts = []
+                break
+            parts.append(f"{arg}={value:.{precision}g}")
+        if parts:
+            return f"{type(prior).__name__}({', '.join(parts)})"
+    return type(prior).__name__
+
+
+def _collect(
+    model: tp.Any, *, priors: tp.Mapping[str, tp.Any] | None = None
+) -> list[ParamRecord]:
+    """Walk ``model`` and produce one :class:`ParamRecord` per parameter.
+
+    ``priors`` optionally maps a parameter's name (as shown in the Parameter
+    column) to a prior object, populating the otherwise-empty Prior column.
+    """
+    prior_map = priors or {}
     records: list[ParamRecord] = []
     paths_leaves, _ = jax.tree_util.tree_flatten_with_path(
         model, is_leaf=_is_param_leaf
@@ -127,13 +160,14 @@ def _collect(model: tp.Any) -> list[ParamRecord]:
             cls = "Array"
         else:
             cls = type(leaf).__name__
+        name = jax.tree_util.keystr(path).lstrip(".")
         records.append(
             ParamRecord(
-                name=jax.tree_util.keystr(path).lstrip("."),
+                name=name,
                 cls=cls,
                 value=value,
                 bijector=_bijector_name(leaf) if is_param else "Identity",
-                prior="-",
+                prior=prior_map.get(name),
                 trainable=not _is_frozen(leaf),
                 shape=tuple(getattr(value, "shape", ())),
                 dtype=_short_dtype(value.dtype) if hasattr(value, "dtype") else "?",
@@ -162,7 +196,7 @@ def _render(
             r.value, max_array=max_array, precision=precision
         ),
         "Bijector": lambda r: r.bijector,
-        "Prior": lambda r: r.prior,
+        "Prior": lambda r: _format_prior(r.prior, precision=precision),
         "Trainable": lambda r: (
             "[green]yes[/green]" if r.trainable else "[dim red]no[/dim red]"
         ),
@@ -190,6 +224,7 @@ def summarise(
     max_array: int = 4,
     precision: int = 3,
     title: str | None = None,
+    priors: tp.Mapping[str, tp.Any] | None = None,
 ) -> None:
     """Print a ``rich`` table summarising a GPJax model's parameters.
 
@@ -206,6 +241,9 @@ def summarise(
         max_array: Maximum number of array elements shown per value.
         precision: Significant figures for numeric values.
         title: Table title; defaults to the model's class name.
+        priors: Optional mapping from a parameter's name (as shown in the
+            Parameter column) to a prior object (e.g. a NumPyro distribution),
+            used to populate the Prior column. Defaults to ``None`` (all ``-``).
 
     Example:
         >>> import gpjax as gpx
@@ -219,7 +257,7 @@ def summarise(
             f"unknown column(s) {unknown}; valid columns are {list(_DEFAULT_COLUMNS)}"
         )
     table = _render(
-        _collect(model),
+        _collect(model, priors=priors),
         columns=cols,
         title=title if title is not None else type(model).__name__,
         max_array=max_array,

--- a/gpjax/summary.py
+++ b/gpjax/summary.py
@@ -254,5 +254,8 @@ class _SummaryMixin:
         console.print(self.__rich__())
         return {
             "text/plain": console.export_text(clear=False),
-            "text/html": console.export_html(),
+            "text/html": console.export_html(
+                inline_styles=True,
+                code_format='<pre style="font-family:Menlo,monospace">{code}</pre>',
+            ),
         }

--- a/gpjax/summary.py
+++ b/gpjax/summary.py
@@ -193,28 +193,24 @@ def summarise(
 ) -> None:
     """Print a ``rich`` table summarising a GPJax model's parameters.
 
-    Parameters
-    ----------
-    model
-        Any GPJax pytree (kernel, prior, posterior, likelihood, variational
-        family, ...).
-    columns
-        Subset/ordering of columns to show. Defaults to the full GPflow-style
-        column set.
-    console
-        Target ``rich.Console``; defaults to a fresh one.
-    max_array
-        Maximum number of array elements shown per value.
-    precision
-        Significant figures for numeric values.
-    title
-        Table title; defaults to the model's class name.
+    Renders one row per parameter -- showing the constrained value, bijector,
+    trainability, shape, and dtype -- for any GPJax model (kernel, prior,
+    posterior, likelihood, or variational family).
 
-    Examples
-    --------
-    >>> import gpjax as gpx
-    >>> kernel = gpx.kernels.RBF()
-    >>> gpx.summarise(kernel)  # doctest: +SKIP
+    Args:
+        model: Any GPJax pytree (kernel, prior, posterior, likelihood,
+            variational family, ...).
+        columns: Subset/ordering of columns to show. Defaults to the full
+            GPflow-style column set.
+        console: Target ``rich.Console``; defaults to a fresh one.
+        max_array: Maximum number of array elements shown per value.
+        precision: Significant figures for numeric values.
+        title: Table title; defaults to the model's class name.
+
+    Example:
+        >>> import gpjax as gpx
+        >>> kernel = gpx.kernels.RBF()
+        >>> gpx.summarise(kernel)  # doctest: +SKIP
     """
     cols = tuple(columns) if columns is not None else _DEFAULT_COLUMNS
     unknown = [c for c in cols if c not in _DEFAULT_COLUMNS]

--- a/gpjax/summary.py
+++ b/gpjax/summary.py
@@ -235,3 +235,24 @@ def summarise(
         precision=precision,
     )
     target.print(table)
+
+
+class _SummaryMixin:
+    """Adds ``rich`` / notebook rendering to user-facing GPJax bases.
+
+    ``repr`` is intentionally left to Equinox; this only powers
+    ``rich.print(model)`` and Jupyter auto-rendering.
+    """
+
+    def __rich__(self) -> Table:
+        return _render(_collect(self), title=type(self).__name__)
+
+    def _repr_mimebundle_(
+        self, include: tp.Any = None, exclude: tp.Any = None
+    ) -> dict[str, str]:
+        console = Console(record=True, file=io.StringIO(), width=120)
+        console.print(self.__rich__())
+        return {
+            "text/plain": console.export_text(clear=False),
+            "text/html": console.export_html(),
+        }

--- a/gpjax/summary.py
+++ b/gpjax/summary.py
@@ -176,7 +176,8 @@ def _render(
         table.add_row(*cells, style=None if record.trainable else "dim")
         n_trainable += int(record.trainable)
 
-    table.caption = f"{len(records)} parameters, {n_trainable} trainable"
+    plural = "" if len(records) == 1 else "s"
+    table.caption = f"{len(records)} parameter{plural}, {n_trainable} trainable"
     table.caption_justify = "left"
     return table
 
@@ -220,9 +221,15 @@ def summarise(
     if not records:
         target.print("no trainable parameters")
         return
+    cols = tuple(columns) if columns is not None else _DEFAULT_COLUMNS
+    unknown = [c for c in cols if c not in _DEFAULT_COLUMNS]
+    if unknown:
+        raise ValueError(
+            f"unknown column(s) {unknown}; valid columns are {list(_DEFAULT_COLUMNS)}"
+        )
     table = _render(
         records,
-        columns=tuple(columns) if columns is not None else _DEFAULT_COLUMNS,
+        columns=cols,
         title=title if title is not None else type(model).__name__,
         max_array=max_array,
         precision=precision,

--- a/gpjax/summary.py
+++ b/gpjax/summary.py
@@ -83,7 +83,12 @@ def _bijector_name(leaf: tp.Any) -> str:
 def _short_dtype(dtype: tp.Any) -> str:
     """Abbreviate a dtype name, e.g. float64 -> f64."""
     name = np.dtype(dtype).name
-    return name.replace("float", "f").replace("complex", "c").replace("int", "i")
+    return (
+        name.replace("float", "f")
+        .replace("complex", "c")
+        .replace("uint", "u")
+        .replace("int", "i")
+    )
 
 
 def _is_traced(value: tp.Any) -> bool:
@@ -116,10 +121,16 @@ def _collect(model: tp.Any) -> list[ParamRecord]:
         if not (is_param or isinstance(leaf, (jax.Array, np.ndarray))):
             continue
         value = paramax.unwrap(leaf) if is_param else leaf
+        # A frozen *bare* array stops traversal at a NonTrainable wrapper; label
+        # it like its unfrozen form ("Array"), not "NonTrainable".
+        if not is_param or isinstance(leaf, paramax.NonTrainable):
+            cls = "Array"
+        else:
+            cls = type(leaf).__name__
         records.append(
             ParamRecord(
                 name=jax.tree_util.keystr(path).lstrip("."),
-                cls=type(leaf).__name__ if is_param else "Array",
+                cls=cls,
                 value=value,
                 bijector=_bijector_name(leaf) if is_param else "Identity",
                 prior="-",

--- a/gpjax/summary.py
+++ b/gpjax/summary.py
@@ -12,8 +12,8 @@ import io
 import beartype.typing as tp
 import jax
 import numpy as np
-import paramax
 from numpyro.distributions import biject_to
+import paramax
 from paramax import AbstractUnwrappable
 from rich import box
 from rich.console import Console

--- a/gpjax/summary.py
+++ b/gpjax/summary.py
@@ -78,3 +78,28 @@ def _bijector_name(leaf: tp.Any) -> str:
         return "Identity"
     raw = type(biject_to(constraint)).__name__
     return _BIJECTOR_NAMES.get(raw, raw)
+
+
+def _short_dtype(dtype: tp.Any) -> str:
+    """Abbreviate a dtype name, e.g. float64 -> f64."""
+    name = np.dtype(dtype).name
+    return name.replace("float", "f").replace("complex", "c").replace("int", "i")
+
+
+def _is_traced(value: tp.Any) -> bool:
+    """True for abstract values seen under a ``jax.jit`` trace."""
+    return isinstance(value, jax.core.Tracer)
+
+
+def _format_value(value: tp.Any, *, max_array: int, precision: int) -> str:
+    """Format a parameter value; never crashes on traced values."""
+    if _is_traced(value):
+        return f"<traced {_short_dtype(value.dtype)}{list(value.shape)}>"
+    arr = np.asarray(value)
+    if arr.ndim == 0:
+        return f"{float(arr):.{precision}g}"
+    flat = arr.reshape(-1)
+    shown = ", ".join(f"{float(v):.{precision}g}" for v in flat[:max_array])
+    if flat.size > max_array:
+        shown += ", ..."
+    return f"[{shown}]"

--- a/gpjax/summary.py
+++ b/gpjax/summary.py
@@ -140,3 +140,42 @@ def _collect(model: tp.Any) -> list[ParamRecord]:
             )
         )
     return records
+
+
+def _render(
+    records: list[ParamRecord],
+    *,
+    columns: tp.Sequence[str] = _DEFAULT_COLUMNS,
+    title: str | None = None,
+    max_array: int = 4,
+    precision: int = 3,
+) -> Table:
+    """Render collected records into a ``rich.Table``."""
+    table = Table(title=title, box=box.ROUNDED, title_justify="left")
+    for column in columns:
+        table.add_column(column, overflow="fold")
+
+    accessors: dict[str, tp.Callable[[ParamRecord], str]] = {
+        "Parameter": lambda r: r.name,
+        "Class": lambda r: r.cls,
+        "Value": lambda r: _format_value(
+            r.value, max_array=max_array, precision=precision
+        ),
+        "Bijector": lambda r: r.bijector,
+        "Prior": lambda r: r.prior,
+        "Trainable": lambda r: (
+            "[green]yes[/green]" if r.trainable else "[dim red]no[/dim red]"
+        ),
+        "Shape": lambda r: str(r.shape),
+        "Dtype": lambda r: r.dtype,
+    }
+
+    n_trainable = 0
+    for record in records:
+        cells = [accessors[column](record) for column in columns]
+        table.add_row(*cells, style=None if record.trainable else "dim")
+        n_trainable += int(record.trainable)
+
+    table.caption = f"{len(records)} parameters, {n_trainable} trainable"
+    table.caption_justify = "left"
+    return table

--- a/gpjax/variational_families.py
+++ b/gpjax/variational_families.py
@@ -48,6 +48,7 @@ from gpjax.parameters import (
     LowerTriangular,
     Real,
 )
+from gpjax.summary import _SummaryMixin
 from gpjax.typing import (
     Array,
     ScalarFloat,
@@ -79,7 +80,7 @@ def _tri_solve(L, B):
     return jsp.linalg.solve_triangular(L, B, lower=True)
 
 
-class AbstractVariationalFamily(eqx.Module, tp.Generic[L]):
+class AbstractVariationalFamily(_SummaryMixin, eqx.Module, tp.Generic[L]):
     r"""
     Abstract base class used to represent families of distributions that can be
     used within variational inference.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,7 +34,6 @@ nav:
     - Multi-Output GPs: _examples/multioutput.md
     - Accelerated Multi-Output GPs: _examples/oilmm.md
     - Orthogonal Additive GPs: _examples/oak.md
-  - 🧪 Experimental:
     - Numpyro Integration: _examples/numpyro_integration.md
     - Spatial Linear Gaussian Process: _examples/spatial_linear_gp.md
   - 📖 Guides for customisation:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "optimistix>=0.0.9",
   "numpy>=2.0.0",
   "tensorstore!=0.1.76; sys_platform == 'darwin'",
+  "rich>=13.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -257,3 +257,17 @@ def test_summarise_is_jit_safe():
 
     f(Prior(mean_function=Zero(), kernel=RBF()))  # must not raise
     assert "traced" in console.export_text()
+
+
+def test_summarise_rejects_unknown_columns():
+    with pytest.raises(ValueError, match="unknown column"):
+        summary.summarise(
+            Prior(mean_function=Zero(), kernel=RBF()),
+            console=Console(record=True, file=io.StringIO()),
+            columns=["Bijektor"],
+        )
+
+
+def test_render_caption_singular_for_one_parameter():
+    table = summary._render(summary._collect(PositiveReal(1.0)))
+    assert table.caption == "1 parameter, 1 trainable"

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,8 +1,8 @@
 import io
 
 import equinox as eqx
-from jax import config
 import jax
+from jax import config
 import jax.numpy as jnp
 import numpy as np
 import paramax
@@ -295,3 +295,28 @@ def test_summary_mixin_mimebundle_has_text_and_html():
     assert "text/html" in bundle
     assert "<" in bundle["text/html"]
     assert "x" in bundle["text/plain"]
+
+
+@pytest.mark.parametrize(
+    "model_fn",
+    [
+        lambda: RBF(),
+        lambda: Zero(),
+        lambda: Gaussian(num_datapoints=5),
+        lambda: Prior(mean_function=Zero(), kernel=RBF()),
+        lambda: Prior(mean_function=Zero(), kernel=RBF()) * Gaussian(num_datapoints=5),
+    ],
+)
+def test_abstract_bases_have_rich_protocol(model_fn):
+    model = model_fn()
+    assert isinstance(model.__rich__(), Table)
+    assert "text/html" in model._repr_mimebundle_()
+
+
+def test_variational_family_has_rich_protocol():
+    prior = Prior(mean_function=Zero(), kernel=RBF())
+    posterior = prior * Gaussian(num_datapoints=5)
+    q = gpx.variational_families.VariationalGaussian(
+        posterior=posterior, inducing_inputs=jnp.linspace(-3, 3, 5).reshape(-1, 1)
+    )
+    assert isinstance(q.__rich__(), Table)

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -5,6 +5,7 @@ import jax
 from jax import config
 import jax.numpy as jnp
 import numpy as np
+import numpyro.distributions as npd
 import paramax
 import pytest
 from rich.console import Console
@@ -342,3 +343,36 @@ def test_summarise_validates_columns_for_parameter_free_model():
         summary.summarise(
             (), columns=["BadCol"], console=Console(record=True, file=io.StringIO())
         )
+
+
+def test_format_prior_handles_none_str_and_distribution():
+    assert summary._format_prior(None, precision=3) == "-"
+    assert summary._format_prior("LogNormal(0, 1)", precision=3) == "LogNormal(0, 1)"
+    assert (
+        summary._format_prior(npd.LogNormal(0.0, 0.5), precision=3)
+        == "LogNormal(loc=0, scale=0.5)"
+    )
+
+
+def test_collect_attaches_priors_by_name():
+    model = Prior(mean_function=Zero(), kernel=RBF())
+    priors = {"kernel.lengthscale": npd.LogNormal(0.0, 1.0)}
+    records = summary._collect(model, priors=priors)
+    matched = _record_by_name(records, "kernel.lengthscale")
+    assert isinstance(matched.prior, npd.LogNormal)
+    # Parameters without a registered prior stay empty.
+    assert _record_by_name(records, "kernel.variance").prior is None
+
+
+def test_summarise_renders_prior_column_when_priors_given():
+    model = Prior(mean_function=Zero(), kernel=RBF())
+    priors = {
+        "kernel.lengthscale": npd.LogNormal(0.0, 1.0),
+        "kernel.variance": npd.LogNormal(0.0, 1.0),
+    }
+    assert "LogNormal" in _capture(model, priors=priors)
+
+
+def test_summarise_prior_column_defaults_to_dash():
+    # Without a priors map the Prior column is present but unpopulated.
+    assert "LogNormal" not in _capture(Prior(mean_function=Zero(), kernel=RBF()))

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -65,3 +65,27 @@ def test_is_frozen_true_for_frozen_parameter():
 
 def test_is_frozen_false_for_plain_parameter():
     assert summary._is_frozen(PositiveReal(1.0)) is False
+
+
+@pytest.mark.parametrize(
+    ("param", "expected"),
+    [
+        (PositiveReal(2.0), "Softplus"),
+        (NonNegativeReal(0.5), "Softplus"),
+        (Real(-3.0), "Identity"),
+        (LowerTriangular(jnp.eye(2)), "LowerCholesky"),
+    ],
+)
+def test_bijector_name_mapping(param, expected):
+    assert summary._bijector_name(param) == expected
+
+
+def test_bijector_name_sigmoid_bounded_uses_bounds():
+    param = SigmoidBounded(0.5, low=0.0, high=2.0)
+    assert summary._bijector_name(param) == "Sigmoid[0, 2]"
+
+
+def test_bijector_name_falls_back_to_identity_without_constraint():
+    # A NonTrainable-wrapped bare array has no `_constraint`.
+    wrapped = paramax.non_trainable(jnp.array(1.0))
+    assert summary._bijector_name(wrapped) == "Identity"

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -242,9 +242,10 @@ def test_summarise_column_subset_hides_other_columns():
     assert "Bijector" not in text
 
 
-def test_summarise_empty_model_message():
+def test_summarise_empty_model_renders_empty_table():
     text = _capture(())  # a pytree with no leaves
-    assert "no trainable parameters" in text
+    assert "0 parameters, 0 trainable" in text
+    assert "Parameter" in text  # header row still rendered
 
 
 def test_summarise_is_jit_safe():
@@ -334,3 +335,10 @@ def test_summary_mixin_leaves_repr_to_equinox():
     # The mixin must NOT define its own __repr__; Equinox owns model repr.
     assert "__repr__" not in vars(summary._SummaryMixin)
     assert repr(RBF()).startswith("RBF(")
+
+
+def test_summarise_validates_columns_for_parameter_free_model():
+    with pytest.raises(ValueError, match="unknown column"):
+        summary.summarise(
+            (), columns=["BadCol"], console=Console(record=True, file=io.StringIO())
+        )

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -112,3 +112,59 @@ def test_format_value_array_truncates():
 def test_format_value_short_array_not_truncated():
     out = summary._format_value(jnp.array([1.0, 2.0]), max_array=4, precision=3)
     assert out == "[1, 2]"
+
+
+def _record_by_name(records, name):
+    matches = [r for r in records if r.name == name]
+    assert matches, f"{name!r} not in {[r.name for r in records]}"
+    return matches[0]
+
+
+def test_collect_isotropic_rbf_prior():
+    prior = Prior(mean_function=Zero(), kernel=RBF())
+    records = summary._collect(prior)
+    names = {r.name for r in records}
+    assert "kernel.lengthscale" in names
+    assert "kernel.variance" in names
+
+    ls = _record_by_name(records, "kernel.lengthscale")
+    assert ls.cls == "PositiveReal"
+    assert ls.bijector == "Softplus"
+    assert ls.trainable is True
+    assert ls.shape == ()
+    assert ls.dtype == "f64"
+
+
+def test_collect_renders_bare_array_leaf():
+    prior = Prior(mean_function=Zero(), kernel=RBF())
+    rec = _record_by_name(summary._collect(prior), "mean_function.constant")
+    assert rec.cls == "Array"
+    assert rec.bijector == "Identity"
+    assert rec.trainable is True
+
+
+def test_collect_composite_kernel_paths():
+    prior = Prior(mean_function=Zero(), kernel=RBF() + Linear())
+    names = {r.name for r in summary._collect(prior)}
+    assert "kernel.kernels[0].lengthscale" in names
+    assert "kernel.kernels[1].variance" in names
+
+
+def test_collect_marks_and_unwraps_frozen_parameter():
+    records = summary._collect(_frozen_prior())
+    ls = _record_by_name(records, "kernel.lengthscale")
+    assert ls.trainable is False
+    # paramax.unwrap returns a concrete constrained value even when frozen.
+    assert float(np.asarray(ls.value)) > 0.0
+
+
+def test_collect_variational_family_lower_cholesky():
+    prior = Prior(mean_function=Zero(), kernel=RBF())
+    posterior = prior * Gaussian(num_datapoints=5)
+    q = gpx.variational_families.VariationalGaussian(
+        posterior=posterior, inducing_inputs=jnp.linspace(-3, 3, 5).reshape(-1, 1)
+    )
+    rec = _record_by_name(summary._collect(q), "variational_root_covariance")
+    assert rec.cls == "LowerTriangular"
+    assert rec.bijector == "LowerCholesky"
+    assert rec.shape == (5, 5)

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -89,3 +89,26 @@ def test_bijector_name_falls_back_to_identity_without_constraint():
     # A NonTrainable-wrapped bare array has no `_constraint`.
     wrapped = paramax.non_trainable(jnp.array(1.0))
     assert summary._bijector_name(wrapped) == "Identity"
+
+
+def test_short_dtype_abbreviates():
+    assert summary._short_dtype(jnp.float64) == "f64"
+    assert summary._short_dtype(jnp.float32) == "f32"
+    assert summary._short_dtype(jnp.int32) == "i32"
+
+
+def test_format_value_scalar_uses_precision():
+    assert summary._format_value(jnp.array(1.0), max_array=4, precision=3) == "1"
+    assert (
+        summary._format_value(jnp.array(0.123456), max_array=4, precision=3) == "0.123"
+    )
+
+
+def test_format_value_array_truncates():
+    out = summary._format_value(jnp.arange(6.0), max_array=4, precision=3)
+    assert out == "[0, 1, 2, 3, ...]"
+
+
+def test_format_value_short_array_not_truncated():
+    out = summary._format_value(jnp.array([1.0, 2.0]), max_array=4, precision=3)
+    assert out == "[1, 2]"

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -212,3 +212,48 @@ def test_render_respects_column_subset():
     records = summary._collect(Prior(mean_function=Zero(), kernel=RBF()))
     table = summary._render(records, columns=["Parameter", "Trainable"])
     assert [c.header for c in table.columns] == ["Parameter", "Trainable"]
+
+
+def _capture(model, **kwargs):
+    console = Console(record=True, file=io.StringIO(), width=120)
+    summary.summarise(model, console=console, **kwargs)
+    return console.export_text()
+
+
+def test_summarise_prints_parameter_names_and_footer():
+    text = _capture(Prior(mean_function=Zero(), kernel=RBF()))
+    assert "kernel.lengthscale" in text
+    assert "Bijector" in text
+    assert "parameters," in text  # footer present
+
+
+def test_summarise_marks_frozen_row():
+    text = _capture(_frozen_prior())
+    # markup is stripped in export_text, leaving plain yes/no tokens.
+    assert "no" in text
+    assert "yes" in text
+
+
+def test_summarise_column_subset_hides_other_columns():
+    text = _capture(
+        Prior(mean_function=Zero(), kernel=RBF()), columns=["Parameter", "Trainable"]
+    )
+    assert "Parameter" in text
+    assert "Bijector" not in text
+
+
+def test_summarise_empty_model_message():
+    text = _capture(())  # a pytree with no leaves
+    assert "no trainable parameters" in text
+
+
+def test_summarise_is_jit_safe():
+    console = Console(record=True, file=io.StringIO(), width=120)
+
+    @jax.jit
+    def f(m):
+        summary.summarise(m, console=console)
+        return m
+
+    f(Prior(mean_function=Zero(), kernel=RBF()))  # must not raise
+    assert "traced" in console.export_text()

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,52 @@
+import io
+
+import equinox as eqx
+from jax import config
+import jax
+import jax.numpy as jnp
+import numpy as np
+import paramax
+import pytest
+from rich.console import Console
+from rich.table import Table
+
+# Match the rest of the suite: stable float64 numerics.
+config.update("jax_enable_x64", True)
+
+import gpjax as gpx
+from gpjax import summary
+from gpjax.gps import Prior
+from gpjax.kernels import RBF, Linear
+from gpjax.likelihoods import Gaussian
+from gpjax.mean_functions import Zero
+from gpjax.parameters import (
+    LowerTriangular,
+    NonNegativeReal,
+    PositiveReal,
+    Real,
+    SigmoidBounded,
+)
+
+
+def _frozen_prior():
+    """A prior whose lengthscale has been frozen via paramax.non_trainable."""
+    prior = Prior(mean_function=Zero(), kernel=RBF())
+    return eqx.tree_at(
+        lambda m: m.kernel.lengthscale, prior, replace_fn=paramax.non_trainable
+    )
+
+
+def test_paramrecord_fields_exist():
+    rec = summary.ParamRecord(
+        name="kernel.lengthscale",
+        cls="PositiveReal",
+        value=jnp.array(1.0),
+        bijector="Softplus",
+        prior="-",
+        trainable=True,
+        shape=(),
+        dtype="f64",
+    )
+    assert rec.name == "kernel.lengthscale"
+    assert rec.trainable is True
+    assert rec.prior == "-"

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -50,3 +50,18 @@ def test_paramrecord_fields_exist():
     assert rec.name == "kernel.lengthscale"
     assert rec.trainable is True
     assert rec.prior == "-"
+
+
+def test_is_param_leaf_stops_at_parameters():
+    assert summary._is_param_leaf(PositiveReal(1.0)) is True
+    assert summary._is_param_leaf(jnp.array(1.0)) is False
+
+
+def test_is_frozen_true_for_frozen_parameter():
+    frozen = _frozen_prior()
+    assert summary._is_frozen(frozen.kernel.lengthscale) is True
+    assert summary._is_frozen(frozen.kernel.variance) is False
+
+
+def test_is_frozen_false_for_plain_parameter():
+    assert summary._is_frozen(PositiveReal(1.0)) is False

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -271,3 +271,27 @@ def test_summarise_rejects_unknown_columns():
 def test_render_caption_singular_for_one_parameter():
     table = summary._render(summary._collect(PositiveReal(1.0)))
     assert table.caption == "1 parameter, 1 trainable"
+
+
+def test_summary_mixin_rich_returns_table():
+    class _M(summary._SummaryMixin, eqx.Module):
+        x: jax.Array
+
+        def __init__(self):
+            self.x = jnp.array(1.0)
+
+    assert isinstance(_M().__rich__(), Table)
+
+
+def test_summary_mixin_mimebundle_has_text_and_html():
+    class _M(summary._SummaryMixin, eqx.Module):
+        x: jax.Array
+
+        def __init__(self):
+            self.x = jnp.array(1.0)
+
+    bundle = _M()._repr_mimebundle_()
+    assert "text/plain" in bundle
+    assert "text/html" in bundle
+    assert "<" in bundle["text/html"]
+    assert "x" in bundle["text/plain"]

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -192,3 +192,23 @@ def test_collect_frozen_bare_array_keeps_array_class():
     assert rec.cls == "Array"
     assert rec.trainable is False
     assert rec.bijector == "Identity"
+
+
+def test_render_returns_table_with_row_per_record():
+    records = summary._collect(Prior(mean_function=Zero(), kernel=RBF()))
+    table = summary._render(records)
+    assert isinstance(table, Table)
+    assert table.row_count == len(records)
+    assert [c.header for c in table.columns] == list(summary._DEFAULT_COLUMNS)
+
+
+def test_render_footer_counts_trainable():
+    table = summary._render(summary._collect(_frozen_prior()))
+    # frozen prior: lengthscale frozen, variance + mean constant trainable.
+    assert table.caption == "3 parameters, 2 trainable"
+
+
+def test_render_respects_column_subset():
+    records = summary._collect(Prior(mean_function=Zero(), kernel=RBF()))
+    table = summary._render(records, columns=["Parameter", "Trainable"])
+    assert [c.header for c in table.columns] == ["Parameter", "Trainable"]

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -168,3 +168,27 @@ def test_collect_variational_family_lower_cholesky():
     assert rec.cls == "LowerTriangular"
     assert rec.bijector == "LowerCholesky"
     assert rec.shape == (5, 5)
+
+
+def test_format_value_traced_value_placeholder():
+    captured = {}
+
+    @jax.jit
+    def f(x):
+        captured["s"] = summary._format_value(x, max_array=4, precision=3)
+        return x
+
+    f(jnp.arange(3.0))
+    assert captured["s"].startswith("<traced")
+    assert "[3]" in captured["s"]
+
+
+def test_collect_frozen_bare_array_keeps_array_class():
+    prior = Prior(mean_function=Zero(), kernel=RBF())
+    frozen = eqx.tree_at(
+        lambda m: m.mean_function.constant, prior, replace_fn=paramax.non_trainable
+    )
+    rec = _record_by_name(summary._collect(frozen), "mean_function.constant")
+    assert rec.cls == "Array"
+    assert rec.trainable is False
+    assert rec.bijector == "Identity"

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -320,3 +320,8 @@ def test_variational_family_has_rich_protocol():
         posterior=posterior, inducing_inputs=jnp.linspace(-3, 3, 5).reshape(-1, 1)
     )
     assert isinstance(q.__rich__(), Table)
+
+
+def test_summarise_is_publicly_exported():
+    assert gpx.summarise is summary.summarise
+    assert "summarise" in gpx.__all__

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -293,7 +293,10 @@ def test_summary_mixin_mimebundle_has_text_and_html():
     bundle = _M()._repr_mimebundle_()
     assert "text/plain" in bundle
     assert "text/html" in bundle
-    assert "<" in bundle["text/html"]
+    html = bundle["text/html"]
+    assert "<pre" in html
+    assert "<!DOCTYPE" not in html
+    assert "body {" not in html
     assert "x" in bundle["text/plain"]
 
 
@@ -325,3 +328,9 @@ def test_variational_family_has_rich_protocol():
 def test_summarise_is_publicly_exported():
     assert gpx.summarise is summary.summarise
     assert "summarise" in gpx.__all__
+
+
+def test_summary_mixin_leaves_repr_to_equinox():
+    # The mixin must NOT define its own __repr__; Equinox owns model repr.
+    assert "__repr__" not in vars(summary._SummaryMixin)
+    assert repr(RBF()).startswith("RBF(")

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-24T20:37:42.717195Z"
+exclude-newer = "2026-06-20T07:57:15.444069Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -991,6 +991,7 @@ dependencies = [
     { name = "optax" },
     { name = "optimistix" },
     { name = "paramax" },
+    { name = "rich" },
     { name = "tensorstore", marker = "sys_platform == 'darwin'" },
     { name = "tqdm" },
 ]
@@ -1075,6 +1076,7 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'docs'", specifier = ">=1.5.3" },
     { name = "paramax", specifier = ">=0.0.5" },
     { name = "pymdown-extensions", marker = "extra == 'docs'", specifier = ">=10.7.1" },
+    { name = "rich", specifier = ">=13.0.0" },
     { name = "scikit-learn", marker = "extra == 'docs'", specifier = ">=1.5.1" },
     { name = "seaborn", marker = "extra == 'docs'", specifier = ">=0.12.2" },
     { name = "tensorstore", marker = "sys_platform == 'darwin'", specifier = "!=0.1.76" },


### PR DESCRIPTION
## Motivation

The default Equinox `repr` is unfit for inspecting a model: it shows unconstrained internal storage (`_unconstrained=f32[3]`), shapes instead of values, leaks `<DenseKernelComputation object at 0x…>`, and conveys nothing about bijectors or trainability. GPJax had no GPflow-style `print_summary` equivalent.

## Solution

Add `gpx.summarise(model)` — a `rich`-rendered, flat one-row-per-parameter table for **any** GPJax pytree (kernel, prior, posterior, likelihood, variational family). It is a rendering-agnostic collector (`jax.tree_util.tree_flatten_with_path`, stopping at `paramax.AbstractUnwrappable` leaves) → `ParamRecord`s → a `rich.Table`. A methods-only `_SummaryMixin` adds `__rich__` and `_repr_mimebundle_` to the user-facing abstract bases (`AbstractKernel`, `AbstractMeanFunction`, `AbstractLikelihood`, `AbstractPrior`, `AbstractPosterior`, `AbstractVariationalFamily`) so `rich.print(model)` and Jupyter auto-render work; `repr()` is left to Equinox.

Columns: Parameter · Class · Value · Bijector · Prior · Trainable · Shape · Dtype (subset/reorder via `columns=`; validated). Values are read with `paramax.unwrap` (works for frozen params); frozen rows are dimmed; the call is jit-safe (traced values render as `<traced …>`, never crash). `_repr_mimebundle_` emits a self-contained `<pre>` fragment (no global stylesheet that would restyle the notebook). The Prior column is a `-` placeholder by design (GPJax attaches NumPyro priors at sample-site time, not on params).

`rich` becomes a core runtime dependency.

## Verification

- `uv run poe test` → **2463 passed, 1 skipped**
- `uv run poe lint` → clean
- `uv run poe docstrings` → 30/30
- New `tests/test_summary.py` (42 tests): collector across isotropic/anisotropic RBF, `RBF + Linear`, frozen params, conjugate posterior, ICM, variational family; bijector mapping incl. `SigmoidBounded`/`LowerCholesky`; jit-safety; renderer footer/columns; column validation; mimebundle fragment HTML; `repr()` untouched; public export.

## Notes

CHANGELOG `[Unreleased]` entry added. Out of scope (YAGNI): great-tables/HTML backend, grouped/tree layouts, `.summary()` method, live prior detection, colour themes.