### PR TITLE
docs: clarify collapsed elbo batching

### DIFF
--- a/gpjax/objectives.py
+++ b/gpjax/objectives.py
@@ -407,8 +407,8 @@ def collapsed_elbo(variational_family: VF, data: Dataset) -> ScalarFloat:
     Compute the evidence lower bound under this model. In short, this requires
     evaluating the expectation of the model's log-likelihood under the variational
     approximation. To this, we sum the KL divergence from the variational posterior
-    to the prior. When batching occurs, the result is scaled by the batch size
-    relative to the full dataset size.
+    to the prior. This collapsed bound is evaluated on the full dataset supplied in
+    ``data`` and does not apply minibatch scaling.
 
     Example:
         >>> import gpjax as gpx


### PR DESCRIPTION
Summary:
- clarify that `collapsed_elbo` is evaluated on the full dataset supplied in `data`
- remove the misleading inherited minibatch-scaling wording from the collapsed bound docstring

Validation:
- `python -m compileall gpjax\objectives.py`
- `git diff --check`

Closes #667