### PR TITLE
Fix Matérn kernel docstring formulas

### DIFF
--- a/gpjax/kernels/stationary/matern12.py
+++ b/gpjax/kernels/stationary/matern12.py
@@ -36,7 +36,7 @@ class Matern12(StationaryKernel):
     lengthscale parameter $\ell$ and variance $\sigma^2$.
 
     $$
-    k(x, y) = \sigma^2\exp\Bigg(-\frac{\lvert x-y \rvert}{2\ell}\Bigg)
+    k(x, y) = \sigma^2\exp\Bigg(-\frac{\lvert x-y \rvert}{\ell}\Bigg)
     $$
     """
 

--- a/gpjax/kernels/stationary/matern32.py
+++ b/gpjax/kernels/stationary/matern32.py
@@ -33,7 +33,7 @@ class Matern32(StationaryKernel):
     lengthscale parameter $\ell$ and variance $\sigma^2$.
 
     $$
-    k(x, y) = \sigma^2 \exp \Bigg(1+ \frac{\sqrt{3}\lvert x-y \rvert}{\ell} \ \Bigg)\exp\Bigg(-\frac{\sqrt{3}\lvert x-y\rvert}{\ell^2} \Bigg)
+    k(x, y) = \sigma^2 \Bigg(1 + \frac{\sqrt{3}\lvert x-y \rvert}{\ell}\Bigg)\exp\Bigg(-\frac{\sqrt{3}\lvert x-y\rvert}{\ell}\Bigg)
     $$
     """
 

--- a/gpjax/kernels/stationary/matern52.py
+++ b/gpjax/kernels/stationary/matern52.py
@@ -34,7 +34,7 @@ class Matern52(StationaryKernel):
     lengthscale parameter $\ell$ and variance $\sigma^2$.
 
     $$
-    k(x, y) = \sigma^2 \exp \Bigg(1+ \frac{\sqrt{5}\lvert x-y \rvert}{\ell} + \frac{5\lvert x - y \rvert^2}{3\ell^2} \Bigg)\exp\Bigg(-\frac{\sqrt{5}\lvert x-y\rvert}{\ell^2} \Bigg)
+    k(x, y) = \sigma^2 \Bigg(1 + \frac{\sqrt{5}\lvert x-y \rvert}{\ell} + \frac{5\lvert x - y \rvert^2}{3\ell^2}\Bigg)\exp\Bigg(-\frac{\sqrt{5}\lvert x-y\rvert}{\ell}\Bigg)
     $$
     """
 


### PR DESCRIPTION
## Summary
- correct the Matérn 1/2, 3/2, and 5/2 docstring equations
- align the rendered formulas with the existing implementations and the standard Matérn forms

Fixes #680.

## Checks
- `uv run ruff format --check gpjax/kernels/stationary/matern12.py gpjax/kernels/stationary/matern32.py gpjax/kernels/stationary/matern52.py`
- `uv run ruff check gpjax/kernels/stationary/matern12.py gpjax/kernels/stationary/matern32.py gpjax/kernels/stationary/matern52.py`
- `uv run pytest tests/test_kernels/test_stationary.py tests/test_state_space/test_kernels.py -q -k 'Matern'`\n- `uv run xdoctest gpjax/kernels/stationary/matern12.py`\n- `uv run xdoctest gpjax/kernels/stationary/matern32.py`\n- `uv run xdoctest gpjax/kernels/stationary/matern52.py`