### PR TITLE
docs: serve the documentation from gpjax.quantclimate.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 [**Quickstart**](#simple-example)
 | [**Install guide**](#installation)
-| [**Documentation**](https://docs.quantclimate.com/)
+| [**Documentation**](https://gpjax.quantclimate.com/)
 | [**Slack Community**](https://join.slack.com/t/gpjax/shared_invite/zt-3cesiykcx-nzajjRdnV3ohw7~~eMlCYA)
 
 GPJax aims to provide a low-level interface to Gaussian process (GP) models in
@@ -47,7 +47,7 @@ As a contributor to GPJax, you are expected to abide by our [code of
 conduct](docs/CODE_OF_CONDUCT.md). If you feel that you have either experienced or
 witnessed behaviour that violates this standard, then we ask that you report any such
 behaviours through [this form](https://jaxgaussianprocesses.com/contact/) or reach out to
-one of the project's [_gardeners_](https://docs.quantclimate.com/GOVERNANCE.html#roles).
+one of the project's [_gardeners_](https://gpjax.quantclimate.com/GOVERNANCE.html#roles).
 
 Feel free to join our [Slack
 Channel](https://join.slack.com/t/gpjax/shared_invite/zt-3cesiykcx-nzajjRdnV3ohw7~~eMlCYA),
@@ -62,22 +62,22 @@ GPJax into the package it is today.
 
 ## Notebook examples
 
-> - [**Conjugate Inference**](https://docs.quantclimate.com/examples/regression.html)
-> - [**Classification**](https://docs.quantclimate.com/examples/classification.html)
-> - [**Sparse Variational Inference**](https://docs.quantclimate.com/examples/collapsed_vi.html)
-> - [**Stochastic Variational Inference**](https://docs.quantclimate.com/examples/uncollapsed_vi.html)
-> - [**Laplace Approximation**](https://docs.quantclimate.com/examples/classification.html#laplace-approximation)
-> - [**Inference on Non-Euclidean Spaces**](https://docs.quantclimate.com/examples/constructing_new_kernels.html#custom-kernel)
-> - [**Inference on Graphs**](https://docs.quantclimate.com/examples/graph_kernels.html)
-> - [**Heteroscedastic Inference**](https://docs.quantclimate.com/examples/heteroscedastic_inference.html)
-> - [**Learning Gaussian Process Barycentres**](https://docs.quantclimate.com/examples/barycentres.html)
-> - [**Deep Kernel Regression**](https://docs.quantclimate.com/examples/deep_kernels.html)
-> - [**Poisson Regression**](https://docs.quantclimate.com/examples/poisson.html)
+> - [**Conjugate Inference**](https://gpjax.quantclimate.com/examples/regression.html)
+> - [**Classification**](https://gpjax.quantclimate.com/examples/classification.html)
+> - [**Sparse Variational Inference**](https://gpjax.quantclimate.com/examples/collapsed_vi.html)
+> - [**Stochastic Variational Inference**](https://gpjax.quantclimate.com/examples/uncollapsed_vi.html)
+> - [**Laplace Approximation**](https://gpjax.quantclimate.com/examples/classification.html#laplace-approximation)
+> - [**Inference on Non-Euclidean Spaces**](https://gpjax.quantclimate.com/examples/constructing_new_kernels.html#custom-kernel)
+> - [**Inference on Graphs**](https://gpjax.quantclimate.com/examples/graph_kernels.html)
+> - [**Heteroscedastic Inference**](https://gpjax.quantclimate.com/examples/heteroscedastic_inference.html)
+> - [**Learning Gaussian Process Barycentres**](https://gpjax.quantclimate.com/examples/barycentres.html)
+> - [**Deep Kernel Regression**](https://gpjax.quantclimate.com/examples/deep_kernels.html)
+> - [**Poisson Regression**](https://gpjax.quantclimate.com/examples/poisson.html)
 
 ## Guides for customisation
 >
-> - [**Custom kernels**](https://docs.quantclimate.com/examples/constructing_new_kernels.html#custom-kernel)
-> - [**UCI regression**](https://docs.quantclimate.com/examples/yacht.html)
+> - [**Custom kernels**](https://gpjax.quantclimate.com/examples/constructing_new_kernels.html#custom-kernel)
+> - [**UCI regression**](https://gpjax.quantclimate.com/examples/yacht.html)
 
 ## Conversion between `.ipynb` and `.py`
 Above examples are stored in [examples](docs/examples) directory in the double

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 [**Quickstart**](#simple-example)
 | [**Install guide**](#installation)
-| [**Documentation**](https://docs.jaxgaussianprocesses.com/)
+| [**Documentation**](https://docs.quantclimate.com/)
 | [**Slack Community**](https://join.slack.com/t/gpjax/shared_invite/zt-3cesiykcx-nzajjRdnV3ohw7~~eMlCYA)
 
 GPJax aims to provide a low-level interface to Gaussian process (GP) models in
@@ -47,7 +47,7 @@ As a contributor to GPJax, you are expected to abide by our [code of
 conduct](docs/CODE_OF_CONDUCT.md). If you feel that you have either experienced or
 witnessed behaviour that violates this standard, then we ask that you report any such
 behaviours through [this form](https://jaxgaussianprocesses.com/contact/) or reach out to
-one of the project's [_gardeners_](https://docs.jaxgaussianprocesses.com/GOVERNANCE.html#roles).
+one of the project's [_gardeners_](https://docs.quantclimate.com/GOVERNANCE.html#roles).
 
 Feel free to join our [Slack
 Channel](https://join.slack.com/t/gpjax/shared_invite/zt-3cesiykcx-nzajjRdnV3ohw7~~eMlCYA),
@@ -62,22 +62,22 @@ GPJax into the package it is today.
 
 ## Notebook examples
 
-> - [**Conjugate Inference**](https://docs.jaxgaussianprocesses.com/examples/regression.html)
-> - [**Classification**](https://docs.jaxgaussianprocesses.com/examples/classification.html)
-> - [**Sparse Variational Inference**](https://docs.jaxgaussianprocesses.com/examples/collapsed_vi.html)
-> - [**Stochastic Variational Inference**](https://docs.jaxgaussianprocesses.com/examples/uncollapsed_vi.html)
-> - [**Laplace Approximation**](https://docs.jaxgaussianprocesses.com/examples/classification.html#laplace-approximation)
-> - [**Inference on Non-Euclidean Spaces**](https://docs.jaxgaussianprocesses.com/examples/constructing_new_kernels.html#custom-kernel)
-> - [**Inference on Graphs**](https://docs.jaxgaussianprocesses.com/examples/graph_kernels.html)
-> - [**Heteroscedastic Inference**](https://docs.jaxgaussianprocesses.com/examples/heteroscedastic_inference.html)
-> - [**Learning Gaussian Process Barycentres**](https://docs.jaxgaussianprocesses.com/examples/barycentres.html)
-> - [**Deep Kernel Regression**](https://docs.jaxgaussianprocesses.com/examples/deep_kernels.html)
-> - [**Poisson Regression**](https://docs.jaxgaussianprocesses.com/examples/poisson.html)
+> - [**Conjugate Inference**](https://docs.quantclimate.com/examples/regression.html)
+> - [**Classification**](https://docs.quantclimate.com/examples/classification.html)
+> - [**Sparse Variational Inference**](https://docs.quantclimate.com/examples/collapsed_vi.html)
+> - [**Stochastic Variational Inference**](https://docs.quantclimate.com/examples/uncollapsed_vi.html)
+> - [**Laplace Approximation**](https://docs.quantclimate.com/examples/classification.html#laplace-approximation)
+> - [**Inference on Non-Euclidean Spaces**](https://docs.quantclimate.com/examples/constructing_new_kernels.html#custom-kernel)
+> - [**Inference on Graphs**](https://docs.quantclimate.com/examples/graph_kernels.html)
+> - [**Heteroscedastic Inference**](https://docs.quantclimate.com/examples/heteroscedastic_inference.html)
+> - [**Learning Gaussian Process Barycentres**](https://docs.quantclimate.com/examples/barycentres.html)
+> - [**Deep Kernel Regression**](https://docs.quantclimate.com/examples/deep_kernels.html)
+> - [**Poisson Regression**](https://docs.quantclimate.com/examples/poisson.html)
 
 ## Guides for customisation
 >
-> - [**Custom kernels**](https://docs.jaxgaussianprocesses.com/examples/constructing_new_kernels.html#custom-kernel)
-> - [**UCI regression**](https://docs.jaxgaussianprocesses.com/examples/yacht.html)
+> - [**Custom kernels**](https://docs.quantclimate.com/examples/constructing_new_kernels.html#custom-kernel)
+> - [**UCI regression**](https://docs.quantclimate.com/examples/yacht.html)
 
 ## Conversion between `.ipynb` and `.py`
 Above examples are stored in [examples](docs/examples) directory in the double

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-docs.jaxgaussianprocesses.com
+docs.quantclimate.com

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,1 @@
-docs.quantclimate.com
+gpjax.quantclimate.com

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -297,7 +297,7 @@ html_theme = "shibuya"
 html_title = "GPJax"
 # Sitemap, canonical link, og:url and the absolute og:image URL all derive from
 # this, so it must match the domain GitHub Pages is actually serving (docs/CNAME).
-html_baseurl = "https://docs.quantclimate.com/"
+html_baseurl = "https://gpjax.quantclimate.com/"
 sitemap_url_scheme = "{link}"
 html_static_path = ["stylesheets"]
 html_css_files = ["extra.css"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -295,7 +295,9 @@ intersphinx_mapping = {
 # -- HTML output -------------------------------------------------------------
 html_theme = "shibuya"
 html_title = "GPJax"
-html_baseurl = "https://docs.jaxgaussianprocesses.com/"  # for sitemap + canonical
+# Sitemap, canonical link, og:url and the absolute og:image URL all derive from
+# this, so it must match the domain GitHub Pages is actually serving (docs/CNAME).
+html_baseurl = "https://docs.quantclimate.com/"
 sitemap_url_scheme = "{link}"
 html_static_path = ["stylesheets"]
 html_css_files = ["extra.css"]
@@ -367,7 +369,8 @@ html_context = {
 }
 
 # -- Redirects from the retired MkDocs site (sphinx-reredirects) -------------
-# docs.jaxgaussianprocesses.com served the MkDocs site with `use_directory_urls`
+# The retired MkDocs site (then at docs.jaxgaussianprocesses.com) ran with
+# `use_directory_urls`
 # (the default), so every old page lived at `<path>/`, i.e. the file
 # `<path>/index.html`. The keys below therefore end in `/index`, which is what
 # puts the emitted meta-refresh stub exactly where the old URL pointed.

--- a/legacy-docs-redirect/README.md
+++ b/legacy-docs-redirect/README.md
@@ -1,0 +1,57 @@
+# Legacy docs domain redirect
+
+The documentation moved to `gpjax.quantclimate.com` (GitHub Pages). This
+directory is the entire contents of the Netlify site that keeps the **old**
+host, `docs.jaxgaussianprocesses.com`, alive as a permanent redirect.
+
+It is not part of the docs build and is not deployed by CI. It is deployed by
+hand, once, and then only again if the redirect target changes.
+
+## Why this exists
+
+GitHub Pages serves exactly one custom domain per site, so it cannot answer for
+both hosts. Without this, every published link to the old domain 404s — the JOSS
+paper, the PyPI project page, search results, and any third-party citation.
+
+## Deploying it
+
+> [!WARNING]
+> Deploy this to the Netlify site that serves **`docs.jaxgaussianprocesses.com`**.
+> That is a different site from the one serving the `jaxgaussianprocesses.com`
+> apex and `www` (the marketing site). Deploying this bundle to the marketing
+> site would replace it with a redirect to the GPJax docs.
+>
+> Confirm before deploying — `netlify sites:list`, then check which site claims
+> the `docs.` subdomain under Domain management.
+
+The docs site is the same one this repo already uses for PR previews, i.e. the
+site behind the `NETLIFY_SITE_ID` repository secret.
+
+```bash
+npx --yes netlify-cli@latest deploy \
+  --prod \
+  --dir=legacy-docs-redirect \
+  --site="<site-id>" \
+  --message="301 legacy docs host to gpjax.quantclimate.com"
+```
+
+`--prod` is correct **here** and only here: this is a deliberate, manual
+replacement of that site's production deploy. It must never appear in
+`.github/workflows/test_docs.yml`, whose preview step uses `--alias` so a pull
+request can never overwrite a production deploy.
+
+Deploying this does not affect PR previews. Those are alias deploys at
+`pr-<n>--<site>.netlify.app` and are independent of the production deploy.
+
+## Verifying
+
+```bash
+# Expect: 301, and a Location on the new host with the path preserved.
+curl -sI https://docs.jaxgaussianprocesses.com/examples/regression.html \
+  | grep -iE '^HTTP|^location'
+
+# Expect: the same, through an old MkDocs-era URL. The new site's reredirect
+# stub then completes the hop to /examples/classification.html.
+curl -sI https://docs.jaxgaussianprocesses.com/_examples/classification/ \
+  | grep -iE '^HTTP|^location'
+```

--- a/legacy-docs-redirect/_redirects
+++ b/legacy-docs-redirect/_redirects
@@ -1,0 +1,18 @@
+# Netlify redirect rules for the RETIRED docs host, docs.jaxgaussianprocesses.com.
+#
+# `:splat` carries the whole matched path across, so deep links survive:
+#   /examples/regression.html          -> /examples/regression.html
+#   /_examples/classification/         -> /_examples/classification/
+#
+# That second form matters. Old MkDocs URLs are still in the wild, and the new
+# site ships 87 sphinx-reredirects stubs for exactly those paths — so the chain
+# is: legacy host -> (301, path preserved) -> new host -> stub -> final page.
+# Rewriting paths here would break that, which is why this is a bare wildcard.
+#
+# URL fragments are not sent to the server; browsers reattach them after a
+# redirect, so `#laplace-approximation` style deep links survive too.
+#
+# `301!` — permanent, and the `!` forces the rule even if a file of the same
+# name exists in the deploy. This directory contains no other files, so the
+# force is belt-and-braces against a stale build lingering on the site.
+/*    https://gpjax.quantclimate.com/:splat    301!

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ dev = [
 
 
 [project.urls]
-Documentation = "https://docs.jaxgaussianprocesses.com/"
+Documentation = "https://docs.quantclimate.com/"
 Issues = "https://github.com/thomaspinder/GPJax/issues"
 Source = "https://github.com/thomaspinder/GPJax"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ dev = [
 
 
 [project.urls]
-Documentation = "https://docs.quantclimate.com/"
+Documentation = "https://gpjax.quantclimate.com/"
 Issues = "https://github.com/thomaspinder/GPJax/issues"
 Source = "https://github.com/thomaspinder/GPJax"
 


### PR DESCRIPTION
Repoints the published documentation at `gpjax.quantclimate.com`, matching the `<project>.quantclimate.com` convention that Impulso will also adopt.

GitHub Pages serves exactly **one** custom domain per site, so this is a move, not an addition — hence the redirect bundle below.

## What changed

| File | Why it matters |
|---|---|
| `docs/CNAME` | Copied to the site root via `html_extra_path`; the hostname Pages is told to serve |
| `docs/conf.py` (`html_baseurl`) | Drives the sitemap, the canonical link, `og:url` and the absolute `og:image` URL |
| `pyproject.toml` | The `Documentation` project URL shown on PyPI |
| `README.md` | 15 documentation links |
| `legacy-docs-redirect/` | **New.** The Netlify site contents that keep the old host alive as a 301 |

Verified in a clean build: deployed `CNAME`, `<link rel="canonical">`, `og:url`, `og:image` and every `<loc>` in `sitemap.xml` carry the new domain, and no reference to any previous docs host survives in `docs/_build/html`.

**Deliberately not changed:** the three `https://jaxgaussianprocesses.com/contact/` links in `README.md`, `GOVERNANCE.md` and `CODE_OF_CONDUCT.md` — that is the separate marketing site, not the docs host.

## Not losing the existing traffic

`docs.jaxgaussianprocesses.com` is where the JOSS paper, PyPI, search results and every third-party citation point. `legacy-docs-redirect/_redirects` is a bare wildcard:

```
/*    https://gpjax.quantclimate.com/:splat    301!
```

The path is carried through unchanged on purpose. Old MkDocs-era URLs are still in circulation, and the new site ships 87 `sphinx-reredirects` stubs keyed on exactly those paths, so the chain completes:

`/_examples/classification/` on the old host → same path on the new host → reredirect stub → `/examples/classification.html`

Rewriting paths in the redirect would break that. URL fragments are never sent to the server and are reattached by the browser, so `#laplace-approximation` deep links survive too.

It is deployed by hand, once, and never by CI. `--prod` belongs in that one manual command and must never reach the PR preview step, which uses `--alias` specifically so a pull request cannot overwrite a production deploy. PR previews are unaffected — they are alias deploys at `pr-<n>--<site>.netlify.app`.

## Deployment notes — order matters

Merging this alone will not move the site, and merging before DNS is ready would take the docs offline: once a custom domain is set, Pages 301-redirects `thomaspinder.github.io/GPJax` to it, and that URL is currently the only working copy of the new docs.

1. **Porkbun** — replace the parked `gpjax` record with a CNAME to `thomaspinder.github.io`
2. Wait for it to resolve
3. **Set the Pages custom domain** to `gpjax.quantclimate.com`
4. Merge this PR so the next deploy carries the matching `html_baseurl`
5. Enable *Enforce HTTPS* once the certificate provisions
6. Deploy `legacy-docs-redirect/` to the Netlify site serving the old docs host

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXcSotTJspF11tgaJfrXrZ