### PR TITLE
chore(release): prepare v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## [0.18.0] — 2026-07-26
 
 ### Removed
 
@@ -82,6 +82,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   frequencies. RFF Gram/cross-covariance values with *sampled* frequencies are
   bit-identical to `0.17.0` — the lengthscale simply moved from the feature map
   into the measure it is drawn from.
+
+#### Migration
+
+- **`StationaryKernel.spectral_density`**: the return type is now
+  `MultivariateNormal` / `MultivariateStudentT` with `event_shape == (D,)`.
+  Replace `kernel.spectral_density.sample(key, (M, D))` with
+  `kernel.spectral_density.sample(key, (M,))`. Values from `log_prob` now vary
+  with the lengthscale, as they always should have — there is no restore path,
+  the previous output was incorrect.
+- **`kernels.approximations.RFF(..., frequencies=...)`**: supplied frequencies
+  are now used as the spectral frequencies ω directly. If you were
+  pre-compensating for the old division by the lengthscale, remove that
+  compensation. RFF with *sampled* frequencies is bit-identical to `0.17.0`.
+- **`HeteroscedasticGaussian.link_function`**: now requires the noise latent,
+  `link_function(f, g)`. Calls passing only `f` raise `ValueError`; they
+  previously returned `N(y | f, σ²(0))`, which was wrong. Use
+  `expected_log_likelihood(..., mean_g=, variance_g=)` or
+  `predict(dist, noise_dist)` if you want the noise handled for you.
+- **`tensorstore`**: removed as a runtime dependency. If you imported it
+  transitively via GPJax on macOS, depend on it explicitly.
+- **KL divergences**: `distributions._kl_divergence` and the variational
+  `prior_kl` methods return the same values as `0.17.0` (bit-identical, or to
+  ~1e-16 where floating-point reassociation applies). No action needed.
 
 ## [0.17.0] — 2026-07-04
 

--- a/gpjax/__init__.py
+++ b/gpjax/__init__.py
@@ -45,7 +45,7 @@ __license__ = "MIT"
 __description__ = "Gaussian processes in JAX"
 __url__ = "https://github.com/thomaspinder/GPJax"
 __contributors__ = "https://github.com/thomaspinder/GPJax/graphs/contributors"
-__version__ = "0.17.0"
+__version__ = "0.18.0"
 
 __all__ = [
     "Dataset",


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `uv run poe format` before committing.
- [x] I've added tests for new code.
- [x] I've added docstrings for the new code.

## Description

Release preparation for **v0.18.0**. Bumps `__version__` and closes out the `[Unreleased]` CHANGELOG section with a dated heading and a Migration block.

Minor rather than patch, because three entries change public API behaviour — matching how `0.14.0` and `0.15.0` carried their breaking changes under a minor bump.

### What's in this release

**Breaking**
- `StationaryKernel.spectral_density` returns `MultivariateNormal` / `MultivariateStudentT` with `event_shape == (D,)`, and now actually depends on the lengthscale and dimension (#612, #702)
- `HeteroscedasticGaussian.link_function` requires the noise latent `g` (#670, #706)
- `RFF(..., frequencies=...)` uses supplied frequencies directly, no longer dividing by the lengthscale (#702)

**Removed**
- `tensorstore` runtime dependency, ~14 MB off every macOS install (#675, #705)

**Fixed / performance**
- `_kl_divergence`: 4 → 2 Cholesky factorisations (#664, #707)
- `prior_kl`: 4 → 1 for `VariationalGaussian`, 2 → 0 for whitened; ~13× faster `grad(prior_kl)` at m=1024 (#665, #708)
- RationalQuadratic and PoweredExponential docstring formulas (#703)

**Infrastructure**
- ruff pinned to `uv.lock`; CI can no longer silently auto-fix (#704)

### Verification

- `uv build` produces `gpjax-0.18.0-py3-none-any.whl` and `.tar.gz`; installed package reports `0.18.0`
- `uv run poe lint-ci` clean
- Full suite on `main` at this commit: 2666 passed, 1 skipped

### After merge

Tagging `v0.18.0` triggers `.github/workflows/release.yml`, which runs the multi-platform matrix and security scan, builds, creates the GitHub release, **and publishes to PyPI**. The publish step is gated on a real tag push (`github.event_name == 'push'`), so `workflow_dispatch` is a safe dry run if you want one first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bj9k5fnAZ8JzD4Rg3HMDMj
