### PR TITLE
perf: use the closed-form KL in variational families

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`prior_kl` for `VariationalGaussian` and `WhitenedVariationalGaussian`**: both
+  now evaluate in closed form from the stored triangular root, instead of
+  densifying `S = sqrt sqrtᵀ` and handing it to the generic Gaussian KL, which
+  re-factorised a matrix whose Cholesky factor was already to hand
+  ([#665](https://github.com/JaxGaussianProcesses/GPJax/issues/665)). The
+  whitened KL against `N(0, I)` needs no factorisation at all and went from two
+  dense Choleskys per call to zero; `VariationalGaussian` went from four to one,
+  the unavoidable factorisation of `Kzz`. Values and gradients are unchanged.
+  Every variational training step pays this cost, so `grad(prior_kl)` is roughly
+  13× faster for the whitened family and 3× faster for `VariationalGaussian` at
+  1024 inducing points. `GraphVariationalGaussian` and
+  `HeteroscedasticVariationalFamily` inherit the improvement.
 - **`HeteroscedasticGaussian.link_function`**: now requires the noise latent `g`
   and returns the conditional `N(y | f, σ²(g))`. It previously evaluated the
   noise transform at `g = 0` and returned the *prior-noise* density

--- a/gpjax/variational_families.py
+++ b/gpjax/variational_families.py
@@ -201,6 +201,20 @@ class VariationalGaussian(AbstractVariationalGaussian[L]):
         ```
         where $u = f(z)$ and $z$ are the inducing inputs.
 
+        With $S = LL^{\top}$ for the stored triangular root $L$ and
+        $\mathbf{K}_{zz} = L_z L_z^{\top}$, this evaluates in closed form as
+        ```math
+        \tfrac{1}{2}\left(
+            \lVert L_z^{-1}(\mu_z - \mu)\rVert^2
+            + \lVert L_z^{-1} L\rVert_F^2
+            - m
+            + 2\sum_i \log [L_z]_{ii}
+            - 2\sum_i \log \lvert L_{ii}\rvert
+        \right),
+        ```
+        so the Cholesky factor of $\mathbf{K}_{zz}$ is the only factorisation
+        required; $S$ is never formed and never re-factorised.
+
         Returns:
             ScalarFloat: The KL-divergence between our variational
                 approximation and the GP prior.
@@ -209,6 +223,7 @@ class VariationalGaussian(AbstractVariationalGaussian[L]):
         variational_mean = _val(self.variational_mean)
         variational_sqrt = _val(self.variational_root_covariance)
         inducing_inputs = self._fmt_inducing_inputs()
+        num_inducing = self.num_inducing
 
         # Unpack mean function and kernel
         mean_function = self.posterior.prior.mean_function
@@ -217,21 +232,29 @@ class VariationalGaussian(AbstractVariationalGaussian[L]):
         inducing_mean = mean_function(inducing_inputs)
         Kzz = kernel.gram(inducing_inputs)
         Kzz_dense = add_jitter(Kzz.as_matrix(), self.jitter)
-        Kzz_op = _psd(Kzz_dense)
 
-        # variational_covariance = sqrt @ sqrt^T
-        variational_covariance = lx.MatrixLinearOperator(
-            variational_sqrt @ variational_sqrt.T
+        # Lz Lz^T = Kzz. The single unavoidable factorisation.
+        Lz = jnp.linalg.cholesky(Kzz_dense)
+
+        # (muz - mu)^T Kzz^{-1} (muz - mu) = ||Lz^{-1} (muz - mu)||^2
+        mahalanobis = jnp.sum(
+            jnp.square(_tri_solve(Lz, inducing_mean - variational_mean))
         )
 
-        q_inducing = GaussianDistribution(
-            loc=jnp.atleast_1d(variational_mean.squeeze()), scale=variational_covariance
-        )
-        p_inducing = GaussianDistribution(
-            loc=jnp.atleast_1d(inducing_mean.squeeze()), scale=Kzz_op
+        # tr[Kzz^{-1} S] = ||Lz^{-1} sqrt||_F^2  [recall S = sqrt sqrt^T]
+        trace = jnp.sum(jnp.square(_tri_solve(Lz, variational_sqrt)))
+
+        # log|Kzz| and log|S|. The absolute value keeps log|S| = 2 sum log|sqrt_ii|
+        # valid for any square root, though `LowerTriangular` already guarantees a
+        # positive diagonal.
+        log_det_prior = 2.0 * jnp.sum(jnp.log(jnp.diag(Lz)))
+        log_det_variational = 2.0 * jnp.sum(
+            jnp.log(jnp.abs(jnp.diag(variational_sqrt)))
         )
 
-        return q_inducing.kl_divergence(p_inducing)
+        return 0.5 * (
+            mahalanobis - num_inducing + log_det_prior - log_det_variational + trace
+        )
 
     def predict(
         self, test_inputs: tp.Union[Int[Array, "N D"], Float[Array, "N D"]]
@@ -371,6 +394,20 @@ class WhitenedVariationalGaussian(VariationalGaussian[L]):
         \end{align}
         ```
 
+        Against a standard normal prior the divergence has a closed form that
+        needs no matrix factorisation at all. Writing $S = LL^{\top}$ for the
+        stored triangular root $L$, and using
+        $\operatorname{tr}[S] = \lVert L\rVert_F^2$ and
+        $\log\lvert S\rvert = 2\sum_i \log\lvert L_{ii}\rvert$,
+        ```math
+        \operatorname{KL}[\mathcal{N}(\mu, S)\mid\mid\mathcal{N}(0, I)] =
+        \tfrac{1}{2}\left(
+            \lVert\mu\rVert^2 + \lVert L\rVert_F^2 - m
+            - 2\sum_i \log\lvert L_{ii}\rvert
+        \right),
+        ```
+        where $m$ is the number of inducing points.
+
         Returns:
             ScalarFloat: The KL-divergence between our variational
                 approximation and the GP prior.
@@ -379,16 +416,14 @@ class WhitenedVariationalGaussian(VariationalGaussian[L]):
         mu = _val(self.variational_mean)
         sqrt = _val(self.variational_root_covariance)
 
-        # S = LL^T
-        S = lx.MatrixLinearOperator(sqrt @ sqrt.T)
+        # mu^T I^{-1} mu, tr[S] = ||sqrt||_F^2 and log|S| = 2 sum log|sqrt_ii|.
+        # The absolute value keeps the log-determinant valid for any square root,
+        # though `LowerTriangular` already guarantees a positive diagonal.
+        mahalanobis = jnp.sum(jnp.square(mu))
+        trace = jnp.sum(jnp.square(sqrt))
+        log_det_variational = 2.0 * jnp.sum(jnp.log(jnp.abs(jnp.diag(sqrt))))
 
-        # Compute whitened KL divergence
-        qu = GaussianDistribution(loc=jnp.atleast_1d(mu.squeeze()), scale=S)
-        pu_S = lx.IdentityLinearOperator(jnp.ones(self.num_inducing, dtype=mu.dtype))
-        pu = GaussianDistribution(
-            loc=jnp.zeros_like(jnp.atleast_1d(mu.squeeze())), scale=pu_S
-        )
-        return qu.kl_divergence(pu)
+        return 0.5 * (mahalanobis + trace - self.num_inducing - log_det_variational)
 
     def predict(self, test_inputs: Float[Array, "N D"]) -> GaussianDistribution:
         r"""Compute the predictive distribution of the GP at the test inputs t.

--- a/tests/test_variational_families.py
+++ b/tests/test_variational_families.py
@@ -15,8 +15,17 @@
 
 from collections.abc import Callable
 
+import equinox as eqx
 import gpjax as gpx
+import gpjax.distributions
 from gpjax.gps import AbstractPosterior
+import gpjax.linalg.utils
+from gpjax.parameters import (
+    LowerTriangular,
+    Real,
+    _val,
+)
+import gpjax.variational_families
 from gpjax.variational_families import (
     AbstractVariationalFamily,
     CollapsedVariationalGaussian,
@@ -26,6 +35,7 @@ from gpjax.variational_families import (
     VariationalGaussian,
     WhitenedVariationalGaussian,
 )
+import jax
 from jax import config
 import jax.numpy as jnp
 import jax.random as jr
@@ -276,3 +286,347 @@ def test_collapsed_variational_gaussian(
     assert isinstance(sigma, jnp.ndarray)
     assert mu.shape == (n_test,)
     assert sigma.shape == (n_test, n_test)
+
+
+# ---------------------------------------------------------------------------
+# Closed-form prior KL (issue #665)
+#
+# `WhitenedVariationalGaussian.prior_kl` and `VariationalGaussian.prior_kl`
+# used to densify `S = sqrt sqrt^T` and hand it to the generic Gaussian KL,
+# which then re-factorised a matrix whose Cholesky factor is already stored in
+# `variational_root_covariance`. The tests below pin the numerical values and
+# gradients of the old implementation and assert the number of Cholesky
+# factorisations the new implementation is allowed to perform.
+# ---------------------------------------------------------------------------
+
+
+def _kl_variational_mean(num_inducing: int) -> Float[Array, "N 1"]:
+    """Deterministic, non-trivial variational mean."""
+    index = jnp.arange(num_inducing, dtype=jnp.float64)
+    return (0.3 * jnp.cos(1.7 * index) - 0.15 * index).reshape(-1, 1)
+
+
+def _kl_variational_root(num_inducing: int) -> Float[Array, "N N"]:
+    """Deterministic, non-trivial lower-triangular root with positive diagonal."""
+    row = jnp.arange(num_inducing, dtype=jnp.float64)[:, None]
+    col = jnp.arange(num_inducing, dtype=jnp.float64)[None, :]
+    off_diagonal = 0.2 * jnp.sin(0.9 * row + 1.3 * col)
+    diagonal = 0.5 + 0.4 * jnp.cos(0.6 * jnp.arange(num_inducing, dtype=jnp.float64))
+    return jnp.tril(off_diagonal, -1) + jnp.diag(diagonal)
+
+
+def _build_kl_family(
+    family: type[VariationalGaussian], num_inducing: int
+) -> VariationalGaussian:
+    """Build a fully deterministic variational family for KL regression tests."""
+    kernel = gpx.kernels.RBF(lengthscale=jnp.array(0.7), variance=jnp.array(1.3))
+    mean_function = gpx.mean_functions.Constant(jnp.array([0.4]))
+    prior = gpx.gps.Prior(kernel=kernel, mean_function=mean_function)
+    posterior = prior * gpx.likelihoods.Gaussian(num_datapoints=20)
+    inducing_inputs = jnp.linspace(-3.0, 3.0, num_inducing).reshape(-1, 1)
+    return family(
+        posterior=posterior,
+        inducing_inputs=inducing_inputs,
+        variational_mean=_kl_variational_mean(num_inducing),
+        variational_root_covariance=_kl_variational_root(num_inducing),
+    )
+
+
+# KL values recorded from the pre-#665 implementation (densify + generic KL),
+# in float64. These are hard-coded literals so that the test is a genuine
+# regression guard rather than a comparison against the code under test.
+_RECORDED_PRIOR_KL = {
+    ("WhitenedVariationalGaussian", 1): 0.055360515657826292,
+    ("WhitenedVariationalGaussian", 3): 0.4558012885085363,
+    ("WhitenedVariationalGaussian", 5): 2.2228894799193393,
+    ("WhitenedVariationalGaussian", 12): 12.540706158684808,
+    ("VariationalGaussian", 1): 0.051927405288060224,
+    ("VariationalGaussian", 3): 0.89833938800292357,
+    ("VariationalGaussian", 5): 3.0465143546546192,
+    ("VariationalGaussian", 12): 35.666594348171607,
+}
+
+# Gradients recorded from the pre-#665 implementation at ``num_inducing=3``,
+# taken with respect to the *unconstrained* parameters that `fit` optimises.
+_RECORDED_PRIOR_KL_GRADS = {
+    "WhitenedVariationalGaussian": {
+        "variational_mean": np.array(
+            [[0.3], [-0.18865334828865737], [-0.5900394577738384]]
+        ),
+        "variational_root_covariance": np.array(
+            [
+                0.15666538192549667,
+                0.19476952617563908,
+                0.00831613248665811,
+                -0.12527973849920676,
+                -0.21121593177991954,
+                -0.430429665953372,
+            ]
+        ),
+        "inducing_inputs": np.zeros((3, 1)),
+    },
+    "VariationalGaussian": {
+        "variational_mean": np.array(
+            [[-0.07687652189052713], [-0.452723814014418], [-0.7615217319894719]]
+        ),
+        "variational_root_covariance": np.array(
+            [
+                0.12042525327023475,
+                0.14981022922180554,
+                0.00633143799283199,
+                -0.24853831088039383,
+                -0.31926350826875094,
+                -0.5011713127475177,
+            ]
+        ),
+        "inducing_inputs": np.array(
+            [
+                [-9.6628829749081168e-05],
+                [-2.0328302385444184e-04],
+                [2.9991185360352303e-04],
+            ]
+        ),
+    },
+}
+
+
+def _textbook_gaussian_kl(mean_q, cov_q, mean_p, cov_p):
+    """KL[q || p] for two multivariate Gaussians, written from the textbook.
+
+    Deliberately independent of any GPJax linear-algebra helper so that this
+    reference cannot drift with changes to ``gpjax.distributions``.
+    """
+    dim = mean_q.shape[0]
+    trace = jnp.trace(jnp.linalg.solve(cov_p, cov_q))
+    diff = mean_p - mean_q
+    mahalanobis = diff @ jnp.linalg.solve(cov_p, diff)
+    _, log_det_p = jnp.linalg.slogdet(cov_p)
+    _, log_det_q = jnp.linalg.slogdet(cov_q)
+    return 0.5 * (trace + mahalanobis - dim + log_det_p - log_det_q)
+
+
+def _reference_prior_kl(family):
+    """Reference prior KL built from the dense covariance matrices."""
+    variational_mean = _val(family.variational_mean).reshape(-1)
+    variational_sqrt = _val(family.variational_root_covariance)
+    cov_q = variational_sqrt @ variational_sqrt.T
+    num_inducing = variational_sqrt.shape[-1]
+
+    if isinstance(family, WhitenedVariationalGaussian):
+        mean_p = jnp.zeros_like(variational_mean)
+        cov_p = jnp.eye(num_inducing, dtype=variational_sqrt.dtype)
+    else:
+        inducing_inputs = _val(family.inducing_inputs)
+        mean_p = family.posterior.prior.mean_function(inducing_inputs).reshape(-1)
+        cov_p = family.posterior.prior.kernel.gram(inducing_inputs).as_matrix()
+        cov_p = cov_p + jnp.eye(num_inducing, dtype=cov_p.dtype) * family.jitter
+
+    return _textbook_gaussian_kl(variational_mean, cov_q, mean_p, cov_p)
+
+
+@pytest.mark.parametrize(
+    "family",
+    [WhitenedVariationalGaussian, VariationalGaussian],
+    ids=lambda f: f.__name__,
+)
+@pytest.mark.parametrize("num_inducing", [1, 3, 5, 12])
+def test_prior_kl_matches_recorded_values(family, num_inducing):
+    """The closed form must reproduce the pre-#665 KL values."""
+    q = _build_kl_family(family, num_inducing)
+    expected = _RECORDED_PRIOR_KL[(family.__name__, num_inducing)]
+    np.testing.assert_allclose(np.float64(q.prior_kl()), expected, rtol=1e-10, atol=0.0)
+
+
+@pytest.mark.parametrize(
+    "family",
+    [WhitenedVariationalGaussian, VariationalGaussian],
+    ids=lambda f: f.__name__,
+)
+@pytest.mark.parametrize("num_inducing", [1, 2, 3, 5, 12])
+def test_prior_kl_matches_textbook_reference(family, num_inducing):
+    """The closed form must agree with an independent dense-matrix reference."""
+    q = _build_kl_family(family, num_inducing)
+    np.testing.assert_allclose(
+        np.float64(q.prior_kl()),
+        np.float64(_reference_prior_kl(q)),
+        rtol=1e-10,
+        atol=1e-12,
+    )
+
+
+@pytest.mark.parametrize(
+    "family",
+    [WhitenedVariationalGaussian, VariationalGaussian],
+    ids=lambda f: f.__name__,
+)
+def test_prior_kl_gradients_match_recorded_values(family):
+    """Gradients must match those of the pre-#665 implementation."""
+    q = _build_kl_family(family, 3)
+    grads = eqx.filter_grad(lambda model: model.prior_kl())(q)
+    recorded = _RECORDED_PRIOR_KL_GRADS[family.__name__]
+
+    np.testing.assert_allclose(
+        np.asarray(grads.variational_mean.value),
+        recorded["variational_mean"],
+        rtol=1e-10,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        np.asarray(grads.variational_root_covariance._flat),
+        recorded["variational_root_covariance"],
+        rtol=1e-10,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        np.asarray(grads.inducing_inputs.value),
+        recorded["inducing_inputs"],
+        rtol=1e-10,
+        atol=1e-12,
+    )
+
+
+@pytest.mark.parametrize(
+    "family",
+    [WhitenedVariationalGaussian, VariationalGaussian],
+    ids=lambda f: f.__name__,
+)
+@pytest.mark.parametrize("num_inducing", [2, 5, 12])
+def test_prior_kl_gradients_match_textbook_reference(family, num_inducing):
+    """Gradients must agree with an independent dense-matrix reference."""
+    q = _build_kl_family(family, num_inducing)
+    grads = eqx.filter_grad(lambda model: model.prior_kl())(q)
+    reference_grads = eqx.filter_grad(_reference_prior_kl)(q)
+
+    np.testing.assert_allclose(
+        np.asarray(grads.variational_mean.value),
+        np.asarray(reference_grads.variational_mean.value),
+        rtol=1e-9,
+        atol=1e-11,
+    )
+    np.testing.assert_allclose(
+        np.asarray(grads.variational_root_covariance._flat),
+        np.asarray(reference_grads.variational_root_covariance._flat),
+        rtol=1e-9,
+        atol=1e-11,
+    )
+    np.testing.assert_allclose(
+        np.asarray(grads.inducing_inputs.value),
+        np.asarray(reference_grads.inducing_inputs.value),
+        rtol=1e-9,
+        atol=1e-11,
+    )
+
+
+def _count_cholesky_calls(monkeypatch, thunk) -> dict[str, int]:
+    """Count Cholesky factorisations performed while evaluating ``thunk``."""
+    counts = {"cholesky_factor": 0, "dense_cholesky": 0}
+    original_cholesky_factor = gpjax.linalg.utils.cholesky_factor
+    original_dense_cholesky = jnp.linalg.cholesky
+
+    def counting_cholesky_factor(operator):
+        counts["cholesky_factor"] += 1
+        return original_cholesky_factor(operator)
+
+    def counting_dense_cholesky(matrix):
+        counts["dense_cholesky"] += 1
+        return original_dense_cholesky(matrix)
+
+    for module in (
+        gpjax.linalg.utils,
+        gpjax.distributions,
+        gpjax.variational_families,
+    ):
+        monkeypatch.setattr(module, "cholesky_factor", counting_cholesky_factor)
+    monkeypatch.setattr(jnp.linalg, "cholesky", counting_dense_cholesky)
+
+    thunk()
+    return counts
+
+
+@pytest.mark.parametrize(
+    ("family", "expected_dense_cholesky"),
+    [(WhitenedVariationalGaussian, 0), (VariationalGaussian, 1)],
+    ids=["WhitenedVariationalGaussian", "VariationalGaussian"],
+)
+def test_prior_kl_factorisation_count(monkeypatch, family, expected_dense_cholesky):
+    """The KL must not re-factorise a matrix whose root it already holds.
+
+    Before #665 the counts were two dense Choleskys for the whitened family and
+    four for ``VariationalGaussian``. The whitened KL needs none;
+    ``VariationalGaussian`` needs exactly one, of ``Kzz``.
+    """
+    q = _build_kl_family(family, 4)
+    counts = _count_cholesky_calls(monkeypatch, q.prior_kl)
+
+    assert counts["dense_cholesky"] == expected_dense_cholesky
+    assert counts["cholesky_factor"] == 0
+
+
+@pytest.mark.parametrize(
+    "family",
+    [WhitenedVariationalGaussian, VariationalGaussian],
+    ids=lambda f: f.__name__,
+)
+def test_prior_kl_is_jit_grad_and_vmap_compatible(family):
+    q = _build_kl_family(family, 4)
+    eager = q.prior_kl()
+
+    jitted = eqx.filter_jit(lambda model: model.prior_kl())
+    np.testing.assert_allclose(np.float64(jitted(q)), np.float64(eager), rtol=1e-12)
+
+    grads = eqx.filter_grad(lambda model: model.prior_kl())(q)
+    assert jnp.all(jnp.isfinite(grads.variational_mean.value))
+    assert jnp.all(jnp.isfinite(grads.variational_root_covariance._flat))
+
+    def kl_from_mean(mean_value):
+        model = eqx.tree_at(lambda t: t.variational_mean.value, q, mean_value)
+        return model.prior_kl()
+
+    zero_mean = jnp.zeros_like(_val(q.variational_mean))
+    batch = jnp.stack(
+        [_val(q.variational_mean), _val(q.variational_mean) + 0.5, zero_mean]
+    )
+    batched = jax.vmap(kl_from_mean)(batch)
+
+    assert batched.shape == (3,)
+    np.testing.assert_allclose(
+        np.float64(batched[0]), np.float64(eager), rtol=1e-12, atol=1e-14
+    )
+    np.testing.assert_allclose(
+        np.float64(batched[2]),
+        np.float64(kl_from_mean(zero_mean)),
+        rtol=1e-12,
+        atol=1e-14,
+    )
+
+
+def test_whitened_prior_kl_is_zero_when_q_equals_the_prior():
+    """KL[N(0, I) || N(0, I)] must be zero."""
+    q = _build_kl_family(WhitenedVariationalGaussian, 6)
+    q = eqx.tree_at(
+        lambda t: (t.variational_mean, t.variational_root_covariance),
+        q,
+        (Real(jnp.zeros((6, 1))), LowerTriangular(jnp.eye(6))),
+    )
+    np.testing.assert_allclose(np.float64(q.prior_kl()), 0.0, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "family",
+    [WhitenedVariationalGaussian, VariationalGaussian],
+    ids=lambda f: f.__name__,
+)
+@pytest.mark.parametrize("seed", [0, 1, 2])
+def test_prior_kl_is_non_negative(family, seed):
+    num_inducing = 6
+    key_mean, key_root = jr.split(jr.key(seed))
+    root = jnp.tril(jr.normal(key_root, (num_inducing, num_inducing)) * 0.2, -1)
+    root = root + jnp.diag(0.3 + jnp.abs(jr.normal(key_root, (num_inducing,))))
+
+    q = _build_kl_family(family, num_inducing)
+    q = eqx.tree_at(
+        lambda t: (t.variational_mean, t.variational_root_covariance),
+        q,
+        (Real(jr.normal(key_mean, (num_inducing, 1))), LowerTriangular(root)),
+    )
+    assert q.prior_kl() >= 0.0


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `uv run poe format` before committing.
- [x] I've added tests for new code.
- [x] I've added docstrings for the new code.

## Description

Closes #665.

`VariationalGaussian.prior_kl` and `WhitenedVariationalGaussian.prior_kl` both densified `S = LLᵀ` and handed it to the generic KL, which then re-factorised a matrix whose Cholesky factor is the stored `variational_root_covariance`. Both now evaluate in closed form.

### Closed forms

Whitened, against the `N(0, I)` prior — no factorisation at all:

$$\mathrm{KL}\big[\mathcal{N}(\mu, LL^\top)\,\|\,\mathcal{N}(0, I)\big] = \tfrac12\big(\lVert\mu\rVert^2 + \lVert L\rVert_F^2 - m - 2\textstyle\sum_i \log\lvert L_{ii}\rvert\big)$$

`VariationalGaussian`, against `N(m_z, K_{zz})` with $L_zL_z^\top = K_{zz}$:

$$\tfrac12\big(\lVert L_z^{-1}(m_z-\mu)\rVert^2 + \lVert L_z^{-1}L\rVert_F^2 - m + 2\textstyle\sum_i \log [L_z]_{ii} - 2\sum_i \log\lvert L_{ii}\rvert\big)$$

The factorisation of `Kzz` is genuinely unavoidable here — it's needed by the Mahalanobis term, the trace, and `log|Kzz|` — so **one** is the established minimum.

### Factorisation counts

`jnp.linalg.cholesky` calls per `prior_kl()`:

| Family | Before | After |
|---|---|---|
| `WhitenedVariationalGaussian` | 2 | **0** |
| `VariationalGaussian` | 4 | **1** |

### Verification

Values and gradients were captured from the pre-change code and hard-coded as literals, so the tests are genuine regression guards rather than self-referential. Measured agreement across both families at m ∈ {3, 5, 12}:

| quantity | max relative difference |
|---|---|
| KL value | 3.5e-16 |
| ∂KL/∂`variational_mean` | exactly 0 |
| ∂KL/∂`variational_root_covariance` | 4.2e-16 |

Gradients matter as much as values here — a closed form that is right in value and wrong in derivative would be worse than the status quo — so `∂KL/∂variational_root_covariance._flat` (the unconstrained vector `fit` actually optimises) and `∂KL/∂inducing_inputs` are pinned too. Cross-checked against an independent textbook reference using `jnp.linalg.solve`/`slogdet` with no GPJax helpers.

TDD held: the count tests failed first with `assert 2 == 0` and `assert 4 == 1`. jit / grad / vmap all exercised; KL ≥ 0 over random draws; whitened KL is exactly 0 at μ=0, L=I.

Speedup on `grad(prior_kl)` under `filter_jit`, CPU float64:

| | m=128 | m=512 | m=1024 |
|---|---|---|---|
| Whitened | 796 → 306 µs | 12.1 → 1.7 ms | 77.4 → **6.0 ms** |
| `VariationalGaussian` | 1.16 → 0.73 ms | 17.4 → 8.7 ms | 115.8 → **42.7 ms** |

`poe lint-ci` clean; full suite 2635 passed / 1 skipped.

### Knock-on effects

- `GraphVariationalGaussian` inherits `VariationalGaussian.prior_kl` and is fixed for free.
- `HeteroscedasticVariationalFamily` sums two such calls: 8 → 2.

### Corrections to the issue text

1. The issue says the generic KL "re-Choleskys `S` twice". It factorises `S` twice *in total* — once directly, once inside `logdet` — not twice on top of an existing one. Total whitened cost was 2, not 3. The identity prior is free, since `cholesky_factor` and `logdet` are both registered for `IdentityLinearOperator`.
2. The quoted whitened form uses `Σ log diag sqrt`; the safe form is `Σ log|diag sqrt|`. `LowerTriangular.unwrap()` already guarantees a positive diagonal, but `log|S| = 2Σ log|Lᵢᵢ|` holds for *any* square root and matches what the generic path did. `abs` is smooth on the positive orthant, so gradients are unchanged.

### Follow-up, not done here

`NaturalVariationalGaussian` (`variational_families.py:522`) shares the exact pattern — it computes a triangular root of `S` via the reversed-Cholesky trick, discards it into `MatrixLinearOperator(sqrt @ sqrt.T)`, and calls the generic KL. Currently 5 dense Choleskys where the minimum is 2. Left alone deliberately to keep this PR scoped; worth its own issue.

`ExpectationVariationalGaussian` does *not* share it — `S = η₂ − η₁η₁ᵀ` is genuinely dense with no root available, so its factorisation is legitimate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bj9k5fnAZ8JzD4Rg3HMDMj
