### PR TITLE
test(kernels): drop dead parametrize marks from test_init fixture

### DIFF
--- a/tests/test_kernels/test_nonstationary.py
+++ b/tests/test_kernels/test_nonstationary.py
@@ -71,10 +71,9 @@ def kernel_request(
     return kernel, params, variance
 
 
-@pytest.mark.parametrize(
-    "kernel, params", [(cls, p) for cls, params in TESTED_KERNELS for p in params]
-)
-@pytest.mark.parametrize("variance", VARIANCES)
+# NOTE: no marks here. `kernel`, `params` and `variance` are supplied by the
+# parametrize marks on each consuming test. Marking a fixture is a no-op and is
+# a hard error from pytest 9.1.
 @pytest.fixture
 def test_init(kernel_request):
     kernel, params, variance = kernel_request


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `uv run poe format` before committing. — `poe lint-ci` clean
- [x] I've added tests for new code. — N/A, removes dead decorators
- [x] I've added docstrings for the new code. — N/A

## Description

Unblocks #736 (`pytest 9.0.2 -> 9.1.1`), which currently fails every matrix job.

`test_init` in `tests/test_kernels/test_nonstationary.py` is a **fixture**, consumed by `test_gram` and `test_cross_covariance`. It also carried two `@pytest.mark.parametrize` decorators:

```python
@pytest.mark.parametrize("kernel, params", ...)
@pytest.mark.parametrize("variance", VARIANCES)
@pytest.fixture
def test_init(kernel_request):
```

Marks on a fixture have never done anything — pytest silently ignored them. Both consumers already parametrize `kernel`, `params` and `variance` themselves, so the marks were pure dead weight.

pytest 9.1 promotes this to a hard collection error:

```
Failed: Marks cannot be applied to fixtures.
See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
```

Collection aborts for the entire file (`Interrupted: 1 error during collection`), so #736 fails on all six matrix jobs.

## Verification

Reproduced #736's environment exactly (`pytest==9.1.1`, `pytest-cov==7.1.0`, `coverage==7.15.2`, `xdoctest==1.3.2`, `asv==0.6.6`, `codespell==2.4.3`, `poethepoet==0.48.0`):

- `tests/test_kernels/test_nonstationary.py` — **297 passed** (was: collection error).
- Full suite under those versions — **2682 passed, 2 skipped**. Since the collection error previously aborted the run, other pytest 9.1 incompatibilities could have been masked; there are none.
- On current pinned pytest 9.0.2 — 297 passed, no behaviour change.
- `uv run poe lint-ci` — clean.

## Note

Scanned the whole test tree for the same pattern; this was the only occurrence.

Issue Number: N/A
