### PR TITLE
Consolidate the duplicated paramax-unwrap _val helper into gpjax.parameters

### DIFF
--- a/gpjax/gps.py
+++ b/gpjax/gps.py
@@ -44,6 +44,7 @@ from gpjax.linalg.utils import add_jitter
 from gpjax.mean_functions import AbstractMeanFunction
 from gpjax.parameters import (
     Real,
+    _val,
 )
 from gpjax.summary import _SummaryMixin
 from gpjax.typing import (
@@ -58,11 +59,6 @@ L = tp.TypeVar("L", bound=AbstractLikelihood)
 NGL = tp.TypeVar("NGL", bound=NonGaussian)
 GL = tp.TypeVar("GL", bound=Gaussian)
 HL = tp.TypeVar("HL", bound=AbstractHeteroscedasticLikelihood)
-
-
-def _val(x):
-    """Unwrap a paramax parameter or return the value directly."""
-    return x.unwrap() if isinstance(x, AbstractUnwrappable) else x
 
 
 class AbstractPrior(_SummaryMixin, eqx.Module, tp.Generic[M, K]):

--- a/gpjax/kernels/base.py
+++ b/gpjax/kernels/base.py
@@ -29,7 +29,7 @@ from gpjax.kernels.computations import (
     AbstractKernelComputation,
     DenseKernelComputation,
 )
-from gpjax.parameters import Real
+from gpjax.parameters import Real, _val
 from gpjax.summary import _SummaryMixin
 from gpjax.typing import (
     Array,
@@ -208,11 +208,6 @@ class AbstractKernel(_SummaryMixin, eqx.Module):
                         if parent_attr_value.__doc__:
                             attr_value.__doc__ = parent_attr_value.__doc__
                             break
-
-
-def _val(x):
-    """Get the value from a parameter (AbstractUnwrappable) or plain array."""
-    return x.unwrap() if isinstance(x, AbstractUnwrappable) else x
 
 
 class Constant(AbstractKernel):

--- a/gpjax/kernels/computations/basis_functions.py
+++ b/gpjax/kernels/computations/basis_functions.py
@@ -3,16 +3,11 @@ import typing as tp
 import jax.numpy as jnp
 from jaxtyping import Float
 import lineax as lx
-from paramax import AbstractUnwrappable
 
 import gpjax
 from gpjax.kernels.computations.base import AbstractKernelComputation
+from gpjax.parameters import _val
 from gpjax.typing import Array
-
-
-def _val(x):
-    return x.unwrap() if isinstance(x, AbstractUnwrappable) else x
-
 
 K = tp.TypeVar("K", bound="gpjax.kernels.approximations.RFF")
 

--- a/gpjax/likelihoods.py
+++ b/gpjax/likelihoods.py
@@ -27,7 +27,6 @@ from jaxtyping import Float
 import lineax as lx
 import numpy as np
 import numpyro.distributions as npd
-from paramax import AbstractUnwrappable
 
 from gpjax.distributions import GaussianDistribution
 from gpjax.integrators import (
@@ -37,6 +36,7 @@ from gpjax.integrators import (
 )
 from gpjax.parameters import (
     NonNegativeReal,
+    _val,
 )
 from gpjax.summary import _SummaryMixin
 from gpjax.typing import (
@@ -46,11 +46,6 @@ from gpjax.typing import (
 
 if TYPE_CHECKING:
     from gpjax.gps import Prior
-
-
-def _val(x):
-    """Unwrap a paramax parameter or return the value directly."""
-    return x.unwrap() if isinstance(x, AbstractUnwrappable) else x
 
 
 def _diagonal_scale(op):

--- a/gpjax/mean_functions.py
+++ b/gpjax/mean_functions.py
@@ -26,16 +26,12 @@ from jaxtyping import (
 )
 from paramax import AbstractUnwrappable
 
+from gpjax.parameters import _val
 from gpjax.summary import _SummaryMixin
 from gpjax.typing import (
     Array,
     ScalarFloat,
 )
-
-
-def _val(x):
-    """Unwrap a paramax parameter or return the value directly."""
-    return x.unwrap() if isinstance(x, AbstractUnwrappable) else x
 
 
 class AbstractMeanFunction(_SummaryMixin, eqx.Module):

--- a/gpjax/models/oilmm.py
+++ b/gpjax/models/oilmm.py
@@ -20,20 +20,14 @@ import jax.numpy as jnp
 import jax.random as jr
 from jaxtyping import Array, Float
 import lineax as lx
-from paramax import AbstractUnwrappable
 
 from gpjax.distributions import GaussianDistribution
-from gpjax.parameters import NonNegativeReal, PositiveReal, Real
+from gpjax.parameters import NonNegativeReal, PositiveReal, Real, _val
 from gpjax.typing import ScalarFloat
 
 if tp.TYPE_CHECKING:
     from gpjax.dataset import Dataset
     from gpjax.kernels.base import AbstractKernel
-
-
-def _val(x):
-    """Unwrap a paramax parameter or return the value directly."""
-    return x.unwrap() if isinstance(x, AbstractUnwrappable) else x
 
 
 class OrthogonalMixingMatrix(eqx.Module):

--- a/gpjax/objectives.py
+++ b/gpjax/objectives.py
@@ -7,7 +7,6 @@ import jax.scipy as jsp
 from jaxtyping import Float
 import lineax as lx
 import numpyro.distributions as npd
-from paramax import AbstractUnwrappable
 import typing_extensions as tpe
 
 from gpjax.dataset import Dataset
@@ -20,6 +19,7 @@ from gpjax.likelihoods import (
     AbstractHeteroscedasticLikelihood,
 )
 from gpjax.linalg.utils import add_jitter
+from gpjax.parameters import _val
 from gpjax.typing import (
     Array,
     ScalarFloat,
@@ -31,11 +31,6 @@ from gpjax.variational_families import (
 
 VF = TypeVar("VF", bound=AbstractVariationalFamily)
 HVF = TypeVar("HVF", bound=HeteroscedasticVariationalFamily)
-
-
-def _val(x):
-    """Unwrap a paramax parameter or return the value directly."""
-    return x.unwrap() if isinstance(x, AbstractUnwrappable) else x
 
 
 Objective = tpe.Callable[[eqx.Module, Dataset], ScalarFloat]

--- a/gpjax/parameters.py
+++ b/gpjax/parameters.py
@@ -54,6 +54,11 @@ class _DtypePreservingSoftplusLowerCholeskyTransform(SoftplusLowerCholeskyTransf
 _dtype_preserving_lower_cholesky = _DtypePreservingSoftplusLowerCholeskyTransform()
 
 
+def _val(x):
+    """Unwrap a paramax parameter or return the value directly."""
+    return x.unwrap() if isinstance(x, AbstractUnwrappable) else x
+
+
 class PositiveReal(AbstractUnwrappable):
     """Strictly positive parameter.
 

--- a/gpjax/variational_families.py
+++ b/gpjax/variational_families.py
@@ -25,7 +25,6 @@ from jaxtyping import (
     Int,
 )
 import lineax as lx
-from paramax import AbstractUnwrappable
 
 from gpjax.dataset import Dataset
 from gpjax.distributions import GaussianDistribution
@@ -47,6 +46,7 @@ from gpjax.mean_functions import AbstractMeanFunction
 from gpjax.parameters import (
     LowerTriangular,
     Real,
+    _val,
 )
 from gpjax.summary import _SummaryMixin
 from gpjax.typing import (
@@ -63,11 +63,6 @@ HL = tp.TypeVar("HL", bound=AbstractHeteroscedasticLikelihood)
 P = tp.TypeVar("P", bound=AbstractPrior)
 PP = tp.TypeVar("PP", bound=AbstractPosterior)
 HP = tp.TypeVar("HP", HeteroscedasticPosterior, ChainedPosterior)
-
-
-def _val(x):
-    """Unwrap a paramax parameter or return the value directly."""
-    return x.unwrap() if isinstance(x, AbstractUnwrappable) else x
 
 
 def _psd(matrix):

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -45,6 +45,7 @@ from gpjax.objectives import (
 )
 from gpjax.parameters import (
     PositiveReal,
+    _val,
 )
 from gpjax.typing import Array
 from gpjax.variational_families import VariationalGaussian
@@ -56,14 +57,8 @@ from jaxtyping import (
 )
 import optax as ox
 import paramax
-from paramax import AbstractUnwrappable
 import pytest
 import scipy
-
-
-def _val(x):
-    """Unwrap a paramax parameter or return the value directly."""
-    return x.unwrap() if isinstance(x, AbstractUnwrappable) else x
 
 
 class LinearModel(eqx.Module):


### PR DESCRIPTION
Closes #677

The identical 3-line helper (unwrap an `AbstractUnwrappable` parameter or return the value directly) was copy-pasted across 9 files: `gps.py`, `variational_families.py`, `mean_functions.py`, `kernels/base.py`, `objectives.py`, `likelihoods.py`, `kernels/computations/basis_functions.py`, `models/oilmm.py`, and `tests/test_fit.py` (the issue mentions 8, but the test file has the same copy too).

Moved the single definition into `gpjax/parameters.py` and imported it everywhere else, removing the now-unused `AbstractUnwrappable` imports in the files where it was only there to support the local copy.

Full test suite passes (2473 passed, 2 skipped) and ruff is clean. No behavior change, same function body everywhere, just one copy instead of nine.