### PR TITLE
fix(mean-functions): keep the Zero mean at zero during fitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Fixed
+
+- **`Zero` mean function is trainable and drifts away from zero.** Fitting a
+  model with the default `Zero()` mean function moved its constant towards the
+  data mean (0.0 → 5.09 on a dataset with mean 5), silently changing the
+  posterior mean of every such model
+  ([#712](https://github.com/JaxGaussianProcesses/GPJax/issues/712)). This is a
+  regression of [#330](https://github.com/JaxGaussianProcesses/GPJax/issues/330),
+  fixed once in #500 and reintroduced by the Equinox migration. The cause is a
+  changed trainability contract rather than a lost line: under `nnx`, `fit`
+  optimised only `Parameter` instances, so `Zero`'s bare array was inert by
+  construction; under Equinox, `fit` partitions on `eqx.is_array`, which makes
+  every array leaf trainable. `Zero` now wraps its constant in
+  `paramax.non_trainable`, so it stays at zero by construction. `Constant` is
+  unchanged and remains trainable.
+
+  `Zero().constant` is now a `NonTrainable` wrapper rather than a bare array.
+  Read it with `paramax.unwrap(mean_function).constant` (or `_val`) if you were
+  accessing it directly; evaluating the mean function is unaffected.
+
 ## [0.18.0] — 2026-07-26
 
 ### Removed

--- a/gpjax/mean_functions.py
+++ b/gpjax/mean_functions.py
@@ -24,6 +24,7 @@ from jaxtyping import (
     Float,
     Num,
 )
+import paramax
 from paramax import AbstractUnwrappable
 
 from gpjax.parameters import _val
@@ -154,10 +155,13 @@ class Zero(Constant):
     The zero mean function. This function returns a zero scalar value for all
     inputs. Unlike the Constant mean function, the constant scalar zero is fixed, and
     cannot be treated as a model hyperparameter and learned during training.
+
+    The constant is wrapped in `paramax.non_trainable` to enforce this: `fit` treats
+    every array leaf as trainable, so a bare array would be optimised away from zero.
     """
 
     def __init__(self):
-        super().__init__(constant=0.0)
+        super().__init__(constant=paramax.non_trainable(jnp.array(0.0)))
 
 
 class CombinationMeanFunction(AbstractMeanFunction):

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -527,47 +527,32 @@ def test_fit_freeze_kernel_variance() -> None:
     assert not jnp.allclose(unwrapped.prior.kernel.lengthscale, 1.0)
 
 
-def test_fit_zero_mean_function_frozen_with_non_trainable() -> None:
-    """Test that Zero mean function constant can be frozen using paramax.non_trainable.
+def test_fit_zero_mean_function_is_frozen_by_default() -> None:
+    """Zero needs no manual freezing: it must stay at zero through `fit`.
 
-    In the equinox backend, plain JAX arrays are trainable by default.
-    To freeze the Zero mean function's constant, use paramax.non_trainable.
+    Regression test for #330/#712.
     """
     key = jr.key(42)
     X = jr.uniform(key, (20, 1), minval=-3.0, maxval=3.0)
-    y = jnp.ones_like(X) + 0.1 * jr.normal(jr.key(43), X.shape)  # Non-zero mean data
+    y = jnp.full_like(X, 25.0)  # data with a large non-zero mean
     D = Dataset(X, y)
 
-    # Create GP with Zero mean function
-    meanf = gpx.mean_functions.Zero()
-    kernel = gpx.kernels.RBF(lengthscale=1.0, variance=1.0)
-    prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n)
-    posterior = prior * likelihood
+    posterior = gpx.gps.Prior(
+        mean_function=gpx.mean_functions.Zero(),
+        kernel=gpx.kernels.RBF(lengthscale=1.0, variance=1.0),
+    ) * gpx.likelihoods.Gaussian(num_datapoints=D.n)
 
-    # Record initial mean function constant (should be 0.0)
-    initial_constant = meanf.constant
-
-    # Freeze the Zero mean function constant using paramax.non_trainable
-    frozen_posterior = eqx.tree_at(
-        lambda m: m.prior.mean_function.constant,
-        posterior,
-        replace_fn=paramax.non_trainable,
-    )
-
-    # Train with frozen constant
     trained_posterior, _ = fit(
-        model=frozen_posterior,
-        objective=gpx.objectives.conjugate_mll,
+        model=posterior,
+        objective=lambda model, data: -gpx.objectives.conjugate_mll(model, data),
         train_data=D,
-        optim=ox.sgd(0.01),
-        num_iters=10,
+        optim=ox.adam(0.1),
+        num_iters=50,
         verbose=False,
     )
 
-    # Assert Zero mean function constant has not changed (remains 0.0)
     unwrapped = paramax.unwrap(trained_posterior)
-    assert jnp.allclose(unwrapped.prior.mean_function.constant, initial_constant)
+    assert jnp.allclose(unwrapped.prior.mean_function.constant, 0.0)
 
 
 def test_fit_constant_mean_function_with_parameter() -> None:

--- a/tests/test_mean_functions.py
+++ b/tests/test_mean_functions.py
@@ -19,20 +19,36 @@ from jax import config
 config.update("jax_enable_x64", True)
 
 
+from gpjax.dataset import Dataset
+from gpjax.fit import fit
+from gpjax.gps import Prior
+from gpjax.kernels import RBF
+from gpjax.likelihoods import Gaussian
 from gpjax.mean_functions import (
     AbstractMeanFunction,
     CombinationMeanFunction,
     Constant,
     Zero,
 )
-from gpjax.parameters import Real
+from gpjax.objectives import conjugate_mll
+from gpjax.parameters import (
+    Real,
+    _val,
+)
+import jax
 import jax.numpy as jnp
+import jax.random as jr
 from jaxtyping import (
     Array,
     Float,
     Num,
 )
-from paramax import AbstractUnwrappable
+import optax as ox
+from paramax import (
+    AbstractUnwrappable,
+    NonTrainable,
+    unwrap,
+)
 import pytest
 
 
@@ -68,14 +84,38 @@ def test_constant(constant: Float[Array, " Q"]) -> None:
 
 
 def test_zero_mean_initialises_at_zero() -> None:
-    """Zero mean function should initialise its constant at 0.0.
-
-    Note: with equinox, the constant is a plain array leaf and *is* trainable.
-    The invariant we test is that the initial value is zero, not that it stays
-    zero after optimisation.
-    """
+    """Zero mean function should initialise its constant at 0.0."""
     meanf = Zero()
-    assert jnp.allclose(meanf.constant, 0.0)
+    assert jnp.allclose(_val(meanf.constant), 0.0)
+
+
+def test_zero_mean_remains_zero() -> None:
+    """The zero mean must stay at zero after fitting data with a non-zero mean.
+
+    Regression test for #330/#712. The constant is frozen, so gradient descent
+    must not be able to move it towards the data mean.
+    """
+    x = jnp.linspace(0.0, 1.0, 20, dtype=jnp.float64).reshape(-1, 1)
+    y = jnp.full((20, 1), 50.0, dtype=jnp.float64)  # dataset with a non-zero mean
+    train_data = Dataset(X=x, y=y)
+
+    posterior = Prior(mean_function=Zero(), kernel=RBF()) * Gaussian(
+        num_datapoints=train_data.n
+    )
+
+    optimised, _ = fit(
+        model=posterior,
+        objective=lambda model, data: -conjugate_mll(model, data),
+        train_data=train_data,
+        optim=ox.adam(0.1),
+        num_iters=100,
+        key=jr.PRNGKey(42),
+        verbose=False,
+    )
+
+    mean_function = unwrap(optimised.prior.mean_function)
+    assert jnp.allclose(mean_function.constant, 0.0)
+    assert jnp.allclose(mean_function(x), 0.0)
 
 
 def test_initialising_zero_mean_with_constant_raises_error():
@@ -287,14 +327,22 @@ def test_constant_mean_function_with_array():
     assert jnp.allclose(result, expected)
 
 
-def test_zero_mean_function_uses_raw_value():
-    """Test that Zero mean function uses raw value, not Static Parameter."""
+def test_zero_mean_function_constant_is_frozen():
+    """The zero constant is wrapped so that optimisers cannot update it.
+
+    ``fit`` treats every array leaf as trainable, so a bare array would be
+    optimised. The ``NonTrainable`` wrapper is what keeps the zero at zero.
+    """
     meanf = Zero()
 
-    # Check that the constant is a raw value (0.0), not a Parameter
-    assert not isinstance(meanf.constant, AbstractUnwrappable)
-    assert isinstance(meanf.constant, jnp.ndarray)
-    assert jnp.allclose(meanf.constant, 0.0)
+    assert isinstance(meanf.constant, NonTrainable)
+    assert jnp.allclose(_val(meanf.constant), 0.0)
+
+    # The wrapper must stop gradients reaching the constant. `eqx.filter` alone
+    # does not hide it -- `unwrap` is what applies `stop_gradient`.
+    x = jnp.array([[1.0], [2.0], [3.0]])
+    grads = jax.grad(lambda mf: jnp.sum((unwrap(mf)(x) - 50.0) ** 2))(meanf)
+    assert jnp.allclose(grads.constant.tree, 0.0)
 
     # Test evaluation
     x = jnp.array([[1.0], [2.0], [3.0]])

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -19,7 +19,10 @@ from gpjax import summary
 from gpjax.gps import Prior
 from gpjax.kernels import RBF, Linear
 from gpjax.likelihoods import Gaussian
-from gpjax.mean_functions import Zero
+from gpjax.mean_functions import (
+    Constant,
+    Zero,
+)
 from gpjax.parameters import (
     LowerTriangular,
     NonNegativeReal,
@@ -137,11 +140,19 @@ def test_collect_isotropic_rbf_prior():
 
 
 def test_collect_renders_bare_array_leaf():
-    prior = Prior(mean_function=Zero(), kernel=RBF())
+    # `Constant` holds a bare array; `Zero` wraps its constant to freeze it.
+    prior = Prior(mean_function=Constant(), kernel=RBF())
     rec = _record_by_name(summary._collect(prior), "mean_function.constant")
     assert rec.cls == "Array"
     assert rec.bijector == "Identity"
     assert rec.trainable is True
+
+
+def test_collect_renders_frozen_zero_mean_leaf():
+    prior = Prior(mean_function=Zero(), kernel=RBF())
+    rec = _record_by_name(summary._collect(prior), "mean_function.constant")
+    assert rec.cls == "Array"
+    assert rec.trainable is False
 
 
 def test_collect_composite_kernel_paths():
@@ -205,8 +216,8 @@ def test_render_returns_table_with_row_per_record():
 
 def test_render_footer_counts_trainable():
     table = summary._render(summary._collect(_frozen_prior()))
-    # frozen prior: lengthscale frozen, variance + mean constant trainable.
-    assert table.caption == "3 parameters, 2 trainable"
+    # frozen prior: lengthscale frozen, zero-mean constant frozen, variance trainable.
+    assert table.caption == "3 parameters, 1 trainable"
 
 
 def test_render_respects_column_subset():


### PR DESCRIPTION
Fixes #712. Regression of #330.

## The bug

`Zero()` is trainable and drifts towards the data mean during `fit`, contradicting its own
docstring ("the constant scalar zero is fixed, and cannot be treated as a model hyperparameter
and learned during training"):

```
before fit, Zero constant = 0.0
after  fit, Zero constant = 5.088802112651860
```

Since `Zero` is the default mean function in most of our examples, this silently shifts the
posterior mean of any model that uses it.

## Root cause

Not a lost line — a changed **trainability contract**.

| PR | Change | Stays zero? |
|---|---|---|
| #500 | Fixes #330 by wrapping as `Static(jnp.array(0.0))` | yes |
| #530 | Removes the `Static` wrapper | yes |
| #614 | Equinox migration | **no** |

Under nnx, `fit` optimised only `Parameter` instances (`trainable: nnx.filterlib.Filter =
Parameter`), so `Zero`'s bare array was inert by construction — which is why #530 could drop
the wrapper and remain correct. Under Equinox, `fit` partitions on `eqx.is_array`
(`fit.py:222`), so every array leaf is trainable. `Zero` was still relying on "bare array =
frozen", and that stopped being true.

The fix wraps the constant in `paramax.non_trainable`, so the invariant holds by construction
rather than depending on the ambient filter semantics.

## The test regression

Worth calling out for its own sake: a guard existed and was **weakened rather than removed**.
#614 replaced `test_zero_mean_remains_zero` (which fitted a dataset with mean 50 and asserted
the mean stayed at zero) with `test_zero_mean_initialises_at_zero`, whose docstring read:

> Note: with equinox, the constant is a plain array leaf and *is* trainable. The invariant we
> test is that the initial value is zero, not that it stays zero after optimisation.

And `test_zero_mean_function_uses_raw_value` asserted `not isinstance(meanf.constant,
AbstractUnwrappable)` — pinning the defect in place.

This PR restores the end-to-end assertion and inverts the unit test.

## Changes

- `gpjax/mean_functions.py` — `Zero.__init__` wraps its constant in `paramax.non_trainable`.
  `Constant` is untouched and remains trainable.
- `tests/test_mean_functions.py` — restores `test_zero_mean_remains_zero` (end-to-end fit
  against data with mean 50); replaces `test_zero_mean_function_uses_raw_value` with
  `test_zero_mean_function_constant_is_frozen`, which asserts the wrapper *and* that gradients
  do not reach the constant.
- `tests/test_fit.py` — replaces the manual-freezing `Zero` test with
  `test_fit_zero_mean_function_is_frozen_by_default`. The equivalent test for `Constant` (the
  case where manual freezing is genuinely the API) already existed and is unchanged.
- `tests/test_summary.py` — `test_collect_renders_bare_array_leaf` now uses `Constant()`, which
  is genuinely a bare array; adds `test_collect_renders_frozen_zero_mean_leaf`; the trainable
  count in the footer test drops from 2 to 1.

## Scope

I swept for anything else relying on "bare array = frozen" across the nnx→Equinox boundary.
`Zero` is the only case: `GraphKernel` already uses `paramax.non_trainable` for its Laplacian
and eigendecomposition, and no other docstring claims a fixed parameter.

`White.lengthscale` is related but distinct — a phantom parameter with identically zero
gradient, so it pollutes `summary()` and MCMC dimensionality without changing results. It
belongs with the structural discussion in #695.

## Compatibility

`Zero().constant` is now a `NonTrainable` wrapper rather than a bare array. Reading it directly
needs `paramax.unwrap(mean_function).constant` (or `_val`). Evaluating the mean function is
unaffected, and `Constant` is unchanged.

## Verification

`uv run poe all-tests` — 2672 passed, 1 skipped. (One local failure,
`test_root_good[review_real-notebooks.md]`, comes from an untracked scratch file in my working
tree that `tests/test_markdown.py` globs; it disappears under `git stash -u` and CI never sees
it.)
