### PR TITLE
ci: skip docs preview deploy for fork PRs

### DIFF
--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -63,7 +63,7 @@ jobs:
 
   deploy-docs-preview:
     needs: test-docs
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:


### PR DESCRIPTION
The `deploy-docs-preview` job uses `actions/deploy-pages` which requires `id-token: write`. GitHub downgrades this permission to none for PRs from forks, causing the job to fail in ~3s for every new contributor.

Add a guard so the preview deploy is skipped when the PR originates from a fork. Same-repo PRs continue to get the preview.