### PR TITLE
perf: reuse Cholesky factors in Gaussian KL divergence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`distributions._kl_divergence`**: now computes both log-determinants from the
+  Cholesky factors it has already built, halving the O(N³) work on the hot path
+  of every ELBO step. It previously factorised `Σq` and `Σp` for the trace and
+  Mahalanobis terms, then called `logdet(Σq)` and `logdet(Σp)`, whose generic
+  implementation factorised both covariances a *second* time — four
+  factorisations where two suffice
+  ([#664](https://github.com/JaxGaussianProcesses/GPJax/issues/664)). A new
+  `linalg.logdet_from_factor(L)` helper computes `log|L Lᵀ| = 2 Σᵢ log Lᵢᵢ` and
+  is itself `singledispatch`ed, so diagonal, block-diagonal, Kronecker and
+  identity operators keep their structure-exploiting fast paths instead of being
+  densified. Returned values are unchanged.
+
 - **`HeteroscedasticGaussian.link_function`**: now requires the noise latent `g`
   and returns the conditional `N(y | f, σ²(g))`. It previously evaluated the
   noise transform at `g = 0` and returned the *prior-noise* density

--- a/gpjax/distributions.py
+++ b/gpjax/distributions.py
@@ -27,7 +27,7 @@ from numpyro.distributions import constraints
 from numpyro.distributions.distribution import Distribution
 from numpyro.distributions.util import is_prng_key
 
-from gpjax.linalg import cholesky_factor, logdet
+from gpjax.linalg import cholesky_factor, logdet, logdet_from_factor
 from gpjax.typing import (
     Array,
     ScalarFloat,
@@ -306,8 +306,14 @@ def _kl_divergence(q: GaussianDistribution, p: GaussianDistribution) -> ScalarFl
         jnp.square(lx.linear_solve(sqrt_p, diff, solver=lx.Triangular()).value)
     )
 
+    # Log-determinants, log|Σ| = 2 Σᵢ log Lᵢᵢ, reusing the factors computed above.
+    # Calling `logdet(Σ)` here would re-factorise both covariances, doubling the
+    # O(N³) work on the hot path of every ELBO step (issue #664).
+    logdet_q = logdet_from_factor(sqrt_q)
+    logdet_p = logdet_from_factor(sqrt_p)
+
     # KL[q(x)||p(x)] = [ [(μp - μq)ᵀ Σp⁻¹ (μp - μq)] - n - log|Σq| + log|Σp| + tr[Σp⁻¹ Σq] ] / 2
-    return (mahalanobis - n_dim - logdet(sigma_q) + logdet(sigma_p) + trace) / 2.0
+    return (mahalanobis - n_dim - logdet_q + logdet_p + trace) / 2.0
 
 
 __all__ = [

--- a/gpjax/linalg/__init__.py
+++ b/gpjax/linalg/__init__.py
@@ -1,7 +1,12 @@
 """Linear algebra module for GPJax."""
 
 from gpjax.linalg.custom_operators import BlockDiag, Kronecker
-from gpjax.linalg.utils import add_jitter, cholesky_factor, logdet
+from gpjax.linalg.utils import (
+    add_jitter,
+    cholesky_factor,
+    logdet,
+    logdet_from_factor,
+)
 
 __all__ = [
     "BlockDiag",
@@ -9,4 +14,5 @@ __all__ = [
     "add_jitter",
     "cholesky_factor",
     "logdet",
+    "logdet_from_factor",
 ]

--- a/gpjax/linalg/utils.py
+++ b/gpjax/linalg/utils.py
@@ -47,10 +47,47 @@ def _cholesky_kronecker(op):
 
 
 @functools.singledispatch
+def logdet_from_factor(factor: lx.AbstractLinearOperator) -> jax.Array:
+    """Log-determinant of ``A = L Lᵀ`` given its lower Cholesky factor ``L``.
+
+    Use this whenever the factor is already in hand, to avoid the redundant
+    re-factorisation that :func:`logdet` would perform.
+
+    The generic implementation materialises the factor, mirroring
+    :func:`cholesky_factor`'s own fallback. Structured operators are handled by
+    the registered implementations below, which never densify.
+    """
+    return 2.0 * jnp.sum(jnp.log(jnp.diag(factor.as_matrix())))
+
+
+@logdet_from_factor.register(lx.DiagonalLinearOperator)
+def _logdet_from_factor_diagonal(factor):
+    return 2.0 * jnp.sum(jnp.log(lx.diagonal(factor)))
+
+
+@logdet_from_factor.register(lx.IdentityLinearOperator)
+def _logdet_from_factor_identity(factor):
+    return jnp.array(0.0)
+
+
+@logdet_from_factor.register(BlockDiag)
+def _logdet_from_factor_blockdiag(factor):
+    return sum(logdet_from_factor(block) for block in factor.blocks)
+
+
+@logdet_from_factor.register(Kronecker)
+def _logdet_from_factor_kronecker(factor):
+    # |A ⊗ B| = |A|^m |B|^n for A of size n and B of size m, and the Cholesky
+    # factor of a Kronecker product is the Kronecker product of the factors.
+    n = factor.A.out_structure().shape[0]
+    m = factor.B.out_structure().shape[0]
+    return m * logdet_from_factor(factor.A) + n * logdet_from_factor(factor.B)
+
+
+@functools.singledispatch
 def logdet(op: lx.AbstractLinearOperator) -> jax.Array:
     """Log-determinant of a PSD operator via its Cholesky factor."""
-    L = cholesky_factor(op)
-    return 2.0 * jnp.sum(jnp.log(jnp.diag(L.as_matrix())))
+    return logdet_from_factor(cholesky_factor(op))
 
 
 @logdet.register(lx.DiagonalLinearOperator)

--- a/tests/test_distributions_kl.py
+++ b/tests/test_distributions_kl.py
@@ -1,0 +1,279 @@
+"""Tests for `gpjax.distributions._kl_divergence`.
+
+Regression cover for issue #664: the KL divergence performed four O(N³)
+Cholesky factorisations where two suffice, because `logdet` re-factorised
+covariances whose factors were already in hand.
+"""
+
+import gpjax.distributions as distributions_module
+from gpjax.distributions import (
+    GaussianDistribution,
+    _kl_divergence,
+)
+import gpjax.linalg.utils as linalg_utils
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+import lineax as lx
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixed problem data. The covariances are hard-coded (rather than regenerated
+# from a PRNG key) so the reference KL values below stay valid regardless of
+# any change to JAX's random number generation.
+# ---------------------------------------------------------------------------
+
+MU_Q = jnp.array([0.5, -1.0, 2.0, 0.25])
+MU_P = jnp.array([-0.5, 0.75, 1.0, -2.0])
+
+SIGMA_Q = jnp.array(
+    [
+        [
+            6.423345932061903,
+            -1.5657236260856189,
+            1.7868650232265757,
+            2.5178265294419315,
+        ],
+        [
+            -1.5657236260856189,
+            5.533719240771048,
+            -0.772030041877254,
+            -1.6540599776143663,
+        ],
+        [1.7868650232265757, -0.772030041877254, 7.552230276375627, 1.0754558214469359],
+        [
+            2.5178265294419315,
+            -1.6540599776143663,
+            1.0754558214469359,
+            6.930344303910331,
+        ],
+    ]
+)
+
+SIGMA_P = jnp.array(
+    [
+        [
+            9.320493791092119,
+            -0.68510143454854,
+            -1.0611906030751206,
+            2.7369839112022785,
+        ],
+        [
+            -0.68510143454854,
+            7.234547691937459,
+            -1.0370790565138517,
+            -0.8781737432082408,
+        ],
+        [
+            -1.0611906030751206,
+            -1.0370790565138517,
+            5.104728457374599,
+            0.21682659649216027,
+        ],
+        [
+            2.7369839112022785,
+            -0.8781737432082408,
+            0.21682659649216027,
+            6.312547386760501,
+        ],
+    ]
+)
+
+DIAG_Q = jnp.array([1.0, 2.5, 0.3, 4.0])
+DIAG_P = jnp.array([0.7, 1.2, 2.0, 0.9])
+
+_STRUCT = jax.ShapeDtypeStruct((4,), jnp.float64)
+
+
+def _scale(kind: str, which: str) -> lx.AbstractLinearOperator:
+    matrix = SIGMA_Q if which == "q" else SIGMA_P
+    diagonal = DIAG_Q if which == "q" else DIAG_P
+    if kind == "dense":
+        return lx.MatrixLinearOperator(matrix)
+    if kind == "diagonal":
+        return lx.DiagonalLinearOperator(diagonal)
+    if kind == "identity":
+        return lx.IdentityLinearOperator(_STRUCT)
+    raise ValueError(kind)
+
+
+def _distributions(kind_q: str, kind_p: str):
+    q = GaussianDistribution(MU_Q, _scale(kind_q, "q"))
+    p = GaussianDistribution(MU_P, _scale(kind_p, "p"))
+    return q, p
+
+
+# Values captured from the implementation *before* the issue #664 fix, in
+# float64. They pin the numerics: the fix must only remove redundant work.
+REFERENCE_KL = {
+    ("dense", "dense"): 0.8126422619336267,
+    ("diagonal", "diagonal"): 6.763412478671601,
+    ("identity", "identity"): 5.0625,
+    ("dense", "diagonal"): 12.294647261400954,
+    ("diagonal", "dense"): 2.428489493791848,
+}
+
+
+# ---------------------------------------------------------------------------
+# Factorisation counting
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def cholesky_calls(monkeypatch):
+    """Count every `cholesky_factor` invocation reachable from `_kl_divergence`.
+
+    `cholesky_factor` is looked up in two places on this code path: as a module
+    global of `gpjax.distributions`, and as a module global of
+    `gpjax.linalg.utils` (which is where `logdet`'s generic fallback finds it).
+    Both bindings are patched so the count covers the whole call tree.
+    """
+    calls: list[str] = []
+    real_cholesky_factor = linalg_utils.cholesky_factor
+
+    def counting_cholesky_factor(op):
+        calls.append(type(op).__name__)
+        return real_cholesky_factor(op)
+
+    monkeypatch.setattr(linalg_utils, "cholesky_factor", counting_cholesky_factor)
+    monkeypatch.setattr(
+        distributions_module, "cholesky_factor", counting_cholesky_factor
+    )
+    return calls
+
+
+def test_kl_dense_performs_exactly_two_factorisations(cholesky_calls):
+    """Dense KL needs one Cholesky per covariance, not two (issue #664)."""
+    q, p = _distributions("dense", "dense")
+    _kl_divergence(q, p)
+    assert len(cholesky_calls) == 2, (
+        f"expected 2 Cholesky factorisations, got {len(cholesky_calls)}: "
+        f"{cholesky_calls}"
+    )
+
+
+def test_kl_mixed_dense_diagonal_performs_exactly_two_factorisations(cholesky_calls):
+    q, p = _distributions("dense", "diagonal")
+    _kl_divergence(q, p)
+    assert len(cholesky_calls) == 2, cholesky_calls
+
+
+def test_kl_diagonal_performs_exactly_two_factorisations(cholesky_calls):
+    q, p = _distributions("diagonal", "diagonal")
+    _kl_divergence(q, p)
+    assert len(cholesky_calls) == 2, cholesky_calls
+
+
+# ---------------------------------------------------------------------------
+# Numerical equivalence with the pre-fix implementation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("kind_q", "kind_p"), list(REFERENCE_KL))
+def test_kl_matches_prefix_reference_value(kind_q, kind_p):
+    q, p = _distributions(kind_q, kind_p)
+    result = _kl_divergence(q, p)
+    expected = REFERENCE_KL[(kind_q, kind_p)]
+    assert result.dtype == jnp.float64
+    assert jnp.abs(result - expected) < 1e-10
+
+
+def test_kl_matches_closed_form_formula():
+    """Independent check against the textbook formula built from dense algebra."""
+    q, p = _distributions("dense", "dense")
+    diff = MU_P - MU_Q
+    sigma_p_inv = jnp.linalg.inv(SIGMA_P)
+    expected = 0.5 * (
+        diff @ sigma_p_inv @ diff
+        - 4
+        - jnp.linalg.slogdet(SIGMA_Q)[1]
+        + jnp.linalg.slogdet(SIGMA_P)[1]
+        + jnp.trace(sigma_p_inv @ SIGMA_Q)
+    )
+    assert jnp.abs(_kl_divergence(q, p) - expected) < 1e-10
+
+
+# ---------------------------------------------------------------------------
+# Mathematical properties
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("kind", ["dense", "diagonal", "identity"])
+def test_kl_of_distribution_with_itself_is_zero(kind):
+    q, _ = _distributions(kind, kind)
+    assert jnp.abs(_kl_divergence(q, q)) < 1e-10
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2, 3])
+def test_kl_is_non_negative(seed):
+    key_q, key_p, key_mu_q, key_mu_p = jr.split(jr.key(seed), 4)
+    n = 5
+
+    def random_psd(key):
+        a = jr.normal(key, (n, n))
+        return a @ a.T + n * jnp.eye(n)
+
+    q = GaussianDistribution(
+        jr.normal(key_mu_q, (n,)), lx.MatrixLinearOperator(random_psd(key_q))
+    )
+    p = GaussianDistribution(
+        jr.normal(key_mu_p, (n,)), lx.MatrixLinearOperator(random_psd(key_p))
+    )
+    assert _kl_divergence(q, p) >= -1e-10
+
+
+def test_kl_via_public_method_matches_private_function():
+    q, p = _distributions("dense", "dense")
+    assert jnp.allclose(q.kl_divergence(p), _kl_divergence(q, p))
+
+
+# ---------------------------------------------------------------------------
+# JAX transformations
+# ---------------------------------------------------------------------------
+
+
+def _kl_from_arrays(mu_q, sigma_q, mu_p, sigma_p):
+    q = GaussianDistribution(mu_q, lx.MatrixLinearOperator(sigma_q))
+    p = GaussianDistribution(mu_p, lx.MatrixLinearOperator(sigma_p))
+    return _kl_divergence(q, p)
+
+
+def test_kl_is_jittable():
+    jitted = jax.jit(_kl_from_arrays)
+    result = jitted(MU_Q, SIGMA_Q, MU_P, SIGMA_P)
+    assert jnp.abs(result - REFERENCE_KL[("dense", "dense")]) < 1e-10
+
+
+def test_kl_is_differentiable():
+    grad_fn = jax.grad(_kl_from_arrays, argnums=(0, 1))
+    grad_mu, grad_sigma = grad_fn(MU_Q, SIGMA_Q, MU_P, SIGMA_P)
+    assert grad_mu.shape == MU_Q.shape
+    assert grad_sigma.shape == SIGMA_Q.shape
+    assert jnp.all(jnp.isfinite(grad_mu))
+    assert jnp.all(jnp.isfinite(grad_sigma))
+    # KL is minimised at q == p, so the gradient there vanishes.
+    zero_grad_mu, zero_grad_sigma = grad_fn(MU_Q, SIGMA_Q, MU_Q, SIGMA_Q)
+    assert jnp.allclose(zero_grad_mu, 0.0, atol=1e-10)
+    assert jnp.allclose(zero_grad_sigma, 0.0, atol=1e-10)
+
+
+def test_kl_is_vmappable():
+    means = jnp.stack([MU_Q, MU_P, jnp.zeros(4)])
+    covs = jnp.stack([SIGMA_Q, SIGMA_P, jnp.eye(4) * 2.0])
+    batched = jax.vmap(_kl_from_arrays, in_axes=(0, 0, None, None))(
+        means, covs, MU_P, SIGMA_P
+    )
+    assert batched.shape == (3,)
+    assert jnp.abs(batched[0] - REFERENCE_KL[("dense", "dense")]) < 1e-10
+    # Second element is KL[p || p] == 0.
+    assert jnp.abs(batched[1]) < 1e-10
+
+
+def test_kl_is_jittable_for_diagonal_scale():
+    def kl_diag(diag_q, diag_p):
+        q = GaussianDistribution(MU_Q, lx.DiagonalLinearOperator(diag_q))
+        p = GaussianDistribution(MU_P, lx.DiagonalLinearOperator(diag_p))
+        return _kl_divergence(q, p)
+
+    result = jax.jit(kl_diag)(DIAG_Q, DIAG_P)
+    assert jnp.abs(result - REFERENCE_KL[("diagonal", "diagonal")]) < 1e-10

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -1,6 +1,6 @@
 """Tests for the Lineax-based linear algebra module."""
 
-from gpjax.linalg import add_jitter, cholesky_factor, logdet
+from gpjax.linalg import add_jitter, cholesky_factor, logdet, logdet_from_factor
 from gpjax.linalg.custom_operators import BlockDiag, Kronecker
 import jax
 import jax.numpy as jnp
@@ -52,6 +52,128 @@ def test_logdet_diagonal():
 def test_logdet_identity():
     op = lx.IdentityLinearOperator(jax.ShapeDtypeStruct((4,), jnp.float64))
     assert jnp.allclose(logdet(op), 0.0)
+
+
+# --- logdet_from_factor tests ---
+#
+# `logdet_from_factor(L)` computes log|A| for A = L Lᵀ, reusing a Cholesky
+# factor the caller already holds (issue #664). It must agree with `logdet`
+# and must not densify structured operators.
+
+
+def _blockdiag_case():
+    b1 = jnp.array(
+        [
+            [5.88278148942421, 1.8045229252228703],
+            [1.8045229252228703, 4.877985143235627],
+        ]
+    )
+    b2 = jnp.array(
+        [
+            [6.8994720881809375, -1.2155970227187396, -0.7818214380109865],
+            [-1.2155970227187396, 3.727962808803854, 0.4565422704125992],
+            [-0.7818214380109865, 0.4565422704125992, 3.355979468413311],
+        ]
+    )
+    return b1, b2
+
+
+def test_logdet_from_factor_dense():
+    A = jnp.array([[4.0, 2.0], [2.0, 3.0]])
+    op = lx.MatrixLinearOperator(A)
+    result = logdet_from_factor(cholesky_factor(op))
+    assert jnp.allclose(result, jnp.log(jnp.linalg.det(A)), atol=1e-10)
+    assert jnp.allclose(result, logdet(op), atol=1e-10)
+
+
+def test_logdet_from_factor_diagonal():
+    d = jnp.array([2.0, 3.0, 5.0])
+    op = lx.DiagonalLinearOperator(d)
+    result = logdet_from_factor(cholesky_factor(op))
+    assert jnp.allclose(result, jnp.sum(jnp.log(d)), atol=1e-10)
+    assert jnp.allclose(result, logdet(op), atol=1e-10)
+
+
+def test_logdet_from_factor_identity():
+    op = lx.IdentityLinearOperator(jax.ShapeDtypeStruct((4,), jnp.float64))
+    assert jnp.allclose(logdet_from_factor(cholesky_factor(op)), 0.0)
+
+
+def test_logdet_from_factor_blockdiag():
+    b1, b2 = _blockdiag_case()
+    op = BlockDiag([lx.MatrixLinearOperator(b1), lx.MatrixLinearOperator(b2)])
+    result = logdet_from_factor(cholesky_factor(op))
+    assert jnp.allclose(result, 7.599554710816069, atol=1e-10)
+    assert jnp.allclose(result, logdet(op), atol=1e-10)
+
+
+def test_logdet_from_factor_kronecker():
+    b1, b2 = _blockdiag_case()
+    op = Kronecker(lx.MatrixLinearOperator(b1), lx.MatrixLinearOperator(b2))
+    result = logdet_from_factor(cholesky_factor(op))
+    assert jnp.allclose(result, 18.435424994931296, atol=1e-10)
+    assert jnp.allclose(result, logdet(op), atol=1e-10)
+
+
+def test_logdet_from_factor_diagonal_does_not_densify(monkeypatch):
+    """The diagonal fast path must never materialise an N×N matrix."""
+
+    def forbidden(self):
+        raise AssertionError("as_matrix() called: diagonal fast path densified")
+
+    monkeypatch.setattr(lx.DiagonalLinearOperator, "as_matrix", forbidden)
+    factor = lx.DiagonalLinearOperator(jnp.array([2.0, 3.0, 5.0]))
+    result = logdet_from_factor(factor)
+    assert jnp.allclose(result, 2.0 * jnp.sum(jnp.log(jnp.array([2.0, 3.0, 5.0]))))
+
+
+def test_logdet_from_factor_blockdiag_does_not_densify(monkeypatch):
+    """Block-diagonal structure must be exploited, not flattened."""
+
+    def forbidden(self):
+        raise AssertionError("as_matrix() called: block-diagonal structure lost")
+
+    monkeypatch.setattr(BlockDiag, "as_matrix", forbidden)
+    b1, b2 = _blockdiag_case()
+    factor = cholesky_factor(
+        BlockDiag([lx.MatrixLinearOperator(b1), lx.MatrixLinearOperator(b2)])
+    )
+    assert jnp.allclose(logdet_from_factor(factor), 7.599554710816069, atol=1e-10)
+
+
+def test_logdet_from_factor_kronecker_does_not_densify(monkeypatch):
+    """Kronecker structure must be exploited, not expanded to the full product."""
+
+    def forbidden(self):
+        raise AssertionError("as_matrix() called: Kronecker structure lost")
+
+    monkeypatch.setattr(Kronecker, "as_matrix", forbidden)
+    b1, b2 = _blockdiag_case()
+    factor = cholesky_factor(
+        Kronecker(lx.MatrixLinearOperator(b1), lx.MatrixLinearOperator(b2))
+    )
+    assert jnp.allclose(logdet_from_factor(factor), 18.435424994931296, atol=1e-10)
+
+
+def test_logdet_diagonal_does_not_densify(monkeypatch):
+    """`logdet`'s own diagonal fast path is unchanged by the #664 refactor."""
+
+    def forbidden(self):
+        raise AssertionError("as_matrix() called: logdet diagonal fast path densified")
+
+    monkeypatch.setattr(lx.DiagonalLinearOperator, "as_matrix", forbidden)
+    d = jnp.array([2.0, 3.0, 5.0])
+    assert jnp.allclose(logdet(lx.DiagonalLinearOperator(d)), jnp.sum(jnp.log(d)))
+
+
+def test_logdet_from_factor_is_jittable():
+    A = jnp.array([[4.0, 2.0], [2.0, 3.0]])
+
+    def fn(matrix):
+        return logdet_from_factor(cholesky_factor(lx.MatrixLinearOperator(matrix)))
+
+    assert jnp.allclose(jax.jit(fn)(A), jnp.log(jnp.linalg.det(A)), atol=1e-10)
+    assert jnp.all(jnp.isfinite(jax.grad(fn)(A)))
 
 
 # --- add_jitter tests ---


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `uv run poe format` before committing.
- [x] I've added tests for new code.
- [x] I've added docstrings for the new code.

## Description

Closes #664.

`_kl_divergence` computed `sqrt_p` / `sqrt_q` via `cholesky_factor`, then called `logdet(sigma_q)` / `logdet(sigma_p)` — whose generic implementation factorises *again*. Four O(N³) factorisations where two suffice, on the hot path of every ELBO step.

### Correction to the issue

The issue says "four factorisations where two suffice". That's true for dense covariances, but not universally — `logdet` already has registered fast paths for diagonal and identity operators that never call `cholesky_factor`. Measured counts:

| q / p | before | after |
|---|---|---|
| dense / dense | **4** | 2 |
| dense / diagonal | **3** | 2 |
| dense / identity | **3** | 2 |
| diagonal / dense | **3** | 2 |
| diagonal / diagonal | 2 | 2 |
| identity / identity | 2 | 2 |

The waste was confined to operators falling through to the generic `logdet`. After the change it is uniformly 2.

### Approach

Adds `logdet_from_factor(L)` to `gpjax/linalg/utils.py` — a `singledispatch` computing `log|LLᵀ| = 2·Σ log Lᵢᵢ` — and uses it on the factors already in hand. `logdet`'s generic fallback becomes `logdet_from_factor(cholesky_factor(op))`, so the formula lives in one place.

The obvious inline fix, `2*sum(log(jnp.diag(L.as_matrix())))`, would have densified structured operators and been a regression for them. Inlining `lx.diagonal` instead doesn't work either: `lx.diagonal` is **not total** — its singledispatch default raises `NotImplementedError`, so `lx.diagonal(BlockDiag(...))` would have turned a working path into a crash. Hence the dispatched helper, with implementations mirroring `logdet`'s registration set: generic dense, `DiagonalLinearOperator`, `IdentityLinearOperator`, `BlockDiag` (sum over blocks), `Kronecker` (`m·logdet(A) + n·logdet(B)`, from `|A⊗B| = |A|ᵐ|B|ⁿ`).

### Verification

Values are **bit-identical** to `main` — max `|new − main|` is exactly `0.0` across all nine combinations of dense/diagonal/identity for q and p.

Tests were written first and watched fail (`expected 2 Cholesky factorisations, got 4`). The counting fixture patches **both** `gpjax.distributions.cholesky_factor` and `gpjax.linalg.utils.cholesky_factor`, since `logdet`'s internal call resolves the latter — patching only the former would have counted 2 before and after and caught nothing. Reference values are hard-coded literals captured from the pre-fix code, so they are a genuine regression guard. Non-densification is asserted by monkeypatching `as_matrix` to raise.

`poe lint-ci` clean; full suite 2629 passed / 1 skipped.

### Separate pre-existing bug found, not fixed here

`_kl_divergence` does not work at all for `BlockDiag` or `Kronecker` covariances, on `main` today and unchanged by this PR:

```
NotImplementedError: `lineax.has_unit_diagonal` has not been implemented for
  <class 'gpjax.linalg.custom_operators.BlockDiag'>
```

`gpjax/linalg/custom_operators.py` registers `is_symmetric`, `is_diagonal` and friends but not `has_unit_diagonal`, which `lx.Triangular()` queries during the Mahalanobis solve. Out of scope for #664 — worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bj9k5fnAZ8JzD4Rg3HMDMj
