### PR TITLE
ci(deps): group dependabot updates and switch pip to uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
-  # Enable version updates for Python dependencies
-  - package-ecosystem: "pip"
+  # Python dependencies. Uses the `uv` ecosystem, not `pip`, so that Dependabot
+  # reads `[tool.uv].dev-dependencies` and keeps `uv.lock` in step with
+  # `pyproject.toml`. The `pip` ecosystem does neither.
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
@@ -18,35 +20,16 @@ updates:
     labels:
       - "dependencies"
       - "automated"
-    # Group related updates together
+    # Catch-all groups: one PR per run for version updates, one for security
+    # updates. Without a `*` pattern, unmatched dependencies get their own PR.
     groups:
-      jax-ecosystem:
+      python-dependencies:
         patterns:
-          - "jax"
-          - "jaxlib"
-          - "flax"
-          - "optax"
-          - "jaxtyping"
-          - "equinox"
-      ml-tools:
+          - "*"
+      python-security:
+        applies-to: security-updates
         patterns:
-          - "numpy"
-          - "scipy"
-          - "scikit-learn"
-          - "matplotlib"
-          - "pandas"
-      testing:
-        patterns:
-          - "pytest*"
-          - "coverage"
-          - "beartype"
-      dev-tools:
-        patterns:
-          - "black"
-          - "ruff"
-          - "isort"
-          - "pre-commit"
-          - "mypy"
+          - "*"
     # Ignore major version updates for stable dependencies
     ignore:
       - dependency-name: "numpy"
@@ -54,7 +37,8 @@ updates:
       - dependency-name: "scipy"
         update-types: ["version-update:semver-major"]
 
-  # Enable version updates for GitHub Actions
+  # GitHub Actions. Groups cannot span `updates` entries, so this is always a
+  # separate PR from the Python one.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -66,6 +50,16 @@ updates:
     commit-message:
       prefix: "ci"
       include: "scope"
+    # `github_actions` (underscore) is the label that exists in the repo;
+    # `github-actions` from labels.yml has never been synced and is ignored.
     labels:
-      - "github-actions"
+      - "github_actions"
       - "automated"
+    groups:
+      actions:
+        patterns:
+          - "*"
+      actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `uv run poe format` before committing. — N/A, config-only
- [x] I've added tests for new code. — N/A, no code
- [x] I've added docstrings for the new code. — N/A, no code

## Description

Three changes to `.github/dependabot.yml`.

**1. One PR per ecosystem instead of one per dependency.**

The config had four named pattern groups, but per the [Dependabot options reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#groups--), *"any outdated dependencies that do not match a rule are updated in individual pull requests."* So we were getting up to four group PRs plus a long tail of singletons.

Replaced with a catch-all `*` group per ecosystem, plus a second group with `applies-to: security-updates` — grouping defaults to version updates only, so security PRs would otherwise stay ungrouped.

Groups cannot span `updates` entries, so the floor is **two** PRs per run: Python and GitHub Actions.

**2. Python ecosystem switched from `pip` to `uv`.**

All dev tooling is declared in `[tool.uv].dev-dependencies` (`pyproject.toml:68-88`), which the `pip` ecosystem does not read. ruff, pytest, pytest-xdist, asv, twine, hypothesis and the rest have never been bumped by Dependabot. The `uv` ecosystem reads them and also keeps `uv.lock` in step with `pyproject.toml`.

This also explains why the removed `testing` and `dev-tools` groups were matching nothing — and `dev-tools` still listed `black`, `isort` and `mypy`, which ruff replaced some time ago.

The `numpy`/`scipy` major-version `ignore` rules carry over unchanged.

**3. Fixed the GitHub Actions labels.**

Custom `labels` *replace* the defaults, and any label not defined in the repo is silently ignored. The Actions entry asked for `github-actions` + `automated`; the repo has neither (it has `github_actions`, with an underscore). Net effect: **Actions PRs have been landing with no labels at all.** Switched to `github_actions`.

## Verification

Parsed the file and checked it against the documented schema: every key under `updates[]` and `groups.*` is a valid option, both group identifiers satisfy `^[A-Za-z][A-Za-z|_-]*[A-Za-z]$`, each ecosystem has a catch-all for both version and security updates, and `pyproject.toml` + `uv.lock` are both present at `/`.

```
ecosystems: ['uv', 'github-actions']
groups: {'uv': ['python-dependencies', 'python-security'],
         'github-actions': ['actions', 'actions-security']}
uv manifests present: ['pyproject.toml', 'uv.lock']
ERRORS: none
```

Cross-checked every configured label against `gh label list`:

```
              uv: dependencies, automated  <-- MISSING (ignored)
  github-actions: github_actions, automated  <-- MISSING (ignored)
```

Each entry now has at least one label that actually lands.

## Follow-ups, not in this PR

- **`.github/labels.yml` has never been synced.** It declares `automated` and `github-actions`, neither of which exists in the repo. I left `automated` in the Dependabot config — it's the declared intent and is harmlessly ignored until someone syncs the file — but syncing `labels.yml` (or dropping the stale entries) is worth doing separately.
- **The first `uv` PR will be large.** The dev-dependency block has never been updated, so expect a big first batch plus a full `uv.lock` regeneration. Worth merging deliberately rather than on autopilot.
- **One red CI run now blocks the whole batch.** Quarantine a bad bump with `exclude-patterns` on the group, or `ignore` at the entry level.
- `[tool.uv] exclude-newer = "7 days"` (`pyproject.toml:66`) will likely delay bumps by a week on top of Dependabot's own 3-day default cooldown, since Dependabot resolves via `uv lock`. Not harmful, just slower than the weekly schedule suggests.
- `commit-message.prefix-development: "dev-deps"` is now largely inert: a mixed prod+dev group commits under `deps`. Left in place; harmless.

Issue Number: N/A
