### PR TITLE
build(deps): migrate dev dependencies to PEP 735 dependency-groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
 version: 2
 updates:
   # Python dependencies. Uses the `uv` ecosystem, not `pip`, so that Dependabot
-  # reads `[tool.uv].dev-dependencies` and keeps `uv.lock` in step with
-  # `pyproject.toml`. The `pip` ecosystem does neither.
+  # reads the PEP 735 `[dependency-groups]` dev group and keeps `uv.lock` in
+  # step with `pyproject.toml`. The `pip` ecosystem does neither.
   - package-ecosystem: "uv"
     directory: "/"
     schedule:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ uv run pytest tests/test_kernels/test_stationary.py -v
 uv run pytest tests/test_gps.py::test_conjugate_posterior -v
 ```
 
-Install dev environment: `uv venv && uv sync --extra dev`
+Install dev environment: `uv venv && uv sync`
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ configuration in development mode.
 git clone https://github.com/thomaspinder/GPJax.git
 cd GPJax
 uv venv
-uv sync --extra dev
+uv sync
 ```
 
 > We recommend you check your installation passes the supplied unit tests:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -75,7 +75,7 @@ you through every detail!
 4.  We use [uv](https://docs.astral.sh/uv/) for packaging and dependency management. Project requirements are in ``pyproject.toml``. To install GPJax with uv, run:
 
   ```bash
-  $ uv sync --extra dev
+  $ uv sync
   ```
 
   At this point we recommend you check your installation passes the supplied unit tests:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -43,7 +43,7 @@ hardware acceleration support as detailed in the
     ```bash
     git clone https://github.com/thomaspinder/GPJax.git
     cd GPJax
-    uv sync --extra dev
+    uv sync
     ```
 
 !!! tip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,13 @@ docs = [
 [tool.uv]
 exclude-newer = "7 days"
 managed = true
-dev-dependencies = [
+
+# PEP 735 dependency group. Must stay here rather than under `[tool.uv]`:
+# Dependabot's uv parser only reads `dependency-groups`, `project.dependencies`
+# and `project.optional-dependencies`, so `[tool.uv].dev-dependencies` was
+# invisible to it and never got updated.
+[dependency-groups]
+dev = [
   "asv>=0.6",
   "ruff>=0.6",
   "pre-commit>=3.2.2",

--- a/static/CONTRIBUTING.md
+++ b/static/CONTRIBUTING.md
@@ -75,7 +75,7 @@ you through every detail!
 4.  We use [uv](https://docs.astral.sh/uv/) for packaging and dependency management. Project requirements are in ``pyproject.toml``. To install GPJax into a uv virtual environment, run:
 
   ```bash
-  $ uv sync --extra dev
+  $ uv sync
   ```
 
   At this point we recommend you check your installation passes the supplied unit tests:


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `uv run poe format` before committing. — `poe lint-ci` clean
- [x] I've added tests for new code. — N/A, config/docs only
- [x] I've added docstrings for the new code. — N/A, no code

## Description

Follow-up to #732. Two related fixes.

**1. Dependabot has never updated the dev tooling.**

#732 switched the Python ecosystem to `uv` on the stated grounds that it would pick up `[tool.uv].dev-dependencies`. The first post-merge run (#734) disproved that: 23 packages bumped, no dev tooling, and the dev tooling is genuinely stale.

| package | uv.lock | PyPI |
| --- | --- | --- |
| ruff | 0.14.14 | 0.16.0 |
| poethepoet | 0.40.0 | 0.48.0 |
| hypothesis | 6.151.2 | 6.161.6 |
| pytest | 9.0.2 | 9.1.1 |
| asv | 0.6.5 | 0.6.6 |

Dependabot's uv parser reads only these pyproject keys:

```
build-system.requires
project.dependencies
project.optional-dependencies
tool.poetry              (poetry compat)
dependency-groups        (PEP 735)
```

`tool.uv` is consulted solely for `sources`. See [`pyproject_files_parser.rb`](https://github.com/dependabot/dependabot-core/blob/main/uv/lib/dependabot/uv/file_parser/pyproject_files_parser.rb) and [`helpers/lib/parser.py:145-149`](https://github.com/dependabot/dependabot-core/blob/main/uv/helpers/lib/parser.py). `[tool.uv].dev-dependencies` is uv's legacy pre-PEP-735 location and is never parsed.

This moves the 19 entries verbatim to `[dependency-groups].dev`. uv itself already flags the old form:

```
warning: The `tool.uv.dev-dependencies` field (used in `pyproject.toml`) is deprecated
and will be removed in a future release; use `dependency-groups.dev` instead
```

**2. The documented install command is broken.**

`uv sync --extra dev` appears in `README.md`, `CLAUDE.md`, `docs/contributing.md`, `docs/installation.md` and `static/CONTRIBUTING.md`, but no `dev` extra has ever existed — `[project.optional-dependencies]` defines only `docs`. The command fails today. Since uv installs the `dev` group by default, the correct form is plain `uv sync`.

## Verification

- **`uv lock` reproduces `uv.lock` byte for byte.** Pure relocation, zero resolution change — `uv.lock` is not in this diff at all.
- **CI is unaffected.** Every workflow uses `uv sync --frozen` (no extra). Ran that exact command; the dev group installs by default and `ruff`, `pytest`, `asv`, `poe` all resolve in `.venv/bin`.
- **`uv run poe lint-ci`** — 141 files formatted, all checks passed.
- **`uv run poe test`** — 2672 passed, 1 skipped.
- **PEP 735 detection satisfied**: `dependency-groups` is now a top-level key, which is exactly the condition Dependabot's `using_pep735?` tests. 19 packages preserved, `tool.uv` reduced to `exclude-newer` + `managed`.

## Notes

- `.github/dependabot.yml`'s header comment claimed Dependabot reads `[tool.uv].dev-dependencies`. Corrected to reference `[dependency-groups]`.
- Expect the next Dependabot run to open a second, larger `python-dependencies` PR once the dev group becomes visible.
- `AGENTS.md` carries the same broken `uv sync --extra dev` line but is gitignored, so it is not in this PR. I fixed it locally.

Issue Number: N/A
