### PR TITLE
OILMM: PCA data-init + diagonal predict operator (0.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are now wrapped in `NonNegativeReal`. They were previously assigned raw —
   silently frozen (Python-float default, excluded by `eqx.partition`) or
   trainable-but-unconstrained (array value, driveable negative → NaN).
+- **`models.create_oilmm_from_data`**: now performs the documented PCA
+  eigen-initialisation of the mixing matrix (top-M eigenvectors/eigenvalues of
+  the empirical output covariance) instead of returning the random default. Raises
+  `ValueError` for `N < 2` (empirical covariance is undefined).
 
 ### Changed
 
@@ -36,6 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-dimensional Matérn `RFF` Gram matrices now converge to the isotropic
   Matérn. `d > 1` outputs differ from `0.16.0`. No restore path.
 - Multi-output `conjugate_loocv` values differ from `0.16.0`. No restore path.
+- **`models.OILMMPosterior.predict(..., return_full_cov=False)`** now returns a
+  `lineax.DiagonalLinearOperator` scale (was a densified `MatrixLinearOperator`).
+  Values are unchanged.
 
 #### Migration
 
@@ -43,6 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `bias_variance`, restore it explicitly with `paramax.non_trainable(...)`.
 - **`sample_approx` / multi-dim Matérn RFF / multi-output LOOCV**: no restore
   path — the previous outputs were incorrect.
+- **OILMM diagonal predict**: `predict(..., return_full_cov=False).scale` is now a
+  `DiagonalLinearOperator`. Use `.as_matrix()` / `.diagonal` rather than assuming a
+  dense matrix.
 
 ## [0.16.0] — 2026-06-28
 

--- a/gpjax/models/oilmm.py
+++ b/gpjax/models/oilmm.py
@@ -624,9 +624,24 @@ def create_oilmm_from_data(
         mean_function=mean_function,
     )
 
-    # NOTE: With equinox modules, we cannot do in-place assignment.
-    # The model returned has default initialization; data-informed init
-    # would require creating new parameter instances.
-    # For now, return the model as-is -- data-informed init will be
-    # addressed in a follow-up task.
+    if dataset.n < 2:  # jnp.cov divides by N-1; N==1 -> all-NaN covariance
+        raise ValueError(
+            "create_oilmm_from_data needs >=2 data points to estimate the "
+            "output covariance for PCA initialisation; got "
+            f"N={dataset.n}. Use OILMMModel/create_oilmm for smaller data."
+        )
+
+    Y = dataset.y  # [N, P]
+    output_cov = jnp.cov(Y, rowvar=False)  # column-centred empirical cov [P, P]
+    eigvals, eigvecs = jnp.linalg.eigh(output_cov)  # ascending
+    top_eigvecs = eigvecs[:, ::-1][:, :num_latent_gps]  # [P, M]
+    top_eigvals = jnp.clip(
+        eigvals[::-1][:num_latent_gps], min=1e-6
+    )  # [M]
+
+    model = eqx.tree_at(
+        lambda m: (m.mixing_matrix.U_latent, m.mixing_matrix.S),
+        model,
+        (Real(top_eigvecs), PositiveReal(top_eigvals)),
+    )
     return model

--- a/gpjax/models/oilmm.py
+++ b/gpjax/models/oilmm.py
@@ -400,16 +400,17 @@ class OILMMPosterior:
             P = self.mixing_matrix.num_outputs
             # Reorder to [N, P, N, P] so flattening matches f_mean.T.ravel().
             f_cov = f_cov_blocks.transpose(2, 0, 3, 1).reshape(N * P, N * P)  # [NP, NP]
+            scale = lx.MatrixLinearOperator(f_cov)
         else:
-            # Diagonal-only covariance for efficiency
+            # Diagonal-only covariance for efficiency — keep it diagonal.
             latent_vars = jnp.array([jnp.diag(cov) for cov in latent_covs])  # [M, N]
             f_vars = jnp.einsum("pm,mn->pn", H_squared, latent_vars)  # [P, N]
             f_vars_flat = f_vars.T.ravel()  # [N*P]
-            f_cov = jnp.diag(f_vars_flat)
+            scale = lx.DiagonalLinearOperator(f_vars_flat)
 
         return GaussianDistribution(
             loc=jnp.atleast_1d(f_mean_flat.squeeze()),
-            scale=lx.MatrixLinearOperator(f_cov),
+            scale=scale,
         )
 
 

--- a/gpjax/models/oilmm.py
+++ b/gpjax/models/oilmm.py
@@ -636,9 +636,7 @@ def create_oilmm_from_data(
     output_cov = jnp.cov(Y, rowvar=False)  # column-centred empirical cov [P, P]
     eigvals, eigvecs = jnp.linalg.eigh(output_cov)  # ascending
     top_eigvecs = eigvecs[:, ::-1][:, :num_latent_gps]  # [P, M]
-    top_eigvals = jnp.clip(
-        eigvals[::-1][:num_latent_gps], min=1e-6
-    )  # [M]
+    top_eigvals = jnp.clip(eigvals[::-1][:num_latent_gps], min=1e-6)  # [M]
 
     model = eqx.tree_at(
         lambda m: (m.mixing_matrix.U_latent, m.mixing_matrix.S),

--- a/tests/test_models_oilmm.py
+++ b/tests/test_models_oilmm.py
@@ -5,6 +5,7 @@ import jax
 import jax.numpy as jnp
 import jax.random as jr
 import paramax
+import pytest
 
 jax.config.update("jax_enable_x64", True)
 
@@ -975,3 +976,50 @@ class TestCovarianceEquivalence:
         kron_cov_n_major = kron_cov[n_major_idx][:, n_major_idx]
 
         assert jnp.allclose(einsum_cov, kron_cov_n_major, atol=1e-6)
+
+def test_create_oilmm_from_data_recovers_planted_subspace():
+    """PCA init must recover the column space of a known low-rank mixing.
+    Random init does not (this is why the no-op shipped undetected)."""
+    from gpjax.dataset import Dataset
+    from gpjax.models.oilmm import create_oilmm_from_data
+
+    key = jr.key(0)
+    N, P, M = 60, 4, 2
+    X = jnp.linspace(0.0, 1.0, N).reshape(-1, 1)
+    # Two latent signals mixed into P=4 outputs via a planted orthonormal basis.
+    latent = jnp.column_stack(
+        [jnp.sin(6.0 * X.squeeze()), jnp.cos(4.0 * X.squeeze())]
+    )  # [N, M]
+    planted, _ = jnp.linalg.qr(jr.normal(key, (P, M)))  # [P, M] orthonormal
+    Y = latent @ planted.T  # [N, P], rank M
+    data = Dataset(X=X, y=Y)
+
+    model = create_oilmm_from_data(dataset=data, num_latent_gps=M, key=jr.key(1))
+    U = model.mixing_matrix.U  # [P, M] orthonormal
+
+    # Principal angles between the recovered and planted column spaces.
+    cos_angles = jnp.linalg.svd(planted.T @ U, compute_uv=False)
+    assert jnp.all(cos_angles > 0.99)  # cos-angles ~= 1.0
+
+
+def test_create_oilmm_from_data_requires_two_points():
+    """N==1 -> jnp.cov divides by 0 -> NaN params. Guard, don't ship NaN."""
+    from gpjax.dataset import Dataset
+    from gpjax.models.oilmm import create_oilmm_from_data
+
+    data = Dataset(X=jnp.zeros((1, 1)), y=jnp.ones((1, 2)))
+    with pytest.raises(ValueError, match="2"):
+        create_oilmm_from_data(dataset=data, num_latent_gps=2, key=jr.key(0))
+
+
+def test_create_oilmm_from_data_two_points_finite():
+    """N==2, m==2 is valid (clamp path); parameters must be finite."""
+    from gpjax.dataset import Dataset
+    from gpjax.models.oilmm import create_oilmm_from_data
+
+    data = Dataset(X=jnp.array([[0.0], [1.0]]), y=jnp.array([[1.0, 2.0], [3.0, 4.0]]))
+    model = create_oilmm_from_data(dataset=data, num_latent_gps=2, key=jr.key(0))
+    assert jnp.all(jnp.isfinite(model.mixing_matrix.U))
+    from gpjax.models.oilmm import _val
+
+    assert jnp.all(jnp.isfinite(_val(model.mixing_matrix.S)))

--- a/tests/test_models_oilmm.py
+++ b/tests/test_models_oilmm.py
@@ -977,6 +977,7 @@ class TestCovarianceEquivalence:
 
         assert jnp.allclose(einsum_cov, kron_cov_n_major, atol=1e-6)
 
+
 def test_create_oilmm_from_data_recovers_planted_subspace():
     """PCA init must recover the column space of a known low-rank mixing.
     Random init does not (this is why the no-op shipped undetected)."""
@@ -1024,12 +1025,13 @@ def test_create_oilmm_from_data_two_points_finite():
 
     assert jnp.all(jnp.isfinite(_val(model.mixing_matrix.S)))
 
+
 def test_oilmm_predict_diagonal_returns_diagonal_operator():
     """The diagonal predict branch must return a DiagonalLinearOperator, not
     a densified MatrixLinearOperator."""
     import gpjax as gpx
-    import lineax as lx
     from gpjax.models.oilmm import OILMMModel
+    import lineax as lx
 
     key = jax.random.PRNGKey(99)
     model = OILMMModel(
@@ -1053,4 +1055,6 @@ def test_oilmm_predict_diagonal_returns_diagonal_operator():
     )
     # Entries must still match the full-cov diagonal
     pred_full = posterior.predict(X_test, return_full_cov=True)
-    assert jnp.allclose(jnp.diag(pred_full.covariance()), jnp.diag(pred_diag.covariance()), atol=1e-6)
+    assert jnp.allclose(
+        jnp.diag(pred_full.covariance()), jnp.diag(pred_diag.covariance()), atol=1e-6
+    )

--- a/tests/test_models_oilmm.py
+++ b/tests/test_models_oilmm.py
@@ -1023,3 +1023,34 @@ def test_create_oilmm_from_data_two_points_finite():
     from gpjax.models.oilmm import _val
 
     assert jnp.all(jnp.isfinite(_val(model.mixing_matrix.S)))
+
+def test_oilmm_predict_diagonal_returns_diagonal_operator():
+    """The diagonal predict branch must return a DiagonalLinearOperator, not
+    a densified MatrixLinearOperator."""
+    import gpjax as gpx
+    import lineax as lx
+    from gpjax.models.oilmm import OILMMModel
+
+    key = jax.random.PRNGKey(99)
+    model = OILMMModel(
+        num_outputs=2,
+        num_latent_gps=2,
+        kernel=gpx.kernels.RBF(),
+        key=key,
+    )
+
+    N, P = 8, 2
+    X = jnp.linspace(0.0, 1.0, N).reshape(-1, 1)
+    y = jr.normal(key, (N, P))
+    dataset = gpx.Dataset(X=X, y=y)
+    posterior = model.condition_on_observations(dataset)
+
+    X_test = jnp.linspace(0.1, 0.9, 5).reshape(-1, 1)
+    pred_diag = posterior.predict(X_test, return_full_cov=False)
+
+    assert isinstance(pred_diag.scale, lx.DiagonalLinearOperator), (
+        f"Expected DiagonalLinearOperator, got {type(pred_diag.scale).__name__}"
+    )
+    # Entries must still match the full-cov diagonal
+    pred_full = posterior.predict(X_test, return_full_cov=True)
+    assert jnp.allclose(jnp.diag(pred_full.covariance()), jnp.diag(pred_diag.covariance()), atol=1e-6)


### PR DESCRIPTION
PR B of the high-severity audit remediation. Fixes #4/#6. docs-build re-run and eyeballed. See plans/2026-07-02-audit-high-severity-remediation-design.md.