### PR TITLE
feat!: v1.0 conditioning architecture — JointModel, Posterior, condition [stack 2/10]

### DIFF
--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -3,8 +3,14 @@ name: "Security Analysis"
 on:
   push:
     branches: [ "main" ]
+  # Deliberately unfiltered: the two jobs below are required contexts on `main`,
+  # and a `branches: [main]` filter here meant they only ever reported on PRs
+  # that already targeted `main`. Stacked PRs — which target their predecessor,
+  # not `main` — produced 16 checks instead of 18, so the whole of a stack got
+  # reviewed and approved without ever being secret- or dependency-scanned; the
+  # gate first fired at retarget time, after review. Scan the code, not the
+  # target branch.
   pull_request:
-    branches: [ "main" ]
   schedule:
     - cron: '30 4 * * 1'  # Weekly on Mondays at 4:30 AM UTC
 

--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -81,4 +81,18 @@ jobs:
       uses: trufflesecurity/trufflehog@main
       with:
         path: ./
-        extra_args: --debug --only-verified
+        # `--exclude-detectors=lob`: TruffleHog's Lob key pattern is
+        # `(live|test)_` followed by 35 more characters, which matches any
+        # pytest function name that happens to be exactly 40 characters long —
+        # and its verifier then reports those as *verified*, so `--only-verified`
+        # does not filter them out. Four real examples in this repo:
+        # test_fit_natgrads_accepts_optax_schedule,
+        # test_dual_natgrad_matches_salimbeni_step,
+        # test_dual_working_matrices_reconstruct_r,
+        # test_prior_kl_matches_textbook_reference.
+        # Reproduced standalone: a fresh repo containing only one of those names
+        # yields `Lob verified=true`. Since `Secrets Detection` is a required
+        # context on `main`, leaving this on means an arbitrary, length-dependent
+        # subset of PRs can never merge. GPJax has no Lob (direct-mail API)
+        # integration, so excluding the detector costs no real coverage.
+        extra_args: --debug --only-verified --exclude-detectors=lob

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,62 @@
+# GPJax domain glossary
+
+The ubiquitous language of this codebase. Code, docs, tests, and reviews use
+these terms exactly; when a concept is missing, add it here in the same PR
+that introduces it.
+
+## Design principle
+
+**Maths-first, comprehensible to the maths-familiar non-expert.** API names
+follow the textbook equation unless the textbook word is jargon a
+practitioner would not own. When the two conflict, choose the word a
+scikit-learn/PyMC user already speaks and state the maths once in the
+docstring (e.g. the class is `JointModel`, and its docstring says "the joint
+distribution p(f, y)").
+
+## Terms
+
+**Prior** — the Gaussian process prior p(f), pairing a kernel with a mean
+function. Queryable at any inputs: `prior(x)` returns the prior predictive.
+Owns the model's single numerical-stabilisation knob, `jitter`.
+
+**Likelihood** — the conditional distribution p(y | f). A *pure* conditional:
+it holds no priors, no dataset facts, and no data sizes. (Both were tried and
+removed at v1.0 — see ADR-0001.)
+
+**JointModel** — the joint distribution p(f, y) = p(y | f) · p(f), created by
+`prior * likelihood`. The *trainable* object: `gpx.fit` optimises its
+hyperparameters. It carries state that must exist before conditioning
+(hyperparameters; the non-conjugate latent; the heteroscedastic noise-process
+model) and no derived quantities. Concrete kinds: `ConjugateModel`,
+`NonConjugateModel`, `HeteroscedasticModel` — each holds state the others
+cannot.
+
+**condition** — the operation p(f, y) + 𝒟 → p(f | 𝒟), spelled
+`model.condition(D)` or the operator form `model | D` (read: "f given D").
+Signatures follow the maths: models take data; already-fit variational
+families will condition without arguments (post-natgrads stack PR).
+
+**Posterior** — the conditioned process p(f | 𝒟) returned by `condition`. An
+*immutable* pytree: the training-covariance factorisation is computed once and
+cached; every query is a view of it. The uniform query surface:
+`posterior(xtest, covariance="dense"|"diagonal")`, plus per-mode views —
+`log_marginal_likelihood` / `loo` / `sample_approx` on the exact mode,
+`log_posterior_density` on the latent mode. Users never name the concrete
+implementations behind the interface.
+
+**evidence / log marginal likelihood** — p(𝒟), the normalising constant of
+conditioning, exposed as `posterior.log_marginal_likelihood`. "Evidence" and
+"marginal likelihood" are the same quantity; the attribute uses the
+GP-community's term.
+
+**sugar** — a documented one-line composition kept for ergonomics, never a
+second implementation. `model.predict(x, D)` and `model(x, D)` are sugar for
+`model.condition(D)(x)`; `model | D` is sugar for `model.condition(D)`.
+
+**objective** — a scalar function `(model, Dataset) -> ScalarFloat` consumed
+by `gpx.fit`. Objectives are thin: `conjugate_mll` is the evidence view of
+the conditioned posterior, not a second derivation.
+
+**Dataset** — the data container. `n_total` records the full-dataset size
+when the object is a minibatch view (stamped by `get_batch`); the minibatch
+ELBO scale is derived from it, never supplied by hand.

--- a/benchmarks/compile.py
+++ b/benchmarks/compile.py
@@ -39,7 +39,7 @@ class CompileSuite:
         kernel = gpx.kernels.RBF()
         mean = gpx.mean_functions.Zero()
         prior = gpx.gps.Prior(kernel=kernel, mean_function=mean)
-        likelihood = gpx.likelihoods.Gaussian(num_datapoints=n)
+        likelihood = gpx.likelihoods.Gaussian()
         self.posterior = prior * likelihood
         self.q = VariationalGaussian(
             posterior=self.posterior, inducing_inputs=X[:M_INDUCING]

--- a/benchmarks/objectives.py
+++ b/benchmarks/objectives.py
@@ -50,7 +50,7 @@ def _conjugate_posterior(n: int):
     kernel = gpx.kernels.RBF()
     mean = gpx.mean_functions.Zero()
     prior = gpx.gps.Prior(kernel=kernel, mean_function=mean)
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n)
+    likelihood = gpx.likelihoods.Gaussian()
     return prior * likelihood, data
 
 
@@ -157,7 +157,7 @@ class HeteroscedasticElboSuite:
         noise_prior = gpx.gps.Prior(
             kernel=noise_kernel, mean_function=gpx.mean_functions.Zero()
         )
-        likelihood = HeteroscedasticGaussian(num_datapoints=n, noise_prior=noise_prior)
+        likelihood = HeteroscedasticGaussian(noise_prior=noise_prior)
         posterior = signal_prior * likelihood
         Z = data.X[:M_INDUCING]
         self.q = HeteroscedasticVariationalFamily(

--- a/benchmarks/state_space.py
+++ b/benchmarks/state_space.py
@@ -36,9 +36,7 @@ class StateSpaceMllSuite:
             kernel=gpx.kernels.Matern32(lengthscale=1.0, variance=1.0),
         )
         likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.1)
-        self.posterior = StateSpaceConjugateModel(
-            prior=prior, likelihood=likelihood
-        )
+        self.posterior = StateSpaceConjugateModel(prior=prior, likelihood=likelihood)
         self.data = _temporal_dataset(n)
         realise(state_space_mll(self.posterior, self.data))
 

--- a/benchmarks/state_space.py
+++ b/benchmarks/state_space.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import gpjax as gpx
 from gpjax.state_space import StateSpacePrior, state_space_mll
-from gpjax.state_space.gps import StateSpaceConjugatePosterior
+from gpjax.state_space.gps import StateSpaceConjugateModel
 import jax.numpy as jnp
 import jax.random as jr
 
@@ -35,8 +35,8 @@ class StateSpaceMllSuite:
             mean_function=gpx.mean_functions.Zero(),
             kernel=gpx.kernels.Matern32(lengthscale=1.0, variance=1.0),
         )
-        likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=0.1)
-        self.posterior = StateSpaceConjugatePosterior(
+        likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.1)
+        self.posterior = StateSpaceConjugateModel(
             prior=prior, likelihood=likelihood
         )
         self.data = _temporal_dataset(n)

--- a/docs/adr/0001-conditioning-architecture.md
+++ b/docs/adr/0001-conditioning-architecture.md
@@ -1,0 +1,88 @@
+# ADR-0001: The v1.0 conditioning architecture
+
+- **Status:** accepted
+- **Date:** 2026-08-06
+- **Deciders:** Thomas Pinder (design settled in an architecture-review +
+  grilling session; full decision tree recorded there)
+
+## Context
+
+An architecture review (2026-08-06) found that no module owned "condition a
+GP on data": the derivation *stabilise → factor → solve → predictive
+moments* was written out at eleven call sites across `gps.py`,
+`objectives.py`, `variational_families.py`, and `models/oilmm.py`. Fixes
+reached some copies and missed others (the diagonal-predict fix landed in two
+of eleven), jitter had two owners (`Prior.jitter` vs `Posterior.jitter`), so
+`predict` and `conjugate_mll` could factorise *different matrices* for the
+same model, and `conjugate_mll` — the oracle for the Kalman MLL and
+`collapsed_elbo` — had no value-level test of its own.
+
+## Decision
+
+One deep conditioning module, with the public API as its veneer, rolled out
+universally at v1.0:
+
+- `prior * likelihood` returns a **`JointModel`** — the joint p(f, y), the
+  trainable object (`ConjugateModel`, `NonConjugateModel` with a lazily-sized
+  latent, `HeteroscedasticModel` owning the noise-process prior).
+- `model.condition(D)` (operator sugar `model | D`) returns a **`Posterior`**:
+  an immutable pytree caching the factorisation, with the predictive,
+  `log_marginal_likelihood`, `loo`, and pathwise `sample_approx` as views of
+  it. One abstract interface; per-mode internal implementations.
+- `prior.jitter` is the single stabilisation knob, applied exactly once,
+  inside conditioning, through `linalg.stabilised_cholesky` (the seed of the
+  linalg deepening).
+- `predict(x, D)` survives as documented one-line sugar. Objectives become
+  one-line views. `return_covariance_type` is renamed `covariance`.
+- Likelihoods are pure conditionals: `num_datapoints` deleted (`Dataset`
+  carries a static `n_total`, stamped by `get_batch`, from which the
+  minibatch ELBO scale is derived) and `noise_prior` moved to
+  `HeteroscedasticModel` (removing the `likelihoods -> gps` circular import).
+- Deleted as failed deletion-tests: `AbstractPrior` (one-adapter seam),
+  `AbstractPosterior` (splits into JointModel/Posterior), the
+  `LatentPosterior` and `ChainedPosterior` markers.
+- Universality is a property of the **v1.0 release**, assembled from stacked
+  PRs: safety net → core conditioning → variational universalisation. The
+  variational PR is sequenced **after** the natural-gradients stack
+  (#714–#730) merges, since that stack rewrites `variational_families.py`;
+  until then the families keep their `posterior` field name and their own
+  predict derivations (renamed mechanically only).
+
+The safety net landed first, in its own PR: closed-form oracles for the MLL,
+predict, and LOOCV; cross-derivation equivalence pins; and an integration
+harness whose failures actually raise.
+
+## Rejected alternatives
+
+- **Dropping the JointModel object** ("just `prior.condition(data,
+  likelihood)`"): the trainable/derived split is load-bearing. `fit` needs a
+  named pytree of everything trainable; the Posterior carries derived cache
+  that a gradient step must never touch. Any container invented to make
+  `fit` ergonomic *is* the JointModel under another name.
+- **Staged or partial public rollout**: a patchy API (some objects
+  conditioning, others not) was ruled out; stacking PRs into one v1.0 release
+  achieves universality without a big-bang branch.
+- **Prior inside the likelihood**: the codebase already ran this experiment —
+  `HeteroscedasticGaussian.noise_prior` produced circular ownership across
+  three modules. Priors live in models; likelihoods stay conditional
+  families.
+- **Keeping `num_datapoints`**: only four real reads existed; nothing
+  validated the value, so a wrong one silently mis-scaled the ELBO; no major
+  GP library puts dataset size on likelihoods (research:
+  `plans/2026-08-06-drop-num-datapoints-research.md`).
+- **Naming the joint `Model`** (rejected in favour of `JointModel`): the
+  prefix self-documents the maths and answers "why can't I predict with this
+  yet?"; "model" remains in the name for practitioners.
+
+## Consequences
+
+- Locality: one home for the algebra; the two-owner jitter bug is
+  structurally impossible; `sample_approx` reuses the same factor as
+  `predict` and refuses multi-output loudly instead of broadcasting wrongly.
+- The evidence is cached with the factorisation, so repeated
+  predict-then-score workflows stop re-factorising.
+- Breaking changes at v1.0 are recorded in `docs/migration.md`; the
+  vocabulary lives in `CONTEXT.md`.
+- Follow-ups tracked for the stack: variational universalisation
+  (post-natgrads), the linalg structure-preserving deepening, one training
+  loop with stepper adapters, and the compute-engine seam.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,6 +72,7 @@ default_role = "literal"
 
 exclude_patterns = [
     "_build",
+    "adr/*",  # ADRs are in-repo records, not (yet) part of the docs site
     "Thumbs.db",
     ".DS_Store",
     "conf.py",  # this config module is not a document
@@ -181,8 +182,14 @@ nb_execution_show_tb = True
 # Everything else (broken xrefs, bad anchors, malformed directives) stays fatal
 # on deploy, which it was not when that build ran without `-W` at all.
 # The PR gate suppresses nothing.
+# codeautolink cannot match doctest blocks carrying `# doctest: +SKIP` markers
+# against their rendered HTML (a matcher limitation, not a doc defect — xdoctest
+# validates the examples). Suppressed on every path; predates the v1.0 stack but
+# first surfaced when this workflow ran cold post-Sphinx-migration.
+suppress_warnings = ["codeautolink.match_block"]
+
 if os.environ.get("GPJAX_DOCS_RESILIENT") == "1":
-    suppress_warnings = [
+    suppress_warnings = suppress_warnings + [
         "mystnb.exec",  # execution failure + "traceback saved in:" follow-up
         "mystnb.glue",  # a glue key that never got produced by a failed notebook
         # A notebook that fails to execute renders with no outputs, and MyST-NB

--- a/docs/examples/backend.py
+++ b/docs/examples/backend.py
@@ -157,7 +157,7 @@ meanf = gpx.mean_functions.Constant()
 
 prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
 
-likelihood = gpx.likelihoods.Gaussian(100)
+likelihood = gpx.likelihoods.Gaussian()
 posterior = likelihood * prior
 print(posterior)
 

--- a/docs/examples/barycentres.py
+++ b/docs/examples/barycentres.py
@@ -132,7 +132,7 @@ cols = plt.rcParams["axes.prop_cycle"].by_key()["color"]
 # ## Dataset
 #
 # We'll simulate five datasets and develop a Gaussian process
-# [posterior](#gpjax.gps.ConjugatePosterior) before
+# [posterior](#gpjax.gps.ConjugateModel) before
 # identifying the Gaussian process barycentre at a set of test points. Each dataset
 # will be a sine function with a different vertical shift, periodicity, and quantity
 # of noise.
@@ -184,7 +184,7 @@ def fit_gp(x: jax.Array, y: jax.Array) -> gpx.distributions.GaussianDistribution
         y = y.reshape(-1, 1)
     D = gpx.Dataset(X=x, y=y)
 
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n)
+    likelihood = gpx.likelihoods.Gaussian()
     posterior = (
         gpx.gps.Prior(
             mean_function=gpx.mean_functions.Constant(), kernel=gpx.kernels.RBF()

--- a/docs/examples/classification.py
+++ b/docs/examples/classification.py
@@ -144,7 +144,7 @@ opt_posterior, history = gpx.fit(
 )
 
 # %% [markdown]
-# From which we can [make predictions](#gpjax.gps.NonConjugateModel.predict) at
+# From which we can [make predictions](#gpjax.gps.JointModel.predict) at
 # novel inputs, as illustrated in {numref}`fig-classification-map-predictive`.
 
 # %% mystnb={"figure": {"caption": "The MAP predictive mean and its one-sigma band over the binary observations.", "name": "fig-classification-map-predictive"}}

--- a/docs/examples/classification.py
+++ b/docs/examples/classification.py
@@ -105,7 +105,7 @@ ax.scatter(x, y)
 kernel = gpx.kernels.RBF()
 meanf = gpx.mean_functions.Constant()
 prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-likelihood = gpx.likelihoods.Bernoulli(num_datapoints=D.n)
+likelihood = gpx.likelihoods.Bernoulli()
 
 # %% [markdown]
 # We construct the posterior through the product of our prior and likelihood.
@@ -144,7 +144,7 @@ opt_posterior, history = gpx.fit(
 )
 
 # %% [markdown]
-# From which we can [make predictions](#gpjax.gps.NonConjugatePosterior.predict) at
+# From which we can [make predictions](#gpjax.gps.NonConjugateModel.predict) at
 # novel inputs, as illustrated in {numref}`fig-classification-map-predictive`.
 
 # %% mystnb={"figure": {"caption": "The MAP predictive mean and its one-sigma band over the binary observations.", "name": "fig-classification-map-predictive"}}

--- a/docs/examples/collapsed_vi.py
+++ b/docs/examples/collapsed_vi.py
@@ -121,7 +121,7 @@ plt.show()
 # %%
 meanf = gpx.mean_functions.Constant()
 kernel = gpx.kernels.RBF()  # 1-dimensional inputs
-likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n)
+likelihood = gpx.likelihoods.Gaussian()
 prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
 posterior = prior * likelihood
 
@@ -242,7 +242,7 @@ plt.show()
 # %%
 full_rank_model = gpx.gps.Prior(
     mean_function=gpx.mean_functions.Zero(), kernel=gpx.kernels.RBF()
-) * gpx.likelihoods.Gaussian(num_datapoints=D.n)
+) * gpx.likelihoods.Gaussian()
 nmll = jit(lambda: -gpx.objectives.conjugate_mll(full_rank_model, D))
 # %timeit nmll().block_until_ready()
 

--- a/docs/examples/constructing_new_kernels.py
+++ b/docs/examples/constructing_new_kernels.py
@@ -287,7 +287,7 @@ D = gpx.Dataset(X=X, y=y)
 # Define polar Gaussian process
 PKern = Polar()
 meanf = gpx.mean_functions.Zero()
-likelihood = gpx.likelihoods.Gaussian(num_datapoints=n)
+likelihood = gpx.likelihoods.Gaussian()
 circular_posterior = gpx.gps.Prior(mean_function=meanf, kernel=PKern) * likelihood
 
 # Optimise GP's marginal log-likelihood using BFGS

--- a/docs/examples/deep_kernels.py
+++ b/docs/examples/deep_kernels.py
@@ -196,7 +196,7 @@ base_kernel = gpx.kernels.Matern52(
 kernel = DeepKernelFunction(network=forward_linear, base_kernel=base_kernel)
 meanf = gpx.mean_functions.Zero()
 prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n)
+likelihood = gpx.likelihoods.Gaussian()
 posterior = prior * likelihood
 # %% [markdown]
 # ### Optimisation

--- a/docs/examples/graph_kernels.py
+++ b/docs/examples/graph_kernels.py
@@ -174,7 +174,7 @@ plt.show()
 # [`fit_scipy`](#gpjax.fit.fit_scipy).
 
 # %%
-likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n)
+likelihood = gpx.likelihoods.Gaussian()
 kernel = gpx.kernels.GraphKernel(laplacian=L)
 prior = gpx.gps.Prior(mean_function=gpx.mean_functions.Zero(), kernel=kernel)
 posterior = prior * likelihood

--- a/docs/examples/heteroscedastic_inference.py
+++ b/docs/examples/heteroscedastic_inference.py
@@ -163,8 +163,9 @@ plt.show()
 # \mathcal{N}\!\big(y_i \mid f(x_i), \exp(g(x_i))\big),
 # $$ (eq-heteroscedastic-likelihood)
 #
-# to form the posterior target that we shall approximate variationally. The product
-# syntax `signal_prior * likelihood` used below constructs this augmented GP model.
+# to form the posterior target that we shall approximate variationally. Because the
+# joint model holds *two* priors — one per latent process — it is constructed
+# directly as a `HeteroscedasticModel` rather than via the two-operand product.
 
 # %%
 # Signal and noise priors.
@@ -176,12 +177,10 @@ noise_prior = gpx.gps.Prior(
     mean_function=gpx.mean_functions.Zero(),
     kernel=gpx.kernels.RBF(),
 )
-likelihood = HeteroscedasticGaussian(
-    num_datapoints=train.n,
-    noise_prior=noise_prior,
-    noise_transform=LogNormalTransform(),
+likelihood = HeteroscedasticGaussian(noise_transform=LogNormalTransform())
+posterior = gpx.gps.HeteroscedasticModel(
+    prior=signal_prior, likelihood=likelihood, noise_prior=noise_prior
 )
-posterior = signal_prior * likelihood
 
 # Variational family over both processes.
 z = jnp.linspace(-3.2, 3.2, 25)[:, None]
@@ -330,12 +329,10 @@ noise_prior_adv = gpx.gps.Prior(
     mean_function=gpx.mean_functions.Zero(),
     kernel=gpx.kernels.RBF(),
 )
-likelihood_adv = HeteroscedasticGaussian(
-    num_datapoints=data_adv.n,
-    noise_prior=noise_prior_adv,
-    noise_transform=SoftplusTransform(),
+likelihood_adv = HeteroscedasticGaussian(noise_transform=SoftplusTransform())
+posterior_adv = gpx.gps.HeteroscedasticModel(
+    prior=mean_prior, likelihood=likelihood_adv, noise_prior=noise_prior_adv
 )
-posterior_adv = mean_prior * likelihood_adv
 
 # %%
 # Configure variational family

--- a/docs/examples/intro_to_kernels.py
+++ b/docs/examples/intro_to_kernels.py
@@ -282,7 +282,7 @@ kernel = gpx.kernels.Matern52(
 prior = gpx.gps.Prior(mean_function=mean, kernel=kernel)
 
 likelihood = gpx.likelihoods.Gaussian(
-    num_datapoints=D.n, obs_stddev=jnp.array(1e-3)
+    obs_stddev=jnp.array(1e-3)
 )  # Our function is noise-free, so we set the observation noise's standard deviation to a very small value
 
 no_opt_posterior = prior * likelihood
@@ -561,7 +561,7 @@ sum_kernel = gpx.kernels.SumKernel(kernels=[linear_kernel, periodic_kernel])
 final_kernel = gpx.kernels.SumKernel(kernels=[rbf_kernel, sum_kernel])
 
 prior = gpx.gps.Prior(mean_function=mean, kernel=final_kernel)
-likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n)
+likelihood = gpx.likelihoods.Gaussian()
 
 posterior = prior * likelihood
 

--- a/docs/examples/likelihoods_guide.py
+++ b/docs/examples/likelihoods_guide.py
@@ -119,7 +119,7 @@ plt.show()
 # argument.
 
 # %%
-gpx.likelihoods.Gaussian(num_datapoints=D.n)
+gpx.likelihoods.Gaussian()
 
 # %% [markdown]
 # ### Likelihood parameters
@@ -134,7 +134,7 @@ gpx.likelihoods.Gaussian(num_datapoints=D.n)
 # this as follows:
 
 # %%
-gpx.likelihoods.Gaussian(num_datapoints=D.n, obs_stddev=0.5)
+gpx.likelihoods.Gaussian(obs_stddev=0.5)
 
 # %% [markdown]
 #
@@ -157,7 +157,7 @@ kernel = gpx.kernels.Matern32()
 meanf = gpx.mean_functions.Zero()
 prior = gpx.gps.Prior(kernel=kernel, mean_function=meanf)
 
-likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n, obs_stddev=0.1)
+likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.1)
 
 posterior = prior * likelihood
 
@@ -187,7 +187,7 @@ for ax in axes.ravel():
 # Similarly, for a Bernoulli likelihood function, the samples of $y$ would be binary.
 
 # %% mystnb={"figure": {"caption": "The same latent draws passed through a Bernoulli likelihood, whose predictive samples are constrained to be binary.", "name": "fig-likelihoods-guide-bernoulli-samples"}}
-likelihood = gpx.likelihoods.Bernoulli(num_datapoints=D.n)
+likelihood = gpx.likelihoods.Bernoulli()
 
 
 fig, axes = plt.subplots(ncols=3, nrows=1, figsize=(9, 2))
@@ -292,7 +292,6 @@ jnp.sum(likelihood.expected_log_likelihood(y=y, mean=mean, variance=variance))
 
 # %%
 lquad = gpx.likelihoods.Gaussian(
-    num_datapoints=D.n,
     obs_stddev=jnp.array([0.1]),
     integrator=gpx.integrators.GHQuadratureIntegrator(num_points=20),
 )

--- a/docs/examples/multioutput.py
+++ b/docs/examples/multioutput.py
@@ -155,7 +155,7 @@ kernel = gpx.kernels.ICMKernel(
 meanf = gpx.mean_functions.Zero()
 prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
 likelihood = gpx.likelihoods.MultiOutputGaussian(
-    num_datapoints=N, num_outputs=P, obs_stddev=1.0
+    num_outputs=P, obs_stddev=1.0
 )
 posterior = prior * likelihood
 
@@ -442,7 +442,7 @@ lcm_kernel = gpx.kernels.LCMKernel(
 meanf_lcm = gpx.mean_functions.Zero()
 prior_lcm = gpx.gps.Prior(mean_function=meanf_lcm, kernel=lcm_kernel)
 likelihood_lcm = gpx.likelihoods.MultiOutputGaussian(
-    num_datapoints=N_lcm, num_outputs=P_lcm, obs_stddev=1.0
+    num_outputs=P_lcm, obs_stddev=1.0
 )
 posterior_lcm = prior_lcm * likelihood_lcm
 

--- a/docs/examples/numpyro_integration.py
+++ b/docs/examples/numpyro_integration.py
@@ -131,7 +131,7 @@ plt.show()
 #
 # We define a NumPyro model that samples all parameters directly using
 # ``numpyro.sample``, builds the GPJax
-# [`ConjugatePosterior`](#gpjax.gps.ConjugatePosterior) from those samples, and
+# [`ConjugateModel`](#gpjax.gps.ConjugateModel) from those samples, and
 # scores it with the conjugate marginal log-likelihood
 # ([`conjugate_mll`](#gpjax.objectives.conjugate_mll)) via ``numpyro.factor``.
 # No special registration step is needed -- GPJax constructors accept raw
@@ -157,7 +157,7 @@ def model(X, Y, X_new=None):
 
     meanf = gpx.mean_functions.Constant()
     prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=N, obs_stddev=obs_noise)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=obs_noise)
     posterior = prior * likelihood
 
     D_resid = gpx.Dataset(X=X, y=residuals)
@@ -199,7 +199,7 @@ example_kernel = gpx.kernels.RBF(lengthscale=1.0, variance=1.0) * gpx.kernels.Pe
 )
 example_posterior = gpx.gps.Prior(
     mean_function=gpx.mean_functions.Constant(), kernel=example_kernel
-) * gpx.likelihoods.Gaussian(num_datapoints=N, obs_stddev=1.0)
+) * gpx.likelihoods.Gaussian(obs_stddev=1.0)
 
 parameter_priors = {
     "prior.kernel.kernels[0].lengthscale": dist.LogNormal(0.0, 1.0),

--- a/docs/examples/oak.py
+++ b/docs/examples/oak.py
@@ -273,7 +273,7 @@ oak_kernel = OrthogonalAdditiveKernel(base_kernels, max_order=3)
 
 mean_function = gpx.mean_functions.Zero()
 prior = gpx.gps.Prior(mean_function=mean_function, kernel=oak_kernel)
-likelihood = gpx.likelihoods.Gaussian(num_datapoints=num_train)
+likelihood = gpx.likelihoods.Gaussian()
 posterior = prior * likelihood
 
 # %%
@@ -286,7 +286,7 @@ opt_posterior, history = gpx.fit_scipy(
 )
 
 latent_dist = opt_posterior.predict(
-    X_test, train_data=train_data, return_covariance_type="diagonal"
+    X_test, train_data=train_data, covariance="diagonal"
 )
 predictive_dist = opt_posterior.likelihood(latent_dist)
 predictive_mean = predictive_dist.mean

--- a/docs/examples/oceanmodelling.py
+++ b/docs/examples/oceanmodelling.py
@@ -334,7 +334,7 @@ class VelocityKernel(gpx.kernels.AbstractKernel):
 def initialise_gp(kernel, mean, dataset):
     prior = gpx.gps.Prior(mean_function=mean, kernel=kernel)
     likelihood = gpx.likelihoods.Gaussian(
-        num_datapoints=dataset.n, obs_stddev=jnp.array([1.0e-3], dtype=jnp.float64)
+        obs_stddev=jnp.array([1.0e-3], dtype=jnp.float64)
     )
     posterior = prior * likelihood
     return posterior

--- a/docs/examples/poisson.py
+++ b/docs/examples/poisson.py
@@ -138,11 +138,12 @@ prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
 likelihood = gpx.likelihoods.Poisson()
 
 # %% [markdown]
-# We construct the [posterior](#gpjax.gps.NonConjugateModel) through the product of our
-# prior and likelihood.
+# We construct the [model](#gpjax.gps.NonConjugateModel) through the product of our
+# prior and likelihood, and initialise the whitened latent vector that MCMC
+# will sample (sized by the training data).
 
 # %%
-posterior = prior * likelihood
+posterior = (prior * likelihood).init_latent(D.n)
 print(type(posterior))
 
 # %% [markdown]

--- a/docs/examples/poisson.py
+++ b/docs/examples/poisson.py
@@ -135,10 +135,10 @@ plt.show()
 kernel = gpx.kernels.RBF()
 meanf = gpx.mean_functions.Constant()
 prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-likelihood = gpx.likelihoods.Poisson(num_datapoints=D.n)
+likelihood = gpx.likelihoods.Poisson()
 
 # %% [markdown]
-# We construct the [posterior](#gpjax.gps.NonConjugatePosterior) through the product of our
+# We construct the [posterior](#gpjax.gps.NonConjugateModel) through the product of our
 # prior and likelihood.
 
 # %%

--- a/docs/examples/regression.py
+++ b/docs/examples/regression.py
@@ -136,11 +136,11 @@ prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
 # the evaluation of the GP's mean and covariance.
 #
 # Since we want to sample from the full posterior, we need to calculate the full covariance matrix.
-# We can enforce this by including the `return_covariance_type = "dense"` attribute when predicting.
+# We can enforce this by including the `covariance = "dense"` attribute when predicting.
 # Note this is what will be defaulted if left blank.
 
 # %% mystnb={"figure": {"caption": "Twenty function samples drawn from the zero-mean RBF prior, shown alongside the prior mean and variance band.", "name": "fig-regression-prior-samples"}}
-prior_dist = prior.predict(xtest, return_covariance_type="dense")
+prior_dist = prior.predict(xtest, covariance="dense")
 
 prior_mean = prior_dist.mean
 prior_std = prior_dist.variance
@@ -181,19 +181,23 @@ plt.show()
 # and what each one assumes about the observations.
 
 # %%
-likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n)
+likelihood = gpx.likelihoods.Gaussian()
 
 # %% [markdown]
-# The posterior is proportional to the prior multiplied by the likelihood, written as
+# The prior and likelihood together define the joint model over the latent
+# function and the observations,
 #
 # $$
-# p(f(\cdot) | \mathcal{D}) \propto p(f(\cdot)) * p(\mathcal{D} | f(\cdot)).
-# $$ (eq-regression-posterior)
+# p(f(\cdot), \mathcal{D}) = p(\mathcal{D} | f(\cdot))\, p(f(\cdot)).
+# $$ (eq-regression-joint)
 #
-# Mimicking this construct, the posterior is established in GPJax through the `*` operator.
+# Mimicking this equation, the joint model is established in GPJax through the
+# `*` operator. Conditioning it on the data — `model.condition(D)`, or the
+# operator form `model | D` that reads as $p(f \mid \mathcal{D})$ — yields the
+# posterior process.
 
 # %%
-posterior = prior * likelihood
+model = prior * likelihood
 
 # %% [markdown]
 # <!-- ## Hyperparameter optimisation
@@ -212,20 +216,20 @@ posterior = prior * likelihood
 # these parameters by optimising the marginal log-likelihood (MLL).
 
 # %%
-print(-gpx.objectives.conjugate_mll(posterior, D))
+print(-gpx.objectives.conjugate_mll(model, D))
 
 # %% [markdown]
 # We can now define an optimiser. For this example we'll use the `bfgs`
 # optimiser.
 
 # %%
-opt_posterior, history = gpx.fit_scipy(
-    model=posterior,
+opt_model, history = gpx.fit_scipy(
+    model=model,
     objective=lambda p, d: -gpx.objectives.conjugate_mll(p, d),
     train_data=D,
 )
 
-print(-gpx.objectives.conjugate_mll(opt_posterior, D))
+print(-gpx.objectives.conjugate_mll(opt_model, D))
 
 # %% [markdown]
 # To inspect the learned hyperparameters, we can render a summary table of the optimised
@@ -234,26 +238,27 @@ print(-gpx.objectives.conjugate_mll(opt_posterior, D))
 # sanity check after optimisation.
 
 # %%
-gpx.summarise(opt_posterior)
+gpx.summarise(opt_model)
 
 # %% [markdown]
 # ## Prediction
 #
 # Equipped with the posterior and a set of optimised hyperparameter values, we are now
 # in a position to query our GP's predictive distribution at novel test inputs. To do
-# this, we use our defined `posterior` and `likelihood` at our test inputs to obtain
-# the predictive distribution as a `Distrax` multivariate Gaussian upon which `mean`
-# and `stddev` can be used to extract the predictive mean and standard deviatation.
+# this, we condition the optimised model on the training data — this factorises
+# the training covariance exactly once and caches it — and then query the
+# resulting posterior process at the test inputs. Pushing the latent
+# distribution through the likelihood yields the predictive distribution, upon
+# which `mean` and `stddev` can be used to extract the predictive mean and
+# standard deviation.
 #
-# We are only concerned here about the variance between the test points and themselves, so
-# we can just copute the diagonal version of the covariance.  We enforce this by using
-# `return_covariance_type = "diagonal"` in the `predict` call.
+# We are only concerned here with the variance at the test points themselves,
+# so we request the diagonal covariance via `covariance="diagonal"`.
 
 # %%
-latent_dist = opt_posterior.predict(
-    xtest, train_data=D, return_covariance_type="diagonal"
-)
-predictive_dist = opt_posterior.likelihood(latent_dist)
+posterior = opt_model.condition(D)  # equivalently: opt_model | D
+latent_dist = posterior(xtest, covariance="diagonal")
+predictive_dist = opt_model.likelihood(latent_dist)
 
 predictive_mean = predictive_dist.mean
 predictive_std = jnp.sqrt(predictive_dist.variance)

--- a/docs/examples/spatial_linear_gp.py
+++ b/docs/examples/spatial_linear_gp.py
@@ -175,7 +175,7 @@ def joint_model(X, Y, X_new=None):
     )
     meanf = gpx.mean_functions.Constant()
     gp_prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=N, obs_stddev=obs_noise)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=obs_noise)
     gp_posterior = gp_prior * likelihood
 
     trend = X @ slope + intercept

--- a/docs/examples/state_space_gps.py
+++ b/docs/examples/state_space_gps.py
@@ -178,7 +178,7 @@ prior = StateSpacePrior(
     mean_function=gpx.mean_functions.Constant(),
     kernel=kernel,
 )
-likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n, obs_stddev=0.5)
+likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.5)
 posterior = prior * likelihood
 
 # %% [markdown]
@@ -446,7 +446,7 @@ def make_loss_callables(num_datapoints, state_space):
     bench_prior = prior_cls(
         mean_function=gpx.mean_functions.Zero(), kernel=bench_kernel
     )
-    bench_lik = gpx.likelihoods.Gaussian(num_datapoints=num_datapoints, obs_stddev=0.1)
+    bench_lik = gpx.likelihoods.Gaussian(obs_stddev=0.1)
     model = bench_prior * bench_lik
     bench_x, bench_y = simulate_dataset(num_datapoints)
     data = gpx.Dataset(X=bench_x, y=bench_y)

--- a/docs/examples/uncollapsed_vi.py
+++ b/docs/examples/uncollapsed_vi.py
@@ -220,7 +220,7 @@ plt.show()
 
 # %%
 meanf = gpx.mean_functions.Zero()
-likelihood = gpx.likelihoods.Gaussian(num_datapoints=n)
+likelihood = gpx.likelihoods.Gaussian()
 kernel = jk.RBF()  # 1-dimensional inputs
 prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
 p = prior * likelihood

--- a/docs/examples/yacht.py
+++ b/docs/examples/yacht.py
@@ -71,7 +71,7 @@ key = jr.key(42)
 # covariates and a single positive, real valued response variable. There are 308
 # observations in the dataset, so we can comfortably use a conjugate regression
 # Gaussian process here, namely a
-# [`ConjugatePosterior`](#gpjax.gps.ConjugatePosterior) (for more more details,
+# [`ConjugateModel`](#gpjax.gps.ConjugateModel) (for more more details,
 # checkout the [Regression notebook](regression.py)).
 
 # %%
@@ -189,7 +189,7 @@ kernel = gpx.kernels.RBF(
 meanf = gpx.mean_functions.Zero()
 prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
 
-likelihood = gpx.likelihoods.Gaussian(num_datapoints=n_train)
+likelihood = gpx.likelihoods.Gaussian()
 
 posterior = prior * likelihood
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -30,7 +30,7 @@ Cholesky factor
 conjugate
 : A prior and likelihood pair for which the posterior has the same form as the
   prior, so it is available in closed form. For Gaussian processes this means a
-  Gaussian likelihood, giving a [`ConjugatePosterior`](#gpjax.gps.ConjugatePosterior)
+  Gaussian likelihood, giving a [`ConjugateModel`](#gpjax.gps.ConjugateModel)
   whose [`conjugate_mll`](#gpjax.objectives.conjugate_mll) needs no approximation.
   Anything else — Bernoulli, Poisson — is non-conjugate, and the latent function
   values must be approximated: by MAP or a Laplace approximation, by

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,9 +18,23 @@ import gpjax as gpx
 mean = gpx.mean_functions.Zero()
 kernel = gpx.kernels.RBF()
 prior = gpx.gps.Prior(mean_function=mean, kernel=kernel)
-likelihood = gpx.likelihoods.Gaussian(num_datapoints=123)
+likelihood = gpx.likelihoods.Gaussian()
 
-posterior = prior * likelihood
+model = prior * likelihood  # the joint p(f, y)
+```
+
+Conditioning the model on data yields the posterior process, which can then
+be queried at any test inputs:
+
+```python
+import jax.numpy as jnp
+
+xtrain = jnp.linspace(0.0, 1.0, 20).reshape(-1, 1)
+D = gpx.Dataset(X=xtrain, y=jnp.sin(xtrain))
+xtest = jnp.linspace(0.0, 1.0, 50).reshape(-1, 1)
+
+posterior = model.condition(D)  # p(f | D) — equivalently: model | D
+predictive = posterior(xtest)
 ```
 
 $$

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -23,8 +23,17 @@ object `gpx.fit` trains. Conditioning it on data yields the posterior
 process, which caches its factorisation and is queried directly:
 
 ```python
-model = prior * likelihood          # JointModel (was: ConjugatePosterior)
-model, history = gpx.fit_scipy(model=model, objective=nmll, train_data=D)
+import gpjax as gpx
+import jax.numpy as jnp
+
+xtrain = jnp.linspace(0.0, 1.0, 20).reshape(-1, 1)
+D = gpx.Dataset(X=xtrain, y=jnp.sin(xtrain))
+xtest = jnp.linspace(0.0, 1.0, 50).reshape(-1, 1)
+prior = gpx.gps.Prior(
+    mean_function=gpx.mean_functions.Zero(), kernel=gpx.kernels.RBF()
+)
+
+model = prior * gpx.likelihoods.Gaussian()  # JointModel (was: ConjugatePosterior)
 posterior = model.condition(D)      # Posterior — equivalently: model | D
 predictive = posterior(xtest)       # was: posterior.predict(xtest, D)
 evidence = posterior.log_marginal_likelihood
@@ -66,8 +75,11 @@ lives on the model, which is constructed directly because it holds two
 priors:
 
 ```python
-model = gpx.gps.HeteroscedasticModel(
-    prior=signal_prior,
+noise_prior = gpx.gps.Prior(
+    mean_function=gpx.mean_functions.Zero(), kernel=gpx.kernels.RBF()
+)
+het_model = gpx.gps.HeteroscedasticModel(
+    prior=prior,
     likelihood=gpx.likelihoods.HeteroscedasticGaussian(),
     noise_prior=noise_prior,
 )

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -8,6 +8,85 @@ Releases not listed here made no breaking changes; see the
 [changelog](gh:blob/main/CHANGELOG.md) for
 the full history.
 
+## 0.18.x → 1.0.0
+
+GPJax `1.0` restructures the core API around **conditioning**: the joint
+model and the conditioned posterior are now distinct objects, and the API
+reads as the maths. The full decision record is
+[ADR-0001](gh:blob/main/docs/adr/0001-conditioning-architecture.md); the
+vocabulary lives in [CONTEXT.md](gh:blob/main/CONTEXT.md).
+
+### The conditioning API
+
+`prior * likelihood` now returns a `JointModel` — the joint p(f, y), the
+object `gpx.fit` trains. Conditioning it on data yields the posterior
+process, which caches its factorisation and is queried directly:
+
+```python
+model = prior * likelihood          # JointModel (was: ConjugatePosterior)
+model, history = gpx.fit_scipy(model=model, objective=nmll, train_data=D)
+posterior = model.condition(D)      # Posterior — equivalently: model | D
+predictive = posterior(xtest)       # was: posterior.predict(xtest, D)
+evidence = posterior.log_marginal_likelihood
+```
+
+`model.predict(xtest, D)` and `model(xtest, D)` remain as documented one-line
+sugar for `model.condition(D)(xtest)` — existing prediction code keeps
+working. When predicting repeatedly, condition once and reuse the returned
+posterior.
+
+### Renames
+
+| 0.18.x | 1.0.0 |
+| --- | --- |
+| `ConjugatePosterior` | `ConjugateModel` |
+| `NonConjugatePosterior` | `NonConjugateModel` |
+| `HeteroscedasticPosterior` / `ChainedPosterior` | `HeteroscedasticModel` |
+| `construct_posterior` | `construct_model` |
+| `AbstractPrior` | folded into `Prior` |
+| `AbstractPosterior` | split into `JointModel` and `Posterior` |
+| `StateSpaceConjugatePosterior` | `StateSpaceConjugateModel` |
+| `return_covariance_type=` kwarg | `covariance=` |
+
+### Likelihoods are pure conditionals
+
+`num_datapoints` is gone from every likelihood constructor:
+
+```python
+likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.1)   # was: Gaussian(num_datapoints=D.n, ...)
+```
+
+The minibatch ELBO scale is now derived from the dataset itself
+(`get_batch` stamps the full size onto each minibatch as `Dataset.n_total`),
+so it can no longer be wrong. `MultiOutputGaussian(num_outputs=P)` likewise
+drops the argument.
+
+`HeteroscedasticGaussian` no longer takes a `noise_prior`; the noise process
+lives on the model, which is constructed directly because it holds two
+priors:
+
+```python
+model = gpx.gps.HeteroscedasticModel(
+    prior=signal_prior,
+    likelihood=gpx.likelihoods.HeteroscedasticGaussian(),
+    noise_prior=noise_prior,
+)
+```
+
+### Non-conjugate latents initialise lazily
+
+`NonConjugateModel` no longer sizes its latent vector at construction (that
+was what `num_datapoints` was for). `gpx.fit` initialises it automatically on
+first contact with the data; to work with the latent before fitting, call
+`model = model.init_latent(D.n)` explicitly.
+
+### One jitter knob
+
+`Prior.jitter` is now the model's single stabilisation knob, applied exactly
+once inside conditioning. The independent `Posterior.jitter` field is gone —
+previously `predict` and `conjugate_mll` could factorise *different*
+matrices when the two knobs diverged.
+
 ## 0.14.x → 0.15.0
 
 GPJax `0.15` adds the `gpjax.state_space` sub-package (state-space / Markovian

--- a/docs/reference/gps.md
+++ b/docs/reference/gps.md
@@ -7,13 +7,24 @@
    :toctree: generated/
    :nosignatures:
 
-   AbstractPosterior
-   AbstractPrior
-   ChainedPosterior
-   ConjugatePosterior
-   HeteroscedasticPosterior
-   LatentPosterior
-   NonConjugatePosterior
+   ConjugateModel
+   HeteroscedasticModel
+   JointModel
+   NonConjugateModel
    Prior
-   construct_posterior
+   construct_model
+```
+
+## Conditioning
+
+```{eval-rst}
+.. currentmodule:: gpjax.conditioning
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   ExactPosterior
+   LatentPosterior
+   Posterior
 ```

--- a/docs/reference/linalg.md
+++ b/docs/reference/linalg.md
@@ -13,4 +13,5 @@
    cholesky_factor
    logdet
    logdet_from_factor
+   stabilised_cholesky
 ```

--- a/docs/reference/state_space.md
+++ b/docs/reference/state_space.md
@@ -7,7 +7,7 @@
    :toctree: generated/
    :nosignatures:
 
-   StateSpaceConjugatePosterior
+   StateSpaceConjugateModel
    StateSpacePrior
    TruncatedPeriodic
    fit

--- a/docs/sharp_bits.md
+++ b/docs/sharp_bits.md
@@ -213,7 +213,7 @@ Which approximation to reach for:
 
 | Data size | Objective | Variational family |
 | --- | --- | --- |
-| Up to a few thousand | [`conjugate_mll`](#gpjax.objectives.conjugate_mll) | none — use [`ConjugatePosterior`](#gpjax.gps.ConjugatePosterior) directly |
+| Up to a few thousand | [`conjugate_mll`](#gpjax.objectives.conjugate_mll) | none — use [`ConjugateModel`](#gpjax.gps.ConjugateModel) directly |
 | Up to ~50,000 | [`collapsed_elbo`](#gpjax.objectives.collapsed_elbo) | [`CollapsedVariationalGaussian`](#gpjax.variational_families.CollapsedVariationalGaussian) |
 | Beyond that, or a non-Gaussian likelihood | [`elbo`](#gpjax.objectives.elbo) | [`VariationalGaussian`](#gpjax.variational_families.VariationalGaussian) |
 :::

--- a/gpjax/__init__.py
+++ b/gpjax/__init__.py
@@ -32,12 +32,21 @@ from gpjax import (
     variational_families,
 )
 from gpjax.citation import cite
+from gpjax.conditioning import Posterior
 from gpjax.dataset import Dataset
 from gpjax.distributions import GaussianDistribution
 from gpjax.fit import (
     fit,
     fit_lbfgs,
     fit_scipy,
+)
+from gpjax.gps import (
+    ConjugateModel,
+    HeteroscedasticModel,
+    JointModel,
+    NonConjugateModel,
+    Prior,
+    construct_model,
 )
 from gpjax.summary import summarise
 
@@ -48,9 +57,16 @@ __contributors__ = "https://github.com/thomaspinder/GPJax/graphs/contributors"
 __version__ = "0.18.0"
 
 __all__ = [
+    "ConjugateModel",
     "Dataset",
     "GaussianDistribution",
+    "HeteroscedasticModel",
+    "JointModel",
+    "NonConjugateModel",
+    "Posterior",
+    "Prior",
     "cite",
+    "construct_model",
     "fit",
     "fit_lbfgs",
     "fit_scipy",

--- a/gpjax/conditioning.py
+++ b/gpjax/conditioning.py
@@ -147,11 +147,7 @@ class ExactPosterior(Posterior):
         num_scalars = residual.shape[0]
         half_logdet = jnp.sum(jnp.log(jnp.diagonal(factor)))
         evidence = (
-            -0.5
-            * (
-                jnp.sum(residual * weights)
-                + num_scalars * jnp.log(2.0 * jnp.pi)
-            )
+            -0.5 * (jnp.sum(residual * weights) + num_scalars * jnp.log(2.0 * jnp.pi))
             - half_logdet
         )
 
@@ -225,9 +221,7 @@ class ExactPosterior(Posterior):
         )
         precision_diag = jnp.sum(factor_inv**2, axis=0).reshape(-1, 1)
 
-        loo_means = (
-            self.residual - self.representer_weights / precision_diag
-        )
+        loo_means = self.residual - self.representer_weights / precision_diag
         loo_vars = 1.0 / precision_diag
         loo_dist = npd.Normal(loc=loo_means, scale=jnp.sqrt(loo_vars))
         return loo_dist.log_prob(self.residual).squeeze(-1)

--- a/gpjax/conditioning.py
+++ b/gpjax/conditioning.py
@@ -1,0 +1,417 @@
+# Copyright 2026 The GPJax Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+r"""The deep conditioning module.
+
+Conditioning a Gaussian process on data is one computation: stabilise and
+factor the training covariance once, then derive every downstream quantity —
+the predictive distribution, the log marginal likelihood (evidence),
+leave-one-out densities, and pathwise samples — as views of that single
+factorisation. This module is the one home of that algebra.
+
+A :class:`Posterior` is an immutable pytree produced by
+``model.condition(train_data)`` (equivalently ``model | train_data``). It
+caches the Cholesky factor and representer weights, so repeated queries never
+re-factorise.
+"""
+
+from abc import abstractmethod
+from typing import Literal
+import warnings
+
+import beartype.typing as tp
+import equinox as eqx
+import jax.numpy as jnp
+import jax.random as jr
+import jax.scipy as jsp
+from jaxtyping import (
+    Float,
+    Num,
+)
+import lineax as lx
+import numpyro.distributions as npd
+
+from gpjax.dataset import Dataset
+from gpjax.distributions import GaussianDistribution
+from gpjax.kernels import RFF
+from gpjax.linalg.utils import stabilised_cholesky
+from gpjax.parameters import _val
+from gpjax.typing import (
+    Array,
+    FunctionalSample,
+    KeyArray,
+    ScalarFloat,
+)
+
+
+class Posterior(eqx.Module):
+    r"""A conditioned Gaussian process, :math:`p(f \mid \mathcal{D})`.
+
+    The result of conditioning a joint model on data. Immutable: the
+    factorisation of the training covariance is computed once at
+    ``condition`` time and cached on this object; every query is a view of
+    it. Query the process at test inputs by calling it::
+
+        posterior = model.condition(train_data)   # or: model | train_data
+        predictive = posterior(test_inputs)
+    """
+
+    @abstractmethod
+    def __call__(
+        self,
+        test_inputs: Num[Array, "N D"],
+        *,
+        covariance: Literal["dense", "diagonal"] = "dense",
+    ) -> GaussianDistribution:
+        r"""Evaluate the conditioned process at the given test inputs.
+
+        Args:
+            test_inputs: Input locations at which to query the process.
+            covariance: Whether to return the dense joint covariance over the
+                test inputs or only the marginal (diagonal) variances.
+
+        Returns:
+            GaussianDistribution: The predictive distribution at the inputs.
+        """
+        raise NotImplementedError
+
+    def predict(
+        self,
+        test_inputs: Num[Array, "N D"],
+        train_data: tp.Optional[Dataset] = None,
+        *,
+        covariance: Literal["dense", "diagonal"] = "dense",
+    ) -> GaussianDistribution:
+        r"""Sugar for calling the posterior: ``predict(t) == self(t)``.
+
+        Retained for signature compatibility with the pre-v1.0 API;
+        ``train_data`` is accepted and ignored — this process is already
+        conditioned on its training set.
+        """
+        del train_data
+        return self(test_inputs, covariance=covariance)
+
+
+class ExactPosterior(Posterior):
+    r"""Exactly conditioned GP: a Gaussian likelihood integrated analytically.
+
+    Caches the lower Cholesky factor of
+    :math:`\Sigma = K_{xx} + \texttt{jitter}\,\mathbf{I} + \mathrm{diag}(\sigma^2)`
+    and the representer weights :math:`\alpha = \Sigma^{-1}(y - m(x))`. The
+    predictive moments, the evidence, LOO densities, and pathwise samples are
+    all views of these two objects.
+    """
+
+    prior: tp.Any
+    likelihood: tp.Any
+    train_data: Dataset
+    cholesky_factor: Float[Array, "NP NP"]
+    representer_weights: Float[Array, "NP 1"]
+    residual: Float[Array, "NP 1"]
+    log_marginal_likelihood: ScalarFloat
+
+    def __init__(self, prior: tp.Any, likelihood: tp.Any, train_data: Dataset):
+        from gpjax.kernels.multioutput.base import MultiOutputKernel
+
+        kernel = prior.kernel
+        if isinstance(kernel, MultiOutputKernel):
+            if not train_data.multi_output:
+                raise ValueError("MultiOutputKernel requires multi-output data.")
+            if train_data.num_outputs != kernel.num_outputs:
+                raise ValueError(
+                    f"Dataset has {train_data.num_outputs} outputs "
+                    f"but kernel expects {kernel.num_outputs}."
+                )
+
+        x, y = train_data.X, train_data.y
+        mean_x = prior.mean_function(x)
+        y_flat, mean_flat = likelihood.prepare_targets(y, mean_x)
+        noise = likelihood.noise_vector(train_data.n)
+
+        gram_plus_noise = kernel.gram(x).as_matrix() + jnp.diag(noise)
+        factor = stabilised_cholesky(gram_plus_noise, prior.jitter)
+        residual = (y_flat - mean_flat).reshape(-1, 1)
+        weights = jsp.linalg.cho_solve((factor, True), residual)
+
+        num_scalars = residual.shape[0]
+        half_logdet = jnp.sum(jnp.log(jnp.diagonal(factor)))
+        evidence = (
+            -0.5
+            * (
+                jnp.sum(residual * weights)
+                + num_scalars * jnp.log(2.0 * jnp.pi)
+            )
+            - half_logdet
+        )
+
+        self.prior = prior
+        self.likelihood = likelihood
+        self.train_data = train_data
+        self.cholesky_factor = factor
+        self.representer_weights = weights
+        self.residual = residual
+        self.log_marginal_likelihood = jnp.squeeze(evidence)
+
+    def __call__(
+        self,
+        test_inputs: Num[Array, "N D"],
+        *,
+        covariance: Literal["dense", "diagonal"] = "dense",
+    ) -> GaussianDistribution:
+        kernel = self.prior.kernel
+        x = self.train_data.X
+        num_outputs = self.likelihood.num_outputs
+
+        cross_cov = kernel.cross_covariance(x, test_inputs)
+        solved_cross = jsp.linalg.solve_triangular(
+            self.cholesky_factor, cross_cov, lower=True
+        )
+
+        mean_test_raw = self.prior.mean_function(test_inputs)
+        mean_test = (
+            jnp.tile(mean_test_raw, (num_outputs, 1))
+            if num_outputs > 1
+            else mean_test_raw
+        )
+        mean = mean_test + jnp.matmul(cross_cov.T, self.representer_weights)
+
+        if covariance == "diagonal" and num_outputs > 1:
+            warnings.warn(
+                "Diagonal covariance is not yet supported for multi-output GPs. "
+                "Returning full covariance.",
+                stacklevel=2,
+            )
+            covariance = "dense"
+
+        if covariance == "dense":
+            test_gram = kernel.gram(test_inputs).as_matrix()
+            predictive_cov = test_gram - jnp.matmul(solved_cross.T, solved_cross)
+            predictive_cov = predictive_cov + self.prior.jitter * jnp.eye(
+                predictive_cov.shape[0]
+            )
+            scale = lx.MatrixLinearOperator(predictive_cov)
+        else:
+            test_var_diag = lx.diagonal(kernel.diagonal(test_inputs))
+            marginal_var = (
+                test_var_diag
+                - jnp.einsum("ij,ji->i", solved_cross.T, solved_cross)
+                + self.prior.jitter
+            )
+            scale = lx.DiagonalLinearOperator(jnp.atleast_1d(marginal_var.squeeze()))
+
+        return GaussianDistribution(loc=jnp.atleast_1d(mean.squeeze()), scale=scale)
+
+    def loo(self) -> Float[Array, " NP"]:
+        r"""Per-point leave-one-out predictive log-densities.
+
+        Computed from the cached factor via Rasmussen & Williams eq. 5.12 —
+        no model is refit. Sum the result for the LOOCV objective.
+        """
+        factor = self.cholesky_factor
+        num_scalars = factor.shape[0]
+        factor_inv = jsp.linalg.solve_triangular(
+            factor, jnp.eye(num_scalars), lower=True
+        )
+        precision_diag = jnp.sum(factor_inv**2, axis=0).reshape(-1, 1)
+
+        loo_means = (
+            self.residual - self.representer_weights / precision_diag
+        )
+        loo_vars = 1.0 / precision_diag
+        loo_dist = npd.Normal(loc=loo_means, scale=jnp.sqrt(loo_vars))
+        return loo_dist.log_prob(self.residual).squeeze(-1)
+
+    def sample_approx(
+        self,
+        num_samples: int,
+        key: KeyArray,
+        num_features: int | None = 100,
+    ) -> FunctionalSample:
+        r"""Draw approximate posterior samples via pathwise conditioning.
+
+        Decomposes each sample into Fourier features of the prior plus
+        canonical features weighted through the cached training factor
+        (Wilson et al., 2020).
+
+        Args:
+            num_samples: The desired number of samples.
+            key: The random seed used for the sample(s).
+            num_features: The number of Fourier features used to approximate
+                the prior component of each sample.
+
+        Returns:
+            FunctionalSample: A function evaluating the sample draws at any
+                inputs; the same draw is returned for all queries.
+        """
+        if (not isinstance(num_samples, int)) or num_samples <= 0:
+            raise ValueError("num_samples must be a positive integer")
+        if self.likelihood.num_outputs > 1:
+            raise ValueError(
+                "sample_approx does not support multi-output likelihoods yet."
+            )
+
+        freq_key, weight_key, noise_key = jr.split(key, 3)
+        fourier_feature_fn = _build_fourier_features_fn(
+            self.prior, num_features, freq_key
+        )
+        fourier_weights = jr.normal(weight_key, [num_samples, 2 * num_features])
+
+        x = self.train_data.X
+        obs_var = _val(self.likelihood.obs_stddev) ** 2
+        observation_noise = jnp.sqrt(obs_var) * jr.normal(
+            noise_key, [self.train_data.n, num_samples]
+        )
+        prior_features = fourier_feature_fn(x)
+        perturbed_residual = (
+            self.residual
+            + observation_noise
+            - jnp.inner(prior_features, fourier_weights)
+        )
+        canonical_weights = jsp.linalg.cho_solve(
+            (self.cholesky_factor, True), perturbed_residual
+        )
+
+        def sample_fn(test_inputs: Float[Array, "n D"]) -> Float[Array, "n B"]:
+            fourier_features = fourier_feature_fn(test_inputs)
+            weight_space_contribution = jnp.inner(fourier_features, fourier_weights)
+            canonical_features = self.prior.kernel.cross_covariance(test_inputs, x)
+            function_space_contribution = jnp.matmul(
+                canonical_features, canonical_weights
+            )
+            return (
+                self.prior.mean_function(test_inputs)
+                + weight_space_contribution
+                + function_space_contribution
+            )
+
+        return sample_fn
+
+
+class LatentPosterior(Posterior):
+    r"""Approximately conditioned GP for non-Gaussian likelihoods.
+
+    Conditioning is on the model's whitened latent vector rather than on the
+    observations directly: the cached factor is the prior gram's Cholesky, and
+    the latent plays the role of the representer weights. The joint
+    log-density (``log_posterior_density``) is the quantity MCMC or MAP
+    optimisation targets.
+    """
+
+    prior: tp.Any
+    likelihood: tp.Any
+    train_data: Dataset
+    cholesky_factor: Float[Array, "N N"]
+    latent: Float[Array, "N 1"]
+
+    def __init__(
+        self,
+        prior: tp.Any,
+        likelihood: tp.Any,
+        latent: tp.Any,
+        train_data: Dataset,
+    ):
+        self.prior = prior
+        self.likelihood = likelihood
+        self.train_data = train_data
+        self.cholesky_factor = stabilised_cholesky(
+            prior.kernel.gram(train_data.X).as_matrix(), prior.jitter
+        )
+        self.latent = _val(latent)
+
+    def __call__(
+        self,
+        test_inputs: Num[Array, "N D"],
+        *,
+        covariance: Literal["dense", "diagonal"] = "dense",
+    ) -> GaussianDistribution:
+        kernel = self.prior.kernel
+        x = self.train_data.X
+
+        cross_cov = kernel.cross_covariance(x, test_inputs)
+        solved_cross = jsp.linalg.solve_triangular(
+            self.cholesky_factor, cross_cov, lower=True
+        )
+
+        mean_test = self.prior.mean_function(test_inputs)
+        mean = mean_test + jnp.matmul(solved_cross.T, self.latent)
+
+        if covariance == "dense":
+            test_gram = kernel.gram(test_inputs).as_matrix()
+            predictive_cov = test_gram - jnp.matmul(solved_cross.T, solved_cross)
+            predictive_cov = predictive_cov + self.prior.jitter * jnp.eye(
+                predictive_cov.shape[0]
+            )
+            scale = lx.MatrixLinearOperator(predictive_cov)
+        else:
+            test_var_diag = lx.diagonal(kernel.diagonal(test_inputs))
+            marginal_var = (
+                test_var_diag
+                - jnp.einsum("ij,ji->i", solved_cross.T, solved_cross)
+                + self.prior.jitter
+            )
+            scale = lx.DiagonalLinearOperator(jnp.atleast_1d(marginal_var.squeeze()))
+
+        return GaussianDistribution(jnp.atleast_1d(mean.squeeze()), scale)
+
+    @property
+    def log_posterior_density(self) -> ScalarFloat:
+        r"""Unnormalised log-posterior density of the whitened latent model.
+
+        :math:`\log p(y \mid f(x)) + \log \mathcal{N}(w_x \mid 0, I)` where
+        :math:`f(x) = m(x) + L_x w_x`.
+        """
+        mean_x = self.prior.mean_function(self.train_data.X)
+        latent_function = mean_x + self.cholesky_factor @ self.latent
+        observation_density = self.likelihood.link_function(latent_function)
+        whitened_prior = npd.Normal(loc=0.0, scale=1.0)
+        return (
+            observation_density.log_prob(self.train_data.y).sum()
+            + whitened_prior.log_prob(self.latent).sum()
+        )
+
+
+def _build_fourier_features_fn(
+    prior: tp.Any, num_features: int, key: KeyArray
+) -> tp.Callable[[Float[Array, "N D"]], Float[Array, "N L"]]:
+    r"""Return a function evaluating features sampled from the Fourier feature
+    decomposition of the prior's kernel.
+
+    Args:
+        prior (Prior): The Prior distribution.
+        num_features (int): The number of feature functions to be sampled.
+        key (KeyArray): The random seed used.
+
+    Returns:
+        Callable: A callable function evaluating the sampled feature functions.
+    """
+    if (not isinstance(num_features, int)) or num_features <= 0:
+        raise ValueError("num_features must be a positive integer")
+
+    approximate_kernel = RFF(
+        base_kernel=prior.kernel, num_basis_fns=num_features, key=key
+    )
+
+    def eval_fourier_features(test_inputs: Float[Array, "N D"]) -> Float[Array, "N L"]:
+        feature_matrix = approximate_kernel.compute_features(x=test_inputs)
+        feature_matrix *= jnp.sqrt(_val(prior.kernel.variance) / num_features)
+        return feature_matrix
+
+    return eval_fourier_features
+
+
+__all__ = [
+    "ExactPosterior",
+    "LatentPosterior",
+    "Posterior",
+]

--- a/gpjax/dataset.py
+++ b/gpjax/dataset.py
@@ -31,10 +31,14 @@ class Dataset:
     Args:
         X: input data.
         y: output data.
+        n_total: full-dataset size when this object is a minibatch view of a
+            larger dataset (stamped by ``gpjax.fit.get_batch``); ``None`` means
+            the dataset is self-describing (``n_total == n``).
     """
 
     X: Optional[Num[Array, "N D"]] = None
     y: Optional[Num[Array, "N Q"]] = None
+    n_total: Optional[int] = None
 
     def __post_init__(self) -> None:
         r"""Checks that the shapes of $X$ and $y$ are compatible,
@@ -93,11 +97,11 @@ class Dataset:
         return self.y.shape[1]
 
     def tree_flatten(self):
-        return (self.X, self.y), None
+        return (self.X, self.y), self.n_total
 
     @classmethod
     def tree_unflatten(cls, aux_data, children):
-        return cls(*children)
+        return cls(*children, n_total=aux_data)
 
 
 def _check_shape(

--- a/gpjax/fit.py
+++ b/gpjax/fit.py
@@ -66,7 +66,7 @@ def fit(
         >>>
         >>> meanf = gpx.mean_functions.Constant()
         >>> kernel = gpx.kernels.RBF()
-        >>> likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n)
+        >>> likelihood = gpx.likelihoods.Gaussian()
         >>> prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
         >>> posterior = prior * likelihood
         >>>
@@ -108,6 +108,8 @@ def fit(
         _check_batch_size(batch_size)
         _check_log_rate(log_rate)
         _check_verbose(verbose)
+
+    model = _prepare_model(model, train_data)
 
     # Use paramax.unwrap for the constrained -> unconstrained -> constrained cycle.
     # paramax handles the bijection automatically via AbstractUnwrappable subclasses.
@@ -192,7 +194,7 @@ def fit_scipy(
 
         >>> meanf = gpx.mean_functions.Constant()
         >>> kernel = gpx.kernels.RBF()
-        >>> likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n)
+        >>> likelihood = gpx.likelihoods.Gaussian()
         >>> prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
         >>> posterior = prior * likelihood
 
@@ -207,6 +209,8 @@ def fit_scipy(
         _check_train_data(train_data)
         _check_num_iters(max_iters)
         _check_verbose(verbose)
+
+    model = _prepare_model(model, train_data)
 
     # Split model into trainable arrays and static parts
     params, static = eqx.partition(model, eqx.is_array)
@@ -287,7 +291,7 @@ def fit_lbfgs(
 
         >>> meanf = gpx.mean_functions.Constant()
         >>> kernel = gpx.kernels.RBF()
-        >>> likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n)
+        >>> likelihood = gpx.likelihoods.Gaussian()
         >>> prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
         >>> posterior = prior * likelihood
 
@@ -301,6 +305,8 @@ def fit_lbfgs(
         _check_model(model)
         _check_train_data(train_data)
         _check_num_iters(max_iters)
+
+    model = _prepare_model(model, train_data)
 
     # Split model into trainable arrays and static parts
     params, static = eqx.partition(model, eqx.is_array)
@@ -390,6 +396,19 @@ def get_batch(train_data: Dataset, batch_size: int, key: KeyArray) -> Dataset:
 
     full_size = train_data.n_total if train_data.n_total is not None else n
     return Dataset(X=x[indices], y=y[indices], n_total=full_size)
+
+
+def _prepare_model(model: Model, train_data: Dataset) -> Model:
+    """Run any data-dependent initialisation the model defines.
+
+    JointModels use this to size lazily-initialised state (e.g. the
+    non-conjugate latent vector) from the training data.
+    """
+    from gpjax.gps import JointModel
+
+    if isinstance(model, JointModel):
+        return model._prepare(train_data)
+    return model
 
 
 def _check_model(model: tp.Any) -> None:

--- a/gpjax/fit.py
+++ b/gpjax/fit.py
@@ -388,7 +388,8 @@ def get_batch(train_data: Dataset, batch_size: int, key: KeyArray) -> Dataset:
     # Subsample mini-batch indices with replacement.
     indices = jr.choice(key, n, (batch_size,), replace=True)
 
-    return Dataset(X=x[indices], y=y[indices])
+    full_size = train_data.n_total if train_data.n_total is not None else n
+    return Dataset(X=x[indices], y=y[indices], n_total=full_size)
 
 
 def _check_model(model: tp.Any) -> None:

--- a/gpjax/gps.py
+++ b/gpjax/gps.py
@@ -12,15 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+r"""Gaussian process priors and joint models.
 
-from abc import abstractmethod
+The API mirrors the mathematics:
+
+.. code-block:: python
+
+    prior = gpx.Prior(mean_function=meanf, kernel=kernel)   # p(f)
+    likelihood = gpx.likelihoods.Gaussian()                 # p(y | f)
+    model = prior * likelihood                              # p(f, y)
+    posterior = model.condition(train_data)                 # p(f | D)
+    predictive = posterior(test_inputs)
+
+A :class:`JointModel` is the trainable object — ``gpx.fit`` optimises its
+hyperparameters. Conditioning it on data returns an immutable
+:class:`gpjax.conditioning.Posterior` that caches the factorisation.
+"""
+
 from typing import Literal
 
 import beartype.typing as tp
 import equinox as eqx
 import jax.numpy as jnp
 import jax.random as jr
-import jax.scipy as jsp
 from jaxtyping import (
     Float,
     Num,
@@ -28,23 +42,24 @@ from jaxtyping import (
 import lineax as lx
 from paramax import AbstractUnwrappable
 
+from gpjax.conditioning import (
+    ExactPosterior,
+    LatentPosterior,
+    Posterior,
+    _build_fourier_features_fn,
+)
 from gpjax.dataset import Dataset
 from gpjax.distributions import GaussianDistribution
-from gpjax.kernels import RFF
 from gpjax.kernels.base import AbstractKernel
 from gpjax.likelihoods import (
     AbstractHeteroscedasticLikelihood,
     AbstractLikelihood,
     Gaussian,
-    HeteroscedasticGaussian,
     NonGaussian,
 )
 from gpjax.linalg.utils import add_jitter
 from gpjax.mean_functions import AbstractMeanFunction
-from gpjax.parameters import (
-    Real,
-    _val,
-)
+from gpjax.parameters import Real
 from gpjax.summary import _SummaryMixin
 from gpjax.typing import (
     Array,
@@ -60,98 +75,11 @@ GL = tp.TypeVar("GL", bound=Gaussian)
 HL = tp.TypeVar("HL", bound=AbstractHeteroscedasticLikelihood)
 
 
-class AbstractPrior(_SummaryMixin, eqx.Module, tp.Generic[M, K]):
-    r"""Abstract Gaussian process prior."""
-
-    kernel: K
-    mean_function: M
-    jitter: float = eqx.field(static=True, default=1e-6)
-
-    def __init__(
-        self,
-        kernel: K,
-        mean_function: M,
-        jitter: float = 1e-6,
-    ):
-        r"""Construct a Gaussian process prior.
-
-        Args:
-            kernel: kernel object inheriting from AbstractKernel.
-            mean_function: mean function object inheriting from AbstractMeanFunction.
-        """
-        self.kernel = kernel
-        self.mean_function = mean_function
-        self.jitter = jitter
-
-    def __call__(
-        self,
-        test_inputs: Num[Array, "N D"],
-        *,
-        return_covariance_type: Literal["dense", "diagonal"] = "dense",
-    ) -> GaussianDistribution:
-        r"""Evaluate the Gaussian process at the given points.
-
-        The output of this function is a ``GaussianDistribution`` from which
-        the latent function's mean and covariance can be evaluated and the
-        distribution can be sampled.
-
-        Under the hood, ``__call__`` invokes the ``predict`` method. Classes
-        inheriting ``AbstractPrior`` should not overwrite ``__call__`` and
-        should instead define a ``predict`` method.
-
-        Args:
-            test_inputs: Input locations where the GP should be evaluated.
-            return_covariance_type: Literal denoting whether to return the full covariance
-                of the joint predictive distribution at the test_inputs (dense)
-                or just the the standard-deviation of the predictive distribution at
-                the test_inputs.
-
-        Returns:
-            GaussianDistribution: A multivariate normal random variable representation
-                of the Gaussian process.
-        """
-        return self.predict(
-            test_inputs,
-            return_covariance_type=return_covariance_type,
-        )
-
-    @abstractmethod
-    def predict(
-        self,
-        test_inputs: Num[Array, "N D"],
-        *,
-        return_covariance_type: Literal["dense", "diagonal"] = "dense",
-    ) -> GaussianDistribution:
-        r"""Evaluate the predictive distribution.
-
-        Compute the latent function's multivariate normal distribution for a
-        given set of parameters. For any class inheriting the `AbstractPrior` class,
-        this method must be implemented.
-
-        Args:
-            test_inputs: Input locations where the GP should be evaluated.
-            return_covariance_type: Literal denoting whether to return the full covariance
-                of the joint predictive distribution at the test_inputs (dense)
-                or just the the standard-deviation of the predictive distribution at
-                the test_inputs.
-
-        Returns:
-            GaussianDistribution: A multivariate normal random variable representation
-                of the Gaussian process.
-        """
-        raise NotImplementedError
-
-
 #######################
 # GP Priors
 #######################
-class Prior(AbstractPrior[M, K]):
+class Prior(_SummaryMixin, eqx.Module, tp.Generic[M, K]):
     r"""A Gaussian process prior object.
-
-    The GP is parameterised by a
-    mean
-    and kernel
-    function.
 
     A Gaussian process prior parameterised by a mean function $m(\cdot)$ and a kernel
     function $k(\cdot, \cdot)$ is given by
@@ -171,88 +99,110 @@ class Prior(AbstractPrior[M, K]):
         :doc:`/examples/regression` puts one to work end to end.
     """
 
+    kernel: K
+    mean_function: M
+    jitter: float = eqx.field(static=True, default=1e-6)
+
+    def __init__(
+        self,
+        kernel: K,
+        mean_function: M,
+        jitter: float = 1e-6,
+    ):
+        r"""Construct a Gaussian process prior.
+
+        Args:
+            kernel: kernel object inheriting from AbstractKernel.
+            mean_function: mean function object inheriting from AbstractMeanFunction.
+            jitter: the model's single numerical-stabilisation knob. Applied
+                exactly once, inside conditioning.
+        """
+        self.kernel = kernel
+        self.mean_function = mean_function
+        self.jitter = jitter
+
     if tp.TYPE_CHECKING:
 
         @tp.overload
-        def __mul__(self, other: GL) -> "ConjugatePosterior[Prior[M, K], GL]": ...
+        def __mul__(self, other: GL) -> "ConjugateModel[M, K, GL]": ...
 
         @tp.overload
-        def __mul__(self, other: NGL) -> "NonConjugatePosterior[Prior[M, K], NGL]": ...
+        def __mul__(self, other: NGL) -> "NonConjugateModel[M, K, NGL]": ...
 
         @tp.overload
-        def __mul__(self, other: L) -> "AbstractPosterior[Prior[M, K], L]": ...
+        def __mul__(self, other: L) -> "JointModel[M, K, L]": ...
 
     def __mul__(self, other):
-        r"""Combine the prior with a likelihood to form a posterior distribution.
+        r"""Combine the prior with a likelihood to form a joint model.
 
-        The product of a prior and likelihood is proportional to the posterior
-        distribution. By computing the product of a GP prior and a likelihood
-        object, a posterior GP object will be returned. Mathematically, this can
-        be described by:
+        The product of a prior and likelihood is the joint distribution over
+        latent function and observations,
 
         .. math::
 
-            p(f(\cdot) \mid y) \propto p(y \mid f(\cdot))p(f(\cdot)),
+            p(f(\cdot), y) = p(y \mid f(\cdot))\,p(f(\cdot)),
 
-        where $p(y | f(\cdot))$ is the likelihood and $p(f(\cdot))$ is the prior.
+        where $p(y | f(\cdot))$ is the likelihood and $p(f(\cdot))$ is the
+        prior. Conditioning the returned model on data yields the posterior.
 
         Example:
             >>> import gpjax as gpx
             >>> meanf = gpx.mean_functions.Zero()
             >>> kernel = gpx.kernels.RBF()
             >>> prior = gpx.gps.Prior(mean_function=meanf, kernel = kernel)
-            >>> likelihood = gpx.likelihoods.Gaussian(num_datapoints=100)
-            >>> prior * likelihood
+            >>> likelihood = gpx.likelihoods.Gaussian()
+            >>> model = prior * likelihood
+
         Args:
-            other (Likelihood): The likelihood distribution of the observed dataset.
+            other (AbstractLikelihood): The likelihood of the observations.
 
         Returns:
-            Posterior: The relevant GP posterior for the given prior and
-                likelihood. Special cases are accounted for where the model
-                is conjugate.
+            JointModel: The joint model for the given prior and likelihood.
+                The concrete type reflects conjugacy.
         """
-        return construct_posterior(prior=self, likelihood=other)
+        return construct_model(prior=self, likelihood=other)
 
     if tp.TYPE_CHECKING:
 
         @tp.overload
-        def __rmul__(self, other: GL) -> "ConjugatePosterior[Prior[M, K], GL]": ...
+        def __rmul__(self, other: GL) -> "ConjugateModel[M, K, GL]": ...
 
         @tp.overload
-        def __rmul__(self, other: NGL) -> "NonConjugatePosterior[Prior[M, K], NGL]": ...
+        def __rmul__(self, other: NGL) -> "NonConjugateModel[M, K, NGL]": ...
 
         @tp.overload
-        def __rmul__(self, other: L) -> "AbstractPosterior[Prior[M, K], L]": ...
+        def __rmul__(self, other: L) -> "JointModel[M, K, L]": ...
 
     def __rmul__(self, other):
-        r"""Combine the prior with a likelihood to form a posterior distribution.
+        r"""Order-invariant product: ``likelihood * prior``."""
+        return self.__mul__(other)
 
-        Reimplement the multiplication operator to allow for order-invariant
-        product of a likelihood and a prior i.e., likelihood * prior.
+    def __call__(
+        self,
+        test_inputs: Num[Array, "N D"],
+        *,
+        covariance: Literal["dense", "diagonal"] = "dense",
+    ) -> GaussianDistribution:
+        r"""Evaluate the prior process at the given points.
 
         Args:
-            other (Likelihood): The likelihood distribution of the observed
-                dataset.
+            test_inputs: Input locations where the GP should be evaluated.
+            covariance: Whether to return the dense joint covariance at the
+                test inputs or only the marginal (diagonal) variances.
 
         Returns:
-            Posterior: The relevant GP posterior for the given prior and
-                likelihood. Special cases are accounted for where the model
-                is conjugate.
+            GaussianDistribution: A multivariate normal random variable
+                representation of the Gaussian process.
         """
-        return self.__mul__(other)
+        return self.predict(test_inputs, covariance=covariance)
 
     def predict(
         self,
         test_inputs: Num[Array, "N D"],
         *,
-        return_covariance_type: Literal["dense", "diagonal"] = "dense",
+        covariance: Literal["dense", "diagonal"] = "dense",
     ) -> GaussianDistribution:
-        r"""Compute the predictive prior distribution for a given set of
-        parameters. The output of this function is a ``GaussianDistribution``
-        for a given set of inputs.
-
-        In the following example, we compute the predictive prior distribution
-        and then evaluate it on the interval :math:`[0, 1]`:
+        r"""Compute the prior predictive distribution at the test inputs.
 
         Example:
             >>> import gpjax as gpx
@@ -263,27 +213,24 @@ class Prior(AbstractPrior[M, K]):
             >>> prior.predict(jnp.linspace(0, 1, 100)[:, None])
 
         Args:
-            test_inputs (Float[Array, "N D"]): The inputs at which to evaluate the
-                prior distribution.
-            return_covariance_type: Literal denoting whether to return the full covariance
-                of the joint predictive distribution at the test_inputs (dense)
-                or just the the standard-deviation of the predictive distribution at
-                the test_inputs.
+            test_inputs (Float[Array, "N D"]): The inputs at which to evaluate
+                the prior distribution.
+            covariance: Whether to return the dense joint covariance at the
+                test inputs or only the marginal (diagonal) variances.
 
         Returns:
-            GaussianDistribution: A multivariate normal random variable representation
-                of the Gaussian process.
+            GaussianDistribution: A multivariate normal random variable
+                representation of the Gaussian process.
         """
-
         mean_at_test = self.mean_function(test_inputs)
-        if return_covariance_type == "dense":
-            Kxx_dense = add_jitter(
+        if covariance == "dense":
+            gram_dense = add_jitter(
                 self.kernel.gram(test_inputs).as_matrix(), self.jitter
             )
-            cov = lx.MatrixLinearOperator(Kxx_dense)
+            cov = lx.MatrixLinearOperator(gram_dense)
         else:
-            Ktt_diag = lx.diagonal(self.kernel.diagonal(test_inputs))
-            var = Ktt_diag + self.jitter
+            gram_diag = lx.diagonal(self.kernel.diagonal(test_inputs))
+            var = gram_diag + self.jitter
             cov = lx.DiagonalLinearOperator(jnp.atleast_1d(var.squeeze()))
 
         return GaussianDistribution(
@@ -298,27 +245,14 @@ class Prior(AbstractPrior[M, K]):
     ) -> FunctionalSample:
         r"""Approximate samples from the Gaussian process prior.
 
-        Build an approximate sample from the Gaussian process prior. This method
-        provides a function that returns the evaluations of a sample across any
-        given inputs.
-
-        In particular, we approximate the Gaussian processes' prior as the
+        Build an approximate sample from the Gaussian process prior via the
         finite feature approximation
-        $\hat{f}(x) = \sum_{i=1}^m\phi_i(x)\theta_i$ where $\phi_i$ are $m$ features
-        sampled from the Fourier feature decomposition of the model's kernel and
-        $\theta_i$ are samples from a unit Gaussian.
+        $\hat{f}(x) = \sum_{i=1}^m\phi_i(x)\theta_i$ where $\phi_i$ are $m$
+        features sampled from the Fourier feature decomposition of the model's
+        kernel and $\theta_i$ are samples from a unit Gaussian.
 
-        A key property of such functional samples is that the same sample draw is
-        evaluated for all queries. Consistency is a property that is prohibitively costly
-        to ensure when sampling exactly from the GP prior, as the cost of exact sampling
-        scales cubically with the size of the sample. In contrast, finite feature representations
-        can be evaluated with constant cost regardless of the required number of queries.
-
-        In the following example, we build 10 such samples and then evaluate them
-        over the interval $[0, 1]$:
-
-        For a `prior` distribution, the following code snippet will
-        build and evaluate an approximate sample.
+        The same sample draw is evaluated for all queries, at constant cost
+        per query.
 
         Example:
             >>> import gpjax as gpx
@@ -336,14 +270,13 @@ class Prior(AbstractPrior[M, K]):
         Args:
             num_samples (int): The desired number of samples.
             key (KeyArray): The random seed used for the sample(s).
-            num_features (int): The number of features used when approximating the
-                kernel.
+            num_features (int): The number of features used when approximating
+                the kernel.
 
         Returns:
-            FunctionalSample: A function representing an approximate sample from the
-                Gaussian process prior.
+            FunctionalSample: A function representing an approximate sample
+                from the Gaussian process prior.
         """
-
         if (not isinstance(num_samples, int)) or num_samples <= 0:
             raise ValueError("num_samples must be a positive integer")
 
@@ -360,146 +293,112 @@ class Prior(AbstractPrior[M, K]):
         return sample_fn
 
 
-P = tp.TypeVar("P", bound=AbstractPrior)
-
-
 #######################
-# GP Posteriors
+# Joint models
 #######################
-class AbstractPosterior(_SummaryMixin, eqx.Module, tp.Generic[P, L]):
-    r"""Abstract Gaussian process posterior.
+class JointModel(_SummaryMixin, eqx.Module, tp.Generic[M, K, L]):
+    r"""The joint distribution $p(f, y) = p(y \mid f)\,p(f)$.
 
-    The base GP posterior object conditioned on an observed dataset. All
-    posterior objects should inherit from this class.
+    Pairs a :class:`Prior` with a likelihood. This is the *trainable* object:
+    ``gpx.fit`` optimises its hyperparameters. Conditioning it on data —
+    ``model.condition(D)`` or ``model | D`` — produces the posterior process.
+
+    The base class carries no inference of its own; concrete subclasses
+    (:class:`ConjugateModel`, :class:`NonConjugateModel`,
+    :class:`HeteroscedasticModel`) define what conditioning means for their
+    likelihood. A bare ``JointModel`` is a lightweight pairing used where
+    inference is delegated elsewhere (e.g. variational families over a
+    latent noise process).
     """
 
-    prior: AbstractPrior
+    prior: Prior
     likelihood: tp.Any
-    jitter: float = eqx.field(static=True, default=1e-6)
 
-    def __init__(
-        self,
-        prior: AbstractPrior[M, K],
-        likelihood: L,
-        jitter: float = 1e-6,
-    ):
-        r"""Construct a Gaussian process posterior.
+    def __init__(self, prior: Prior[M, K], likelihood: L):
+        r"""Construct a joint model.
 
         Args:
-            prior (AbstractPrior): The prior distribution.
-            likelihood (AbstractLikelihood): The likelihood distribution.
-            jitter (float): A small constant added to the diagonal of the
-                covariance matrix to ensure numerical stability.
+            prior (Prior): The prior process.
+            likelihood (AbstractLikelihood): The observation likelihood.
         """
         self.prior = prior
         self.likelihood = likelihood
-        self.jitter = jitter
+
+    def condition(self, train_data: Dataset) -> Posterior:
+        r"""Condition the joint model on data, returning the posterior process.
+
+        Args:
+            train_data: The observations to condition on.
+
+        Returns:
+            Posterior: The conditioned process $p(f \mid \mathcal{D})$.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not define direct conditioning; "
+            "use a variational family for inference."
+        )
+
+    def __or__(self, train_data: Dataset) -> Posterior:
+        r"""Sugar for conditioning: ``model | D`` reads as $p(f \mid \mathcal{D})$."""
+        return self.condition(train_data)
+
+    def _prepare(self, train_data: Dataset) -> "JointModel":
+        r"""Hook for data-dependent initialisation; returns a ready-to-fit model."""
+        del train_data
+        return self
 
     def __call__(
         self,
         test_inputs: Num[Array, "N D"],
         train_data: Dataset,
         *,
-        return_covariance_type: Literal["dense", "diagonal"] = "dense",
+        covariance: Literal["dense", "diagonal"] = "dense",
     ) -> GaussianDistribution:
-        r"""Evaluate the Gaussian process posterior at the given points.
+        r"""Sugar: condition on ``train_data`` and query at ``test_inputs``.
 
-        The output of this function is a ``GaussianDistribution`` from which
-        the latent function's mean and covariance can be evaluated and the
-        distribution can be sampled.
-
-        Under the hood, ``__call__`` invokes the ``predict`` method. Classes
-        inheriting ``AbstractPosterior`` should not overwrite ``__call__`` and
-        should instead define a ``predict`` method.
-
-        Args:
-            test_inputs: Input locations where the GP should be evaluated.
-            train_data: Training dataset to condition on.
-            return_covariance_type: Literal denoting whether to return the full covariance
-                of the joint predictive distribution at the test_inputs (dense)
-                or just the the standard-deviation of the predictive distribution at
-                the test_inputs.
-
-        Returns:
-            GaussianDistribution: A multivariate normal random variable representation
-                of the Gaussian process.
+        Equivalent to ``self.condition(train_data)(test_inputs)``.
         """
-        return self.predict(
-            test_inputs,
-            train_data,
-            return_covariance_type=return_covariance_type,
-        )
-
-    @abstractmethod
-    def predict(
-        self,
-        test_inputs: Num[Array, "N D"],
-        train_data: Dataset,
-        *,
-        return_covariance_type: Literal["dense", "diagonal"] = "dense",
-    ) -> GaussianDistribution:
-        r"""Compute the latent function's multivariate normal distribution for a
-        given set of parameters. For any class inheriting the `AbstractPosterior` class,
-        this method must be implemented.
-
-        Args:
-            test_inputs: Input locations where the GP should be evaluated.
-            train_data: Training dataset to condition on.
-            return_covariance_type: Literal denoting whether to return the full covariance
-                of the joint predictive distribution at the test_inputs (dense)
-                or just the the standard-deviation of the predictive distribution at
-                the test_inputs.
-
-        Returns:
-            GaussianDistribution: A multivariate normal random variable representation
-                of the Gaussian process.
-        """
-        raise NotImplementedError
-
-
-class LatentPosterior(AbstractPosterior[P, L]):
-    r"""A posterior shell used to expose prior structure without inference."""
+        return self.predict(test_inputs, train_data, covariance=covariance)
 
     def predict(
         self,
         test_inputs: Num[Array, "N D"],
         train_data: Dataset,
         *,
-        return_covariance_type: Literal["dense", "diagonal"] = "dense",
+        covariance: Literal["dense", "diagonal"] = "dense",
     ) -> GaussianDistribution:
-        raise NotImplementedError(
-            "LatentPosteriors are a lightweight wrapper for priors and do not "
-            "implement predictive distributions. Use a variational family for inference."
-        )
+        r"""Sugar: condition on ``train_data`` and query at ``test_inputs``.
+
+        Defined as exactly ``self.condition(train_data)(test_inputs)``. When
+        making repeated predictions, condition once and reuse the returned
+        posterior — the factorisation is cached there.
+
+        Args:
+            test_inputs: A Jax array of test inputs.
+            train_data: A `gpx.Dataset` to condition on.
+            covariance: Whether to return the dense joint covariance at the
+                test inputs or only the marginal (diagonal) variances.
+
+        Returns:
+            GaussianDistribution: The predictive distribution.
+        """
+        return self.condition(train_data)(test_inputs, covariance=covariance)
 
 
-class ConjugatePosterior(AbstractPosterior[P, GL]):
-    r"""A Conjuate Gaussian process posterior object.
-
-    A Gaussian process posterior distribution when the constituent likelihood
-    function is a Gaussian distribution. In such cases, the latent function values
-    $f$ can be analytically integrated out of the posterior distribution.
-    As such, many computational operations can be simplified; something we make use
-    of in this object.
+class ConjugateModel(JointModel[M, K, GL]):
+    r"""A joint model with Gaussian likelihood: conditioning is exact.
 
     For a Gaussian process prior $p(\mathbf{f})$ and a Gaussian likelihood
-    $p(y | \mathbf{f}) = \mathcal{N}(y\mid \mathbf{f}, \sigma^2))$ where
-    $\mathbf{f} = f(\mathbf{x})$, the predictive posterior distribution at
-    a set of inputs $\mathbf{x}$ is given by
+    $p(y | \mathbf{f}) = \mathcal{N}(y\mid \mathbf{f}, \sigma^2))$, the latent
+    function can be analytically integrated out. Conditioning returns the
+    closed-form posterior
 
     .. math::
 
         \begin{aligned}
-        p(\mathbf{f}^{\star}\mid \mathbf{y}) & = \int p(\mathbf{f}^{\star}, \mathbf{f} \mid \mathbf{y})\\
-            & =\mathcal{N}(\mathbf{f}^{\star} \boldsymbol{\mu}_{\mid \mathbf{y}}, \boldsymbol{\Sigma}_{\mid \mathbf{y}}
-        \end{aligned}
-
-    where
-
-    .. math::
-
-        \begin{aligned}
-        \boldsymbol{\mu}_{\mid \mathbf{y}} & = k(\mathbf{x}^{\star}, \mathbf{x})\left(k(\mathbf{x}, \mathbf{x}')+\sigma^2\mathbf{I}_n\right)^{-1}\mathbf{y}  \\
+        p(\mathbf{f}^{\star}\mid \mathbf{y}) & =\mathcal{N}(\mathbf{f}^{\star};
+        \boldsymbol{\mu}_{\mid \mathbf{y}}, \boldsymbol{\Sigma}_{\mid \mathbf{y}}),\\
+        \boldsymbol{\mu}_{\mid \mathbf{y}} & = k(\mathbf{x}^{\star}, \mathbf{x})\left(k(\mathbf{x}, \mathbf{x}')+\sigma^2\mathbf{I}_n\right)^{-1}\mathbf{y},  \\
         \boldsymbol{\Sigma}_{\mid \mathbf{y}} & =k(\mathbf{x}^{\star}, \mathbf{x}^{\star\prime}) -k(\mathbf{x}^{\star}, \mathbf{x})\left( k(\mathbf{x}, \mathbf{x}') + \sigma^2\mathbf{I}_n \right)^{-1}k(\mathbf{x}, \mathbf{x}^{\star}).
         \end{aligned}
 
@@ -507,120 +406,29 @@ class ConjugatePosterior(AbstractPosterior[P, GL]):
         >>> import gpjax as gpx
         >>> import jax.numpy as jnp
         >>>
+        >>> xtrain = jnp.linspace(0, 1).reshape(-1, 1)
+        >>> D = gpx.Dataset(X=xtrain, y=jnp.sin(xtrain))
+        >>>
         >>> prior = gpx.gps.Prior(
         ...     mean_function = gpx.mean_functions.Zero(),
         ...     kernel = gpx.kernels.RBF()
         ... )
-        >>> likelihood = gpx.likelihoods.Gaussian(num_datapoints=100)
-        >>>
-        >>> posterior = prior * likelihood
+        >>> model = prior * gpx.likelihoods.Gaussian()
+        >>> posterior = model.condition(D)
+        >>> predictive = posterior(xtrain)
+        >>> evidence = posterior.log_marginal_likelihood
     """
 
-    def predict(
-        self,
-        test_inputs: Num[Array, "M D"],
-        train_data: Dataset,
-        *,
-        return_covariance_type: Literal["dense", "diagonal"] = "dense",
-    ) -> GaussianDistribution:
-        r"""Query the predictive posterior distribution.
-
-        Conditional on a training data set, compute the GP's posterior
-        predictive distribution for a given set of parameters. The returned function
-        can be evaluated at a set of test inputs to compute the corresponding
-        predictive density.
-
-        The predictive distribution of a conjugate GP is given by
-        $$
-        p(\mathbf{f}^{\star}\mid \mathbf{y}) & = \int p(\mathbf{f}^{\star} \mathbf{f} \mid \mathbf{y})\\
-        & =\mathcal{N}(\mathbf{f}^{\star} \boldsymbol{\mu}_{\mid \mathbf{y}}, \boldsymbol{\Sigma}_{\mid \mathbf{y}}
-        $$
-        where
-        $$
-        \boldsymbol{\mu}_{\mid \mathbf{y}} & = k(\mathbf{x}^{\star}, \mathbf{x})\left(k(\mathbf{x}, \mathbf{x}')+\sigma^2\mathbf{I}_n\right)^{-1}\mathbf{y} \\
-        \boldsymbol{\Sigma}_{\mid \mathbf{y}} & =k(\mathbf{x}^{\star}, \mathbf{x}^{\star\prime}) -k(\mathbf{x}^{\star}, \mathbf{x})\left( k(\mathbf{x}, \mathbf{x}') + \sigma^2\mathbf{I}_n \right)^{-1}k(\mathbf{x}, \mathbf{x}^{\star}).
-        $$
-
-        The conditioning set is a GPJax `Dataset` object, whilst predictions
-        are made on a regular Jax array.
-
-        Example:
-            >>> import gpjax as gpx
-            >>> import jax.numpy as jnp
-            >>>
-            >>> xtrain = jnp.linspace(0, 1).reshape(-1, 1)
-            >>> ytrain = jnp.sin(xtrain)
-            >>> D = gpx.Dataset(X=xtrain, y=ytrain)
-            >>> xtest = jnp.linspace(0, 1).reshape(-1, 1)
-            >>>
-            >>> prior = gpx.gps.Prior(mean_function = gpx.mean_functions.Zero(), kernel = gpx.kernels.RBF())
-            >>> posterior = prior * gpx.likelihoods.Gaussian(num_datapoints = D.n)
-            >>> predictive_dist = posterior(xtest, D)
-
-        Args:
-            test_inputs (Num[Array, "N D"]): A Jax array of test inputs at which the
-                predictive distribution is evaluated.
-            train_data (Dataset): A `gpx.Dataset` object that contains the input and
-                output data used for training dataset.
-            return_covariance_type: Literal denoting whether to return the full covariance
-                of the joint predictive distribution at the test_inputs (dense)
-                or just the the standard-deviation of the predictive distribution at
-                the test_inputs.
+    def condition(self, train_data: Dataset) -> ExactPosterior:
+        r"""Condition on data exactly.
 
         Returns:
-            GaussianDistribution: A function that accepts an input array and
-                returns the predictive distribution as a `GaussianDistribution`.
+            ExactPosterior: The closed-form posterior process, with the
+                training-covariance factorisation cached. Exposes the
+                predictive (via ``__call__``), ``log_marginal_likelihood``,
+                ``loo`` and ``sample_approx``.
         """
-        import warnings
-
-        kernel = self.prior.kernel
-        x, y = train_data.X, train_data.y
-        P = self.likelihood.num_outputs
-
-        # Prepare targets via likelihood protocol (identity for single-output,
-        # output-major reshape for multi-output)
-        mx = self.prior.mean_function(x)
-        y_flat, mx_flat = self.likelihood.prepare_targets(y, mx)
-        noise = self.likelihood.noise_vector(train_data.n)
-
-        Kxx = kernel.gram(x)
-        Kxx_dense = add_jitter(Kxx.as_matrix(), self.jitter)
-        Sigma_dense = Kxx_dense + jnp.diag(noise)
-        L_sigma = jnp.linalg.cholesky(Sigma_dense)
-
-        Kxt = kernel.cross_covariance(x, test_inputs)
-        L_inv_Kxt = jsp.linalg.solve_triangular(L_sigma, Kxt, lower=True)
-        L_inv_y_diff = jsp.linalg.solve_triangular(
-            L_sigma, y_flat - mx_flat, lower=True
-        )
-
-        mean_t_raw = self.prior.mean_function(test_inputs)
-        mean_t = jnp.tile(mean_t_raw, (P, 1)) if P > 1 else mean_t_raw
-        mean = mean_t + jnp.matmul(L_inv_Kxt.T, L_inv_y_diff)
-
-        # Diagonal covariance not yet supported for multi-output
-        if return_covariance_type == "diagonal" and P > 1:
-            warnings.warn(
-                "Diagonal covariance is not yet supported for multi-output GPs. "
-                "Returning full covariance.",
-                stacklevel=2,
-            )
-            return_covariance_type = "dense"
-
-        if return_covariance_type == "dense":
-            Ktt = kernel.gram(test_inputs).as_matrix()
-            covariance = Ktt - jnp.matmul(L_inv_Kxt.T, L_inv_Kxt)
-            covariance = add_jitter(covariance, self.prior.jitter)
-            cov = lx.MatrixLinearOperator(covariance)
-        else:
-            Ktt_diag = lx.diagonal(kernel.diagonal(test_inputs))
-            var = (
-                Ktt_diag
-                - jnp.einsum("ij,ji->i", L_inv_Kxt.T, L_inv_Kxt)
-                + self.prior.jitter
-            )
-            cov = lx.DiagonalLinearOperator(jnp.atleast_1d(var.squeeze()))
-        return GaussianDistribution(loc=jnp.atleast_1d(mean.squeeze()), scale=cov)
+        return ExactPosterior(self.prior, self.likelihood, train_data)
 
     def sample_approx(
         self,
@@ -629,228 +437,132 @@ class ConjugatePosterior(AbstractPosterior[P, GL]):
         key: KeyArray,
         num_features: int | None = 100,
     ) -> FunctionalSample:
-        r"""Draw approximate samples from the Gaussian process posterior.
+        r"""Sugar: ``self.condition(train_data).sample_approx(...)``.
 
-        Build an approximate sample from the Gaussian process posterior. This method
-        provides a function that returns the evaluations of a sample across any given
-        inputs.
-
-        Unlike when building approximate samples from a Gaussian process prior, decompositions
-        based on Fourier features alone rarely give accurate samples. Therefore, we must also
-        include an additional set of features (known as canonical features) to better model the
-        transition from Gaussian process prior to Gaussian process posterior. For more details
-        see [Wilson et. al. (2020)](https://arxiv.org/abs/2002.09309).
-
-        In particular, we approximate the Gaussian processes' posterior as the finite
-        feature approximation
-        $\hat{f}(x) = \sum_{i=1}^m \phi_i(x)\theta_i + \sum{j=1}^N v_jk(.,x_j)$
-        where $\phi_i$ are m features sampled from the Fourier feature decomposition of
-        the model's kernel and $k(., x_j)$ are N canonical features. The Fourier
-        weights $\theta_i$ are samples from a unit Gaussian. See
-        [Wilson et. al. (2020)](https://arxiv.org/abs/2002.09309) for expressions
-        for the canonical weights $v_j$.
-
-        A key property of such functional samples is that the same sample draw is
-        evaluated for all queries. Consistency is a property that is prohibitively costly
-        to ensure when sampling exactly from the GP prior, as the cost of exact sampling
-        scales cubically with the size of the sample. In contrast, finite feature representations
-        can be evaluated with constant cost regardless of the required number of queries.
-
-        Args:
-            num_samples (int): The desired number of samples.
-            key (KeyArray): The random seed used for the sample(s).
-            num_features (int): The number of features used when approximating the
-                kernel.
-
-        Returns:
-            FunctionalSample: A function representing an approximate sample from the Gaussian
-                process prior.
+        Draw approximate posterior samples via pathwise conditioning
+        (Wilson et al., 2020).
         """
-        if (not isinstance(num_samples, int)) or num_samples <= 0:
-            raise ValueError("num_samples must be a positive integer")
-
-        # sample fourier features
-        freq_key, weight_key, noise_key = jr.split(key, 3)
-        fourier_feature_fn = _build_fourier_features_fn(
-            self.prior, num_features, freq_key
+        return self.condition(train_data).sample_approx(
+            num_samples, key, num_features
         )
 
-        fourier_weights = jr.normal(weight_key, [num_samples, 2 * num_features])
 
-        obs_var = _val(self.likelihood.obs_stddev) ** 2
-        Kxx = self.prior.kernel.gram(train_data.X)
-        Sigma_dense = add_jitter(Kxx.as_matrix(), obs_var + self.jitter)
-        L_sigma = jnp.linalg.cholesky(Sigma_dense)
-        eps = jnp.sqrt(obs_var) * jr.normal(noise_key, [train_data.n, num_samples])
-        y = train_data.y - self.prior.mean_function(train_data.X)
-        Phi = fourier_feature_fn(train_data.X)
-        # Solve L_sigma @ canonical_weights = rhs
-        rhs = y + eps - jnp.inner(Phi, fourier_weights)
-        canonical_weights = jsp.linalg.cho_solve((L_sigma, True), rhs)  # [N, B]
+class NonConjugateModel(JointModel[M, K, NGL]):
+    r"""A joint model with non-Gaussian likelihood.
 
-        def sample_fn(test_inputs: Float[Array, "n D"]) -> Float[Array, "n B"]:
-            fourier_features = fourier_feature_fn(test_inputs)
-            weight_space_contribution = jnp.inner(fourier_features, fourier_weights)
-            canonical_features = self.prior.kernel.cross_covariance(
-                test_inputs, train_data.X
-            )
-            function_space_contribution = jnp.matmul(
-                canonical_features, canonical_weights
-            )
+    Exact conditioning is intractable; the model instead carries a whitened
+    latent vector $w_x$ as a trainable parameter, and conditioning produces
+    the approximate posterior implied by its current value. Markov chain Monte
+    Carlo, variational inference, or MAP optimisation (via
+    ``gpx.objectives.log_posterior_density``) refine it.
 
-            return (
-                self.prior.mean_function(test_inputs)
-                + weight_space_contribution
-                + function_space_contribution
-            )
-
-        return sample_fn
-
-
-class NonConjugatePosterior(AbstractPosterior[P, NGL]):
-    r"""A non-conjugate Gaussian process posterior object.
-
-    A Gaussian process posterior object for models where the likelihood is
-    non-Gaussian. Unlike the `ConjugatePosterior` object, the
-    `NonConjugatePosterior` object does not provide an exact marginal
-    log-likelihood function. Instead, the `NonConjugatePosterior` object
-    represents the posterior distributions as a function of the model's
-    hyperparameters and the latent function. Markov chain Monte Carlo,
-    variational inference, or Laplace approximations can then be used to sample
-    from, or optimise an approximation to, the posterior distribution.
+    The latent is sized by the training data, so it is initialised lazily on
+    first contact with data — ``gpx.fit`` does this automatically, or call
+    :meth:`init_latent` explicitly.
     """
 
     latent: tp.Any
 
     def __init__(
         self,
-        prior: P,
+        prior: Prior[M, K],
         likelihood: NGL,
         latent: tp.Union[Float[Array, "N 1"], AbstractUnwrappable, None] = None,
-        jitter: float = 1e-6,
-        key: KeyArray = jr.key(42),
     ):
-        r"""Construct a non-conjugate Gaussian process posterior.
+        r"""Construct a non-conjugate joint model.
 
         Args:
-            prior (AbstractPrior): The prior distribution.
-            likelihood (AbstractLikelihood): The likelihood distribution.
-            jitter (float): A small constant added to the diagonal of the
-                covariance matrix to ensure numerical stability.
+            prior (Prior): The prior process.
+            likelihood (AbstractLikelihood): The observation likelihood.
+            latent: Whitened latent function values at the training inputs.
+                ``None`` (the default) defers initialisation to first data
+                contact.
         """
-        super().__init__(prior=prior, likelihood=likelihood, jitter=jitter)
+        super().__init__(prior=prior, likelihood=likelihood)
+        if latent is None or isinstance(latent, AbstractUnwrappable):
+            self.latent = latent
+        else:
+            self.latent = Real(latent)
 
-        if latent is None:
-            latent = jr.normal(key, shape=(self.likelihood.num_datapoints, 1))
+    def init_latent(
+        self, num_datapoints: int, key: KeyArray = jr.key(42)
+    ) -> "NonConjugateModel[M, K, NGL]":
+        r"""Return a copy of this model with the latent vector initialised.
 
-        self.latent = (
-            latent if isinstance(latent, AbstractUnwrappable) else Real(latent)
+        Args:
+            num_datapoints: The number of training observations the latent
+                must cover.
+            key: The random seed for the initial values.
+        """
+        latent = jr.normal(key, shape=(num_datapoints, 1))
+        return NonConjugateModel(
+            prior=self.prior, likelihood=self.likelihood, latent=latent
         )
 
-    def predict(
-        self,
-        test_inputs: Num[Array, "M D"],
-        train_data: Dataset,
-        *,
-        return_covariance_type: Literal["dense", "diagonal"] = "dense",
-    ) -> GaussianDistribution:
-        r"""Query the predictive posterior distribution.
+    def _prepare(self, train_data: Dataset) -> "NonConjugateModel[M, K, NGL]":
+        if self.latent is not None:
+            return self
+        return self.init_latent(train_data.n)
 
-        Conditional on a set of training data, compute the GP's posterior
-        predictive distribution for a given set of parameters. The returned
-        function can be evaluated at a set of test inputs to compute the
-        corresponding predictive density. Note, to gain predictions on the scale
-        of the original data, the returned distribution will need to be
-        transformed through the likelihood function's inverse link function.
+    def condition(self, train_data: Dataset) -> LatentPosterior:
+        r"""Return the approximate posterior implied by the current latent.
 
-        Args:
-            test_inputs (Num[Array, "N D"]): A Jax array of test inputs at which the
-                predictive distribution is evaluated.
-            train_data (Dataset): A `gpx.Dataset` object that contains the input
-                and output data used for training dataset.
-            return_covariance_type: Literal denoting whether to return the full
-                covariance of the joint predictive distribution at the test_inputs
-                (dense) or just the the standard-deviation of the predictive
-                distribution at the test_inputs.
+        A ``None`` latent conditions at the prior mean (zeros in whitened
+        space).
 
         Returns:
-            GaussianDistribution: A function that accepts an
-                input array and returns the predictive distribution as
-                a `dx.Distribution`.
+            LatentPosterior: The conditioned process. Exposes the predictive
+                (via ``__call__``) and ``log_posterior_density``.
         """
-        x = train_data.X
-        t = test_inputs
-        mean_function = self.prior.mean_function
-        kernel = self.prior.kernel
-
-        # Precompute lower triangular of Gram matrix
-        Kxx = kernel.gram(x)
-        Kxx_dense = add_jitter(Kxx.as_matrix(), self.prior.jitter)
-        Lx = jnp.linalg.cholesky(Kxx_dense)
-
-        Kxt = kernel.cross_covariance(x, t)
-        # Lx^{-1} Kxt
-        Lx_inv_Kxt = jsp.linalg.solve_triangular(Lx, Kxt, lower=True)
-
-        mean_t = mean_function(t)
-        # Whitened function values, wx, corresponding to the inputs, x
-        wx = _val(self.latent)
-
-        # mut + Ktx Lx^{-1} wx
-        mean = mean_t + jnp.matmul(Lx_inv_Kxt.T, wx)
-
-        if return_covariance_type == "dense":
-            Ktt = kernel.gram(test_inputs).as_matrix()
-            covariance = Ktt - jnp.matmul(Lx_inv_Kxt.T, Lx_inv_Kxt)
-            covariance = add_jitter(covariance, self.prior.jitter)
-            cov = lx.MatrixLinearOperator(covariance)
-        else:
-            Ktt_diag = lx.diagonal(kernel.diagonal(test_inputs))
-            var = (
-                Ktt_diag
-                - jnp.einsum("ij,ji->i", Lx_inv_Kxt.T, Lx_inv_Kxt)
-                + self.prior.jitter
-            )
-            cov = lx.DiagonalLinearOperator(jnp.atleast_1d(var.squeeze()))
-
-        return GaussianDistribution(jnp.atleast_1d(mean.squeeze()), cov)
+        latent = self.latent
+        if latent is None:
+            latent = jnp.zeros((train_data.n, 1))
+        return LatentPosterior(self.prior, self.likelihood, latent, train_data)
 
 
-class HeteroscedasticPosterior(LatentPosterior[P, HL]):
-    r"""Posterior shell for heteroscedastic likelihoods.
+class HeteroscedasticModel(JointModel[M, K, HL]):
+    r"""A joint model with input-dependent (heteroscedastic) noise.
 
-    The posterior retains both the signal and noise priors; inference is delegated
-    to variational families and specialised objectives.
+    The joint holds *two* priors — one over the signal process and one over
+    the latent noise process — which is why it is constructed directly rather
+    than via ``prior * likelihood``:
+
+    .. code-block:: python
+
+        model = gpx.gps.HeteroscedasticModel(
+            prior=signal_prior,
+            likelihood=gpx.likelihoods.HeteroscedasticGaussian(),
+            noise_prior=noise_prior,
+        )
+
+    Inference is delegated to
+    :class:`gpjax.variational_families.HeteroscedasticVariationalFamily` and
+    the ``heteroscedastic_elbo`` objective; the noise process is exposed as
+    the nested joint model :attr:`noise_model`.
     """
 
     noise_prior: tp.Any
-    noise_posterior: tp.Any
+    noise_model: tp.Any
 
     def __init__(
         self,
-        prior: AbstractPrior[M, K],
+        prior: Prior[M, K],
         likelihood: HL,
-        jitter: float = 1e-6,
+        noise_prior: Prior,
     ):
-        if likelihood.noise_prior is None:
-            raise ValueError("Heteroscedastic likelihoods require a noise_prior.")
-        super().__init__(prior=prior, likelihood=likelihood, jitter=jitter)
-        self.noise_prior = likelihood.noise_prior
-        self.noise_posterior = LatentPosterior(
-            prior=self.noise_prior, likelihood=likelihood, jitter=jitter
-        )
+        r"""Construct a heteroscedastic joint model.
 
-
-class ChainedPosterior(HeteroscedasticPosterior[P, HL]):
-    r"""Posterior routed for heteroscedastic likelihoods using chained bounds."""
-
-    def __init__(
-        self,
-        prior: AbstractPrior[M, K],
-        likelihood: HL,
-        jitter: float = 1e-6,
-    ):
-        super().__init__(prior=prior, likelihood=likelihood, jitter=jitter)
+        Args:
+            prior (Prior): The prior over the signal process.
+            likelihood (AbstractHeteroscedasticLikelihood): The observation
+                likelihood.
+            noise_prior (Prior): The prior over the latent noise process.
+        """
+        if noise_prior is None:
+            raise ValueError("Heteroscedastic models require a noise_prior.")
+        super().__init__(prior=prior, likelihood=likelihood)
+        self.noise_prior = noise_prior
+        self.noise_model = JointModel(prior=noise_prior, likelihood=likelihood)
 
 
 #######################
@@ -859,41 +571,33 @@ class ChainedPosterior(HeteroscedasticPosterior[P, HL]):
 
 
 @tp.overload
-def construct_posterior(prior: P, likelihood: GL) -> ConjugatePosterior[P, GL]: ...
+def construct_model(prior: Prior, likelihood: GL) -> ConjugateModel: ...
 
 
 @tp.overload
-def construct_posterior(prior: P, likelihood: NGL) -> NonConjugatePosterior[P, NGL]: ...
+def construct_model(prior: Prior, likelihood: NGL) -> NonConjugateModel: ...
 
 
-@tp.overload
-def construct_posterior(
-    prior: P, likelihood: HeteroscedasticGaussian
-) -> HeteroscedasticPosterior[P, HeteroscedasticGaussian]: ...
+def construct_model(
+    prior: Prior, likelihood: AbstractLikelihood
+) -> "JointModel":
+    r"""Construct the joint model for a prior/likelihood pair.
 
-
-@tp.overload
-def construct_posterior(
-    prior: P, likelihood: AbstractHeteroscedasticLikelihood
-) -> ChainedPosterior[P, AbstractHeteroscedasticLikelihood]: ...
-
-
-def construct_posterior(
-    prior: AbstractPrior, likelihood: AbstractLikelihood
-) -> "AbstractPosterior":
-    r"""Utility function for constructing a posterior object from a prior and
-    likelihood. The function will automatically select the correct posterior
-    object based on the likelihood.
+    Selects the concrete :class:`JointModel` subclass from the likelihood's
+    conjugacy. This is what ``prior * likelihood`` calls.
 
     Args:
-        prior (Prior): The Prior distribution.
-        likelihood (AbstractLikelihood): The likelihood that represents our
-            beliefs around the distribution of the data.
+        prior (Prior): The prior process.
+        likelihood (AbstractLikelihood): The observation likelihood.
 
     Returns:
-        AbstractPosterior: A posterior distribution. If the likelihood is
-            Gaussian, then a `ConjugatePosterior` will be returned. Otherwise, a
-            `NonConjugatePosterior` will be returned.
+        JointModel: A ``ConjugateModel`` for Gaussian likelihoods, a
+            ``NonConjugateModel`` otherwise.
+
+    Raises:
+        ValueError: For heteroscedastic likelihoods, which carry a second
+            prior and must be constructed directly via
+            ``HeteroscedasticModel(prior, likelihood, noise_prior=...)``.
     """
     # Multi-output validation
     from gpjax.kernels.multioutput.base import MultiOutputKernel
@@ -912,59 +616,25 @@ def construct_posterior(
             "Multi-output kernels require a MultiOutputGaussian likelihood."
         )
 
-    if isinstance(likelihood, Gaussian):
-        return ConjugatePosterior(prior=prior, likelihood=likelihood)
-
-    if (
-        isinstance(likelihood, HeteroscedasticGaussian)
-        and likelihood.supports_tight_bound()
-    ):
-        return HeteroscedasticPosterior(prior=prior, likelihood=likelihood)
-
     if isinstance(likelihood, AbstractHeteroscedasticLikelihood):
-        return ChainedPosterior(prior=prior, likelihood=likelihood)
+        raise ValueError(
+            "Heteroscedastic likelihoods carry a second (noise) prior, which "
+            "the two-operand product cannot express. Construct the model "
+            "directly: HeteroscedasticModel(prior, likelihood, "
+            "noise_prior=...)."
+        )
 
-    return NonConjugatePosterior(prior=prior, likelihood=likelihood)
+    if isinstance(likelihood, Gaussian):
+        return ConjugateModel(prior=prior, likelihood=likelihood)
 
-
-def _build_fourier_features_fn(
-    prior: Prior, num_features: int, key: KeyArray
-) -> tp.Callable[[Float[Array, "N D"]], Float[Array, "N L"]]:
-    r"""Return a function that evaluates features sampled from the Fourier feature
-    decomposition of the prior's kernel.
-
-    Args:
-        prior (Prior): The Prior distribution.
-        num_features (int): The number of feature functions to be sampled.
-        key (KeyArray): The random seed used.
-
-    Returns:
-        Callable: A callable function evaluating the sampled feature functions.
-    """
-    if (not isinstance(num_features, int)) or num_features <= 0:
-        raise ValueError("num_features must be a positive integer")
-
-    # Approximate kernel with feature decomposition
-    approximate_kernel = RFF(
-        base_kernel=prior.kernel, num_basis_fns=num_features, key=key
-    )
-
-    def eval_fourier_features(test_inputs: Float[Array, "N D"]) -> Float[Array, "N L"]:
-        Phi = approximate_kernel.compute_features(x=test_inputs)
-        Phi *= jnp.sqrt(_val(prior.kernel.variance) / num_features)
-        return Phi
-
-    return eval_fourier_features
+    return NonConjugateModel(prior=prior, likelihood=likelihood)
 
 
 __all__ = [
-    "AbstractPosterior",
-    "AbstractPrior",
-    "ChainedPosterior",
-    "ConjugatePosterior",
-    "HeteroscedasticPosterior",
-    "LatentPosterior",
-    "NonConjugatePosterior",
+    "ConjugateModel",
+    "HeteroscedasticModel",
+    "JointModel",
+    "NonConjugateModel",
     "Prior",
-    "construct_posterior",
+    "construct_model",
 ]

--- a/gpjax/gps.py
+++ b/gpjax/gps.py
@@ -442,9 +442,7 @@ class ConjugateModel(JointModel[M, K, GL]):
         Draw approximate posterior samples via pathwise conditioning
         (Wilson et al., 2020).
         """
-        return self.condition(train_data).sample_approx(
-            num_samples, key, num_features
-        )
+        return self.condition(train_data).sample_approx(num_samples, key, num_features)
 
 
 class NonConjugateModel(JointModel[M, K, NGL]):
@@ -578,9 +576,7 @@ def construct_model(prior: Prior, likelihood: GL) -> ConjugateModel: ...
 def construct_model(prior: Prior, likelihood: NGL) -> NonConjugateModel: ...
 
 
-def construct_model(
-    prior: Prior, likelihood: AbstractLikelihood
-) -> "JointModel":
+def construct_model(prior: Prior, likelihood: AbstractLikelihood) -> "JointModel":
     r"""Construct the joint model for a prior/likelihood pair.
 
     Selects the concrete :class:`JointModel` subclass from the likelihood's

--- a/gpjax/likelihoods.py
+++ b/gpjax/likelihoods.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import abc
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
 import beartype.typing as tp
 import equinox as eqx
@@ -43,9 +42,6 @@ from gpjax.typing import (
     Array,
     ScalarFloat,
 )
-
-if TYPE_CHECKING:
-    from gpjax.gps import Prior
 
 
 def _diagonal_scale(op):
@@ -85,22 +81,18 @@ class AbstractLikelihood(_SummaryMixin, eqx.Module):
     `link_function` methods.
     """
 
-    num_datapoints: int = eqx.field(static=True)
     integrator: AbstractIntegrator = eqx.field(static=True)
 
     def __init__(
         self,
-        num_datapoints: int,
         integrator: AbstractIntegrator = GHQuadratureIntegrator(),
     ):
         """Initializes the likelihood.
 
         Args:
-            num_datapoints (int): the number of data points.
             integrator (AbstractIntegrator): The integrator to be used for computing expected log
                 likelihoods. Must be an instance of `AbstractIntegrator`.
         """
-        self.num_datapoints = num_datapoints
         self.integrator = integrator
 
     def __call__(
@@ -254,21 +246,16 @@ class SoftplusTransform(AbstractNoiseTransform):
 class AbstractHeteroscedasticLikelihood(AbstractLikelihood):
     r"""Base class for heteroscedastic likelihoods with latent noise processes."""
 
-    noise_prior: tp.Any
     noise_transform: AbstractNoiseTransform
 
     def __init__(
         self,
-        num_datapoints: int,
-        noise_prior: Prior,
         noise_transform: tp.Union[
             AbstractNoiseTransform,
             tp.Callable[[Float[Array, ...]], Float[Array, ...]],
         ] = SoftplusTransform(),
         integrator: AbstractIntegrator = GHQuadratureIntegrator(),
     ):
-        self.noise_prior = noise_prior
-
         if isinstance(noise_transform, AbstractNoiseTransform):
             self.noise_transform = noise_transform
         else:
@@ -281,7 +268,7 @@ class AbstractHeteroscedasticLikelihood(AbstractLikelihood):
                 # Users should implement AbstractNoiseTransform for custom transforms.
                 self.noise_transform = SoftplusTransform()
 
-        super().__init__(num_datapoints=num_datapoints, integrator=integrator)
+        super().__init__(integrator=integrator)
 
     def __call__(
         self,
@@ -331,14 +318,12 @@ class Gaussian(AbstractLikelihood):
 
     def __init__(
         self,
-        num_datapoints: int,
         obs_stddev: tp.Union[ScalarFloat, Float[Array, "#N"], NonNegativeReal] = 1.0,
         integrator: AbstractIntegrator = AnalyticalGaussianIntegrator(),
     ):
         r"""Initializes the Gaussian likelihood.
 
         Args:
-            num_datapoints (int): the number of data points.
             obs_stddev (Union[ScalarFloat, Float[Array, "#N"]]): the standard deviation
                 of the Gaussian observation noise.
             integrator (AbstractIntegrator): The integrator to be used for computing expected log
@@ -350,7 +335,7 @@ class Gaussian(AbstractLikelihood):
         self.obs_stddev = obs_stddev
         self.num_outputs = 1
 
-        super().__init__(num_datapoints, integrator)
+        super().__init__(integrator)
 
     def link_function(self, f: Float[Array, ...]) -> npd.Normal:
         r"""The link function of the Gaussian likelihood.
@@ -412,21 +397,18 @@ class MultiOutputGaussian(Gaussian):
     """Gaussian likelihood with per-output noise variance.
 
     Args:
-        num_datapoints: Total number of observations (N, not N*P).
         num_outputs: Number of output dimensions (P).
         obs_stddev: Per-output noise standard deviation. Scalar broadcasts to [P].
     """
 
     def __init__(
         self,
-        num_datapoints: int,
         num_outputs: int,
         obs_stddev: tp.Union[float, Float[Array, " P"]] = 1.0,
     ):
         if isinstance(obs_stddev, (int, float)):
             obs_stddev = jnp.full(num_outputs, float(obs_stddev))
         super().__init__(
-            num_datapoints=num_datapoints,
             obs_stddev=NonNegativeReal(jnp.asarray(obs_stddev)),
         )
         self.num_outputs = num_outputs

--- a/gpjax/linalg/__init__.py
+++ b/gpjax/linalg/__init__.py
@@ -6,6 +6,7 @@ from gpjax.linalg.utils import (
     cholesky_factor,
     logdet,
     logdet_from_factor,
+    stabilised_cholesky,
 )
 
 __all__ = [
@@ -15,4 +16,5 @@ __all__ = [
     "cholesky_factor",
     "logdet",
     "logdet_from_factor",
+    "stabilised_cholesky",
 ]

--- a/gpjax/linalg/utils.py
+++ b/gpjax/linalg/utils.py
@@ -19,6 +19,17 @@ def add_jitter(matrix: Array, jitter: float | Array = 1e-6) -> Array:
     return matrix + jnp.eye(matrix.shape[0]) * jitter
 
 
+def stabilised_cholesky(matrix: Array, jitter: float | Array) -> Array:
+    """Lower Cholesky factor of ``matrix + jitter * I``.
+
+    The single stabilise-and-factor entry point for GP conditioning: the
+    jitter policy is applied here and nowhere else. Structure-aware
+    dispatch over lineax operators arrives with the linalg deepening; the
+    interface will not change.
+    """
+    return jnp.linalg.cholesky(add_jitter(matrix, jitter))
+
+
 @functools.singledispatch
 def cholesky_factor(op: lx.AbstractLinearOperator) -> lx.AbstractLinearOperator:
     """Cholesky factor of a PSD operator. Returns lower-triangular L s.t. A = L L^T."""

--- a/gpjax/models/oilmm.py
+++ b/gpjax/models/oilmm.py
@@ -470,9 +470,7 @@ def oilmm_mll(model: OILMMModel, data: Dataset) -> ScalarFloat:
     for i in range(m):
         latent_dataset = Dataset(X=X, y=y_projected[i][:, None])
         likelihood = Gaussian(obs_stddev=jnp.sqrt(projected_noise_vars[i]))
-        conditioned = ExactPosterior(
-            model.latent_priors[i], likelihood, latent_dataset
-        )
+        conditioned = ExactPosterior(model.latent_priors[i], likelihood, latent_dataset)
         latent_lls.append(conditioned.log_marginal_likelihood)
 
     return correction + jnp.sum(jnp.array(latent_lls))

--- a/gpjax/models/oilmm.py
+++ b/gpjax/models/oilmm.py
@@ -298,11 +298,10 @@ class OILMMModel(eqx.Module):
 
             # Create likelihood with projected noise
             likelihood = Gaussian(
-                num_datapoints=dataset.n,
                 obs_stddev=jnp.sqrt(projected_noise_vars[i]),
             )
 
-            # Standard GPJax conditioning: Prior * Likelihood -> ConjugatePosterior
+            # Standard GPJax conditioning: Prior * Likelihood -> ConjugateModel
             latent_posteriors.append(self.latent_priors[i] * likelihood)
 
         return OILMMPosterior(
@@ -315,7 +314,7 @@ class OILMMModel(eqx.Module):
 class OILMMPosterior:
     """Posterior distribution for OILMM.
 
-    Wraps M independent ConjugatePosterior objects and provides a unified
+    Wraps M independent ConjugateModel objects and provides a unified
     predict() interface that reconstructs predictions in output space.
 
     This is a plain class (not eqx.Module) because it holds Dataset objects
@@ -323,7 +322,7 @@ class OILMMPosterior:
     are still eqx.Modules and participate in JAX transformations when accessed.
 
     Attributes:
-        latent_posteriors: Tuple of M independent ConjugatePosterior objects
+        latent_posteriors: Tuple of M independent ConjugateModel objects
         latent_datasets: Tuple of M projected training Datasets (one per latent GP)
         mixing_matrix: OrthogonalMixingMatrix for reconstruction
         num_latent_gps: Number of latent GPs (m)
@@ -338,7 +337,7 @@ class OILMMPosterior:
         """Initialize OILMM posterior.
 
         Args:
-            latent_posteriors: Tuple of M ConjugatePosterior objects
+            latent_posteriors: Tuple of M ConjugateModel objects
             latent_datasets: Tuple of M Dataset objects (projected training data)
             mixing_matrix: OrthogonalMixingMatrix containing H, T
         """
@@ -432,8 +431,6 @@ def oilmm_mll(model: OILMMModel, data: Dataset) -> ScalarFloat:
     Returns:
         Scalar log marginal likelihood.
     """
-    from gpjax.linalg.utils import add_jitter
-
     n = data.n
     p = model.num_outputs
     m = model.num_latent_gps
@@ -461,23 +458,22 @@ def oilmm_mll(model: OILMMModel, data: Dataset) -> ScalarFloat:
 
     correction = term_log_S + term_noise + term_residual
 
-    # --- Latent GP log-likelihoods computed directly ---
-    # We compute each latent GP's MLL inline to avoid constructing Gaussian
-    # likelihood objects, which would trigger parameter validation checks
-    # that are incompatible with JAX's JIT tracing.
+    # --- Latent GP log-likelihoods via the conditioning module ---
+    from gpjax.conditioning import ExactPosterior
+    from gpjax.dataset import Dataset
+    from gpjax.likelihoods import Gaussian
+
     X, y_projected = model._project_observations(data)  # [N, D], [M, N]
     projected_noise_vars = mix.projected_noise_variance  # [M]
 
     latent_lls = []
     for i in range(m):
-        yi = y_projected[i]  # [N]
-        prior_i = model.latent_priors[i]
-        mx = prior_i.mean_function(X).squeeze()  # [N]
-        Kxx = prior_i.kernel.gram(X).as_matrix()  # [N, N]
-        Kxx = add_jitter(Kxx, prior_i.jitter)
-        Sigma = Kxx + projected_noise_vars[i] * jnp.eye(n)
-        dist = GaussianDistribution(jnp.atleast_1d(mx), lx.MatrixLinearOperator(Sigma))
-        latent_lls.append(dist.log_prob(jnp.atleast_1d(yi)))
+        latent_dataset = Dataset(X=X, y=y_projected[i][:, None])
+        likelihood = Gaussian(obs_stddev=jnp.sqrt(projected_noise_vars[i]))
+        conditioned = ExactPosterior(
+            model.latent_priors[i], likelihood, latent_dataset
+        )
+        latent_lls.append(conditioned.log_marginal_likelihood)
 
     return correction + jnp.sum(jnp.array(latent_lls))
 

--- a/gpjax/objectives.py
+++ b/gpjax/objectives.py
@@ -5,15 +5,12 @@ from jax import vmap
 import jax.numpy as jnp
 import jax.scipy as jsp
 from jaxtyping import Float
-import lineax as lx
-import numpyro.distributions as npd
 import typing_extensions as tpe
 
 from gpjax.dataset import Dataset
-from gpjax.distributions import GaussianDistribution
 from gpjax.gps import (
-    ConjugatePosterior,
-    NonConjugatePosterior,
+    ConjugateModel,
+    NonConjugateModel,
 )
 from gpjax.likelihoods import (
     AbstractHeteroscedasticLikelihood,
@@ -36,7 +33,7 @@ HVF = TypeVar("HVF", bound=HeteroscedasticVariationalFamily)
 Objective = tpe.Callable[[eqx.Module, Dataset], ScalarFloat]
 
 
-def conjugate_mll(posterior: ConjugatePosterior, data: Dataset) -> ScalarFloat:
+def conjugate_mll(model: ConjugateModel, data: Dataset) -> ScalarFloat:
     r"""Evaluate the marginal log-likelihood of the Gaussian process.
 
     Compute the marginal log-likelihood function of the Gaussian process.
@@ -70,11 +67,11 @@ def conjugate_mll(posterior: ConjugatePosterior, data: Dataset) -> ScalarFloat:
 
         >>> meanf = gpx.mean_functions.Constant()
         >>> kernel = gpx.kernels.RBF()
-        >>> likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n)
+        >>> likelihood = gpx.likelihoods.Gaussian()
         >>> prior = gpx.gps.Prior(mean_function = meanf, kernel=kernel)
-        >>> posterior = prior * likelihood
+        >>> model = prior * likelihood
 
-        >>> gpx.objectives.conjugate_mll(posterior, D)
+        >>> gpx.objectives.conjugate_mll(model, D)
 
         Our goal is to maximise the marginal log-likelihood. Therefore, when optimising
         the model's parameters with respect to the parameters, we use the negative
@@ -83,46 +80,18 @@ def conjugate_mll(posterior: ConjugatePosterior, data: Dataset) -> ScalarFloat:
         >>> nmll = lambda p, d: -gpx.objectives.conjugate_mll(p, d)
 
     Args:
-        posterior (ConjugatePosterior): The posterior distribution for which
-            we want to compute the marginal log-likelihood.
+        model (ConjugateModel): The joint model for which we want to compute
+            the marginal log-likelihood.
         data: The training dataset used to compute the
             marginal log-likelihood.
 
     Returns:
         ScalarFloat: The marginal log-likelihood of the Gaussian process.
     """
-
-    from gpjax.kernels.multioutput.base import MultiOutputKernel
-
-    x, y = data.X, data.y
-    kernel = posterior.prior.kernel
-    mx = posterior.prior.mean_function(x)
-
-    # Validation for multi-output models (user-facing error messages)
-    if isinstance(kernel, MultiOutputKernel):
-        if not data.multi_output:
-            raise ValueError("MultiOutputKernel requires multi-output data.")
-        if data.num_outputs != kernel.num_outputs:
-            raise ValueError(
-                f"Dataset has {data.num_outputs} outputs "
-                f"but kernel expects {kernel.num_outputs}."
-            )
-
-    # Unified path -- prepare_targets is identity for single-output,
-    # output-major reshape for multi-output
-    y_flat, mx_flat = posterior.likelihood.prepare_targets(y, mx)
-    noise = posterior.likelihood.noise_vector(data.n)
-
-    Kxx = kernel.gram(x)
-    Kxx_dense = add_jitter(Kxx.as_matrix(), posterior.prior.jitter)
-    Sigma_dense = Kxx_dense + jnp.diag(noise)
-    Sigma = lx.MatrixLinearOperator(Sigma_dense)
-
-    mll = GaussianDistribution(jnp.atleast_1d(mx_flat.squeeze()), Sigma)
-    return mll.log_prob(jnp.atleast_1d(y_flat.squeeze())).squeeze()
+    return model.condition(data).log_marginal_likelihood
 
 
-def conjugate_loocv(posterior: ConjugatePosterior, data: Dataset) -> ScalarFloat:
+def conjugate_loocv(model: ConjugateModel, data: Dataset) -> ScalarFloat:
     r"""Evaluate the leave-one-out log predictive probability of the Gaussian process following
     section 5.4.2 of Rasmussen et al. 2006 - Gaussian Processes for Machine Learning. This metric
     calculates the average performance of all models that can be obtained by training on all but one
@@ -150,11 +119,11 @@ def conjugate_loocv(posterior: ConjugatePosterior, data: Dataset) -> ScalarFloat
         ...
         >>> meanf = gpx.mean_functions.Constant()
         >>> kernel = gpx.kernels.RBF()
-        >>> likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n)
+        >>> likelihood = gpx.likelihoods.Gaussian()
         >>> prior = gpx.gps.Prior(mean_function = meanf, kernel=kernel)
-        >>> posterior = prior * likelihood
+        >>> model = prior * likelihood
         ...
-        >>> gpx.objectives.conjugate_loocv(posterior, D)
+        >>> gpx.objectives.conjugate_loocv(model, D)
 
         Our goal is to maximise the leave-one-out log predictive probability. Therefore, when
         optimising the model's parameters with respect to the parameters, we use the negative
@@ -163,48 +132,18 @@ def conjugate_loocv(posterior: ConjugatePosterior, data: Dataset) -> ScalarFloat
         >>> nloocv = lambda p, d: -gpx.objectives.conjugate_loocv(p, d)
 
     Args:
-        posterior (ConjugatePosterior): The posterior distribution for which
-            we want to compute the marginal log-likelihood.
+        model (ConjugateModel): The joint model for which we want to compute
+            the leave-one-out predictive probability.
         data: The training dataset used to compute the
-            marginal log-likelihood.
+            leave-one-out predictive probability.
 
     Returns:
-        ScalarFloat: The marginal log-likelihood of the Gaussian process.
+        ScalarFloat: The leave-one-out log predictive probability.
     """
-
-    x, y = data.X, data.y
-
-    mx = posterior.prior.mean_function(x)
-    # Likelihood protocol: identity for single-output, output-major flatten +
-    # per-output noise for multi-output (mirrors conjugate_mll).
-    y_flat, mx_flat = posterior.likelihood.prepare_targets(y, mx)
-    noise = posterior.likelihood.noise_vector(data.n)
-
-    # Sigma = Kxx + diag(noise) (+ jitter)
-    Kxx_dense = add_jitter(
-        posterior.prior.kernel.gram(x).as_matrix(), posterior.prior.jitter
-    )
-    Sigma_dense = Kxx_dense + jnp.diag(noise)
-    L = jnp.linalg.cholesky(Sigma_dense)
-
-    # diag(Sigma^-1) straight from L (R&W eq. 5.12) — no separate jnp.linalg.inv
-    # (folds in audit #662).
-    Linv = jsp.linalg.solve_triangular(L, jnp.eye(Sigma_dense.shape[0]), lower=True)
-    Sigma_inv_diag = jnp.sum(Linv**2, axis=0).reshape(-1, 1)  # [NP, 1]
-
-    resid = (y_flat - mx_flat).reshape(-1, 1)
-    Sigma_inv_y = jsp.linalg.cho_solve((L, True), resid)  # [NP, 1]
-
-    loocv_means = mx_flat.reshape(-1, 1) + resid - Sigma_inv_y / Sigma_inv_diag
-    loocv_stds = jnp.sqrt(1.0 / Sigma_inv_diag)
-
-    loocv_posterior = npd.Normal(loc=loocv_means, scale=loocv_stds)
-    return jnp.sum(loocv_posterior.log_prob(y_flat.reshape(-1, 1)))
+    return jnp.sum(model.condition(data).loo())
 
 
-def log_posterior_density(
-    posterior: NonConjugatePosterior, data: Dataset
-) -> ScalarFloat:
+def log_posterior_density(model: NonConjugateModel, data: Dataset) -> ScalarFloat:
     r"""The log-posterior density of a non-conjugate Gaussian process. This is
     sometimes referred to as the marginal log-likelihood.
 
@@ -233,44 +172,27 @@ def log_posterior_density(
 
         >>> meanf = gpx.mean_functions.Constant()
         >>> kernel = gpx.kernels.RBF()
-        >>> likelihood = gpx.likelihoods.Bernoulli(num_datapoints=D.n)
+        >>> likelihood = gpx.likelihoods.Bernoulli()
         >>> prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-        >>> posterior = prior * likelihood
+        >>> model = (prior * likelihood).init_latent(D.n)
 
-        >>> gpx.objectives.log_posterior_density(posterior, D)
+        >>> gpx.objectives.log_posterior_density(model, D)
 
     Args:
-        posterior (NonConjugatePosterior): The posterior distribution for which
-            we want to compute the marginal log-likelihood.
+        model (NonConjugateModel): The joint model for which we want to
+            compute the log-posterior density.
         data: The training dataset used to compute the
-            marginal log-likelihood.
+            log-posterior density.
 
     Returns:
         ScalarFloat: The log-posterior density of the Gaussian process.
     """
-
-    x, y = data.X, data.y
-
-    # Gram matrix
-    Kxx = posterior.prior.kernel.gram(x)
-    Kxx_dense = add_jitter(Kxx.as_matrix(), posterior.prior.jitter)
-    Lx = jnp.linalg.cholesky(Kxx_dense)
-
-    # Compute the prior mean function
-    mx = posterior.prior.mean_function(x)
-
-    # Whitened function values, wx, corresponding to the inputs, x
-    wx = _val(posterior.latent)
-
-    # f(x) = mx + Lx wx
-    fx = mx + Lx @ wx
-
-    # p(y | f(x), theta), where theta are the model hyperparameters
-    likelihood = posterior.likelihood.link_function(fx)
-
-    # Whitened latent function values prior, p(wx | theta) = N(0, I)
-    latent_prior = npd.Normal(loc=0.0, scale=1.0)
-    return likelihood.log_prob(y).sum() + latent_prior.log_prob(wx).sum()
+    if model.latent is None:
+        raise ValueError(
+            "NonConjugateModel.latent is uninitialised: fit the model or call "
+            "model.init_latent(data.n) first."
+        )
+    return model.condition(data).log_posterior_density
 
 
 non_conjugate_mll = log_posterior_density
@@ -295,7 +217,7 @@ def elbo(variational_family: VF, data: Dataset) -> ScalarFloat:
 
         >>> meanf = gpx.mean_functions.Constant()
         >>> kernel = gpx.kernels.RBF()
-        >>> likelihood = gpx.likelihoods.Bernoulli(num_datapoints=D.n)
+        >>> likelihood = gpx.likelihoods.Bernoulli()
         >>> prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
         >>> posterior = prior * likelihood
 
@@ -346,7 +268,7 @@ def variational_expectation(
 
         >>> meanf = gpx.mean_functions.Constant()
         >>> kernel = gpx.kernels.RBF()
-        >>> likelihood = gpx.likelihoods.Bernoulli(num_datapoints=D.n)
+        >>> likelihood = gpx.likelihoods.Bernoulli()
         >>> prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
         >>> posterior = prior * likelihood
 
@@ -411,7 +333,7 @@ def collapsed_elbo(variational_family: VF, data: Dataset) -> ScalarFloat:
 
         >>> meanf = gpx.mean_functions.Constant()
         >>> kernel = gpx.kernels.RBF()
-        >>> likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n)
+        >>> likelihood = gpx.likelihoods.Gaussian()
         >>> prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
         >>> posterior = prior * likelihood
 

--- a/gpjax/objectives.py
+++ b/gpjax/objectives.py
@@ -323,12 +323,8 @@ def elbo(variational_family: VF, data: Dataset) -> ScalarFloat:
     var_exp = variational_expectation(variational_family, data)
 
     # For batch size b, we compute  n/b * sum_i[ int log(p(y|f(xi))) q(f(xi)) df(xi)] - KL[q(f(.)) || p(f(.))]
-    return (
-        jnp.sum(var_exp)
-        * variational_family.posterior.likelihood.num_datapoints
-        / data.n
-        - kl
-    )
+    full_size = data.n_total if data.n_total is not None else data.n
+    return jnp.sum(var_exp) * full_size / data.n - kl
 
 
 def variational_expectation(
@@ -529,7 +525,8 @@ def heteroscedastic_elbo_conjugate(
         return_parts=True,
     )
 
-    scale = likelihood.num_datapoints / data.n
+    full_size = data.n_total if data.n_total is not None else data.n
+    scale = full_size / data.n
     return scale * jnp.sum(expected_ll) - variational_family.prior_kl()
 
 
@@ -550,7 +547,8 @@ def heteroscedastic_elbo_chained(variational_family: HVF, data: Dataset) -> Scal
         noise_stats=noise_stats,
     )
 
-    scale = likelihood.num_datapoints / data.n
+    full_size = data.n_total if data.n_total is not None else data.n
+    scale = full_size / data.n
     return scale * jnp.sum(expected_ll) - variational_family.prior_kl()
 
 

--- a/gpjax/state_space/__init__.py
+++ b/gpjax/state_space/__init__.py
@@ -4,12 +4,12 @@ See plans/2026-04-21-state-space-gps-design.md for the full design.
 """
 
 from gpjax.state_space.fit import fit, fit_lbfgs, fit_scipy
-from gpjax.state_space.gps import StateSpaceConjugatePosterior, StateSpacePrior
+from gpjax.state_space.gps import StateSpaceConjugateModel, StateSpacePrior
 from gpjax.state_space.kernels import TruncatedPeriodic, to_sde
 from gpjax.state_space.objectives import state_space_mll
 
 __all__ = [
-    "StateSpaceConjugatePosterior",
+    "StateSpaceConjugateModel",
     "StateSpacePrior",
     "TruncatedPeriodic",
     "fit",

--- a/gpjax/state_space/fit.py
+++ b/gpjax/state_space/fit.py
@@ -60,7 +60,7 @@ def fit_scipy(
         ...     mean_function=gpx.mean_functions.Zero(),
         ...     kernel=gpx.kernels.Matern32(lengthscale=1.0, variance=1.0),
         ... )
-        >>> likelihood = gpx.likelihoods.Gaussian(num_datapoints=20, obs_stddev=0.1)
+        >>> likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.1)
         >>> posterior = prior * likelihood
         >>> fitted, history = fit_scipy(
         ...     model=posterior,
@@ -105,7 +105,7 @@ def fit_lbfgs(
         ...     mean_function=gpx.mean_functions.Zero(),
         ...     kernel=gpx.kernels.Matern32(lengthscale=1.0, variance=1.0),
         ... )
-        >>> likelihood = gpx.likelihoods.Gaussian(num_datapoints=20, obs_stddev=0.1)
+        >>> likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.1)
         >>> posterior = prior * likelihood
         >>> fitted, history = fit_lbfgs(
         ...     model=posterior,
@@ -158,7 +158,7 @@ def fit(
         ...     mean_function=gpx.mean_functions.Zero(),
         ...     kernel=gpx.kernels.Matern32(lengthscale=1.0, variance=1.0),
         ... )
-        >>> likelihood = gpx.likelihoods.Gaussian(num_datapoints=20, obs_stddev=0.1)
+        >>> likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.1)
         >>> posterior = prior * likelihood
         >>> fitted, history = fit(
         ...     model=posterior,

--- a/gpjax/state_space/gps.py
+++ b/gpjax/state_space/gps.py
@@ -10,7 +10,7 @@ import lineax as lx
 import paramax
 
 from gpjax.distributions import GaussianDistribution
-from gpjax.gps import ConjugatePosterior, Prior
+from gpjax.gps import ConjugateModel, Prior
 from gpjax.likelihoods import Gaussian, MultiOutputGaussian
 
 
@@ -25,7 +25,7 @@ class StateSpacePrior(Prior):
     covariance only; the marginals are exact. A dense joint predictive is not
     implemented in v1 and is tracked as a follow-up. This predictive is
     therefore not Liskov-substitutable for a dense
-    ``gpjax.gps.ConjugatePosterior`` predictive.
+    dense ``gpjax.gps.ConjugateModel`` predictive.
 
     Example:
         >>> import gpjax as gpx
@@ -38,16 +38,16 @@ class StateSpacePrior(Prior):
         True
     """
 
-    def __call__(self, test_inputs, *, return_covariance_type="diagonal"):
-        return self.predict(test_inputs, return_covariance_type=return_covariance_type)
+    def __call__(self, test_inputs, *, covariance="diagonal"):
+        return self.predict(test_inputs, covariance=covariance)
 
-    def predict(self, test_inputs, *, return_covariance_type="diagonal"):
-        if return_covariance_type != "diagonal":
+    def predict(self, test_inputs, *, covariance="diagonal"):
+        if covariance != "diagonal":
             raise NotImplementedError(
                 "State-space prior prediction returns diagonal (marginal) covariance "
                 "only; a dense joint predictive is not implemented in v1 and is "
                 "tracked as a follow-up. The marginal variances returned are exact, "
-                "so for diagonal-only use pass return_covariance_type='diagonal'."
+                "so for diagonal-only use pass covariance='diagonal'."
             )
         from gpjax.state_space.kernels import to_sde
 
@@ -68,7 +68,7 @@ class StateSpacePrior(Prior):
         return StateSpaceConjugatePosterior(prior=self, likelihood=other)
 
 
-class StateSpaceConjugatePosterior(ConjugatePosterior):
+class StateSpaceConjugatePosterior(ConjugateModel):
     """Conjugate posterior for a state-space (Markovian) GP.
 
     v1 prediction surface:
@@ -76,14 +76,14 @@ class StateSpaceConjugatePosterior(ConjugatePosterior):
       - ``predict_filter`` : causal filtered prediction (Phase 10)
       - ``__call__``       : delegates to ``predict``
 
-    Both ``predict`` and ``predict_filter`` reject ``return_covariance_type="dense"``
+    Both ``predict`` and ``predict_filter`` reject ``covariance="dense"``
     in favour of v1's diagonal-only contract before any further dispatch.
 
     **Predictive contract (v1):** prediction returns diagonal (marginal)
     covariance only; the marginals are exact. A dense joint predictive is not
     implemented in v1 and is tracked as a follow-up. This predictive is
     therefore not Liskov-substitutable for a dense
-    ``gpjax.gps.ConjugatePosterior`` predictive.
+    dense ``gpjax.gps.ConjugateModel`` predictive.
 
     Example:
         >>> import gpjax as gpx
@@ -92,7 +92,7 @@ class StateSpaceConjugatePosterior(ConjugatePosterior):
         ...     mean_function=gpx.mean_functions.Zero(),
         ...     kernel=gpx.kernels.Matern32(lengthscale=1.0, variance=1.0),
         ... )
-        >>> likelihood = gpx.likelihoods.Gaussian(num_datapoints=20, obs_stddev=0.1)
+        >>> likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.1)
         >>> posterior = prior * likelihood
         >>> posterior.__class__.__name__
         'StateSpaceConjugatePosterior'
@@ -103,13 +103,13 @@ class StateSpaceConjugatePosterior(ConjugatePosterior):
         test_inputs,
         train_data,
         *,
-        return_covariance_type="diagonal",
+        covariance="diagonal",
         observation_mask=None,
     ):
         return self.predict(
             test_inputs,
             train_data,
-            return_covariance_type=return_covariance_type,
+            covariance=covariance,
             observation_mask=observation_mask,
         )
 
@@ -118,16 +118,16 @@ class StateSpaceConjugatePosterior(ConjugatePosterior):
         test_inputs,
         train_data,
         *,
-        return_covariance_type="diagonal",
+        covariance="diagonal",
         observation_mask=None,
     ):
-        if return_covariance_type != "diagonal":
+        if covariance != "diagonal":
             raise NotImplementedError(
                 "State-space posterior predict returns diagonal (marginal) "
                 "covariance only; a dense joint predictive is not implemented in v1 "
                 "and is tracked as a follow-up. The marginal variances returned are "
                 "exact, so for diagonal-only use pass "
-                "return_covariance_type='diagonal'."
+                "covariance='diagonal'."
             )
         from gpjax.state_space.prediction import predict_smoothed
 
@@ -140,16 +140,16 @@ class StateSpaceConjugatePosterior(ConjugatePosterior):
         test_inputs,
         train_data,
         *,
-        return_covariance_type="diagonal",
+        covariance="diagonal",
         observation_mask=None,
     ):
-        if return_covariance_type != "diagonal":
+        if covariance != "diagonal":
             raise NotImplementedError(
                 "State-space posterior predict_filter returns diagonal (marginal) "
                 "covariance only; a dense joint predictive is not implemented in v1 "
                 "and is tracked as a follow-up. The marginal variances returned are "
                 "exact, so for diagonal-only use pass "
-                "return_covariance_type='diagonal'."
+                "covariance='diagonal'."
             )
         from gpjax.state_space.prediction import predict_filtered
 

--- a/gpjax/state_space/gps.py
+++ b/gpjax/state_space/gps.py
@@ -1,4 +1,4 @@
-"""StateSpacePrior and StateSpaceConjugatePosterior classes.
+"""StateSpacePrior and StateSpaceConjugateModel classes.
 
 See plans/2026-04-21-state-space-gps-design.md.
 """
@@ -65,10 +65,10 @@ class StateSpacePrior(Prior):
 
     def __mul__(self, other):
         _require_scalar_gaussian_likelihood(other)
-        return StateSpaceConjugatePosterior(prior=self, likelihood=other)
+        return StateSpaceConjugateModel(prior=self, likelihood=other)
 
 
-class StateSpaceConjugatePosterior(ConjugateModel):
+class StateSpaceConjugateModel(ConjugateModel):
     """Conjugate posterior for a state-space (Markovian) GP.
 
     v1 prediction surface:
@@ -95,7 +95,7 @@ class StateSpaceConjugatePosterior(ConjugateModel):
         >>> likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.1)
         >>> posterior = prior * likelihood
         >>> posterior.__class__.__name__
-        'StateSpaceConjugatePosterior'
+        'StateSpaceConjugateModel'
     """
 
     def __call__(

--- a/gpjax/state_space/objectives.py
+++ b/gpjax/state_space/objectives.py
@@ -45,7 +45,7 @@ def state_space_mll(
         ...     mean_function=gpx.mean_functions.Zero(),
         ...     kernel=gpx.kernels.Matern32(lengthscale=1.0, variance=1.0),
         ... )
-        >>> likelihood = gpx.likelihoods.Gaussian(num_datapoints=20, obs_stddev=0.1)
+        >>> likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.1)
         >>> posterior = prior * likelihood
         >>> train_data = gpx.Dataset(X=X, y=y)
         >>> mll = state_space_mll(posterior, train_data)

--- a/gpjax/variational_families.py
+++ b/gpjax/variational_families.py
@@ -29,10 +29,9 @@ import lineax as lx
 from gpjax.dataset import Dataset
 from gpjax.distributions import GaussianDistribution
 from gpjax.gps import (
-    AbstractPosterior,
-    AbstractPrior,
-    ChainedPosterior,
-    HeteroscedasticPosterior,
+    HeteroscedasticModel,
+    JointModel,
+    Prior,
 )
 from gpjax.kernels.base import AbstractKernel
 from gpjax.likelihoods import (
@@ -60,9 +59,9 @@ L = tp.TypeVar("L", Gaussian, NonGaussian)
 NGL = tp.TypeVar("NGL", bound=NonGaussian)
 GL = tp.TypeVar("GL", bound=Gaussian)
 HL = tp.TypeVar("HL", bound=AbstractHeteroscedasticLikelihood)
-P = tp.TypeVar("P", bound=AbstractPrior)
-PP = tp.TypeVar("PP", bound=AbstractPosterior)
-HP = tp.TypeVar("HP", HeteroscedasticPosterior, ChainedPosterior)
+P = tp.TypeVar("P", bound=Prior)
+PP = tp.TypeVar("PP", bound=JointModel)
+HP = tp.TypeVar("HP", bound=HeteroscedasticModel)
 
 
 def _psd(matrix):
@@ -81,9 +80,9 @@ class AbstractVariationalFamily(_SummaryMixin, eqx.Module, tp.Generic[L]):
     used within variational inference.
     """
 
-    posterior: AbstractPosterior
+    posterior: JointModel
 
-    def __init__(self, posterior: AbstractPosterior[P, L]):
+    def __init__(self, posterior: JointModel):
         self.posterior = posterior
 
     def __call__(self, *args: tp.Any, **kwargs: tp.Any) -> GaussianDistribution:
@@ -126,7 +125,7 @@ class AbstractVariationalGaussian(AbstractVariationalFamily[L]):
 
     def __init__(
         self,
-        posterior: AbstractPosterior[P, L],
+        posterior: JointModel,
         inducing_inputs: tp.Union[
             Int[Array, "N D"],
             Float[Array, "N D"],
@@ -163,7 +162,7 @@ class VariationalGaussian(AbstractVariationalGaussian[L]):
 
     def __init__(
         self,
-        posterior: AbstractPosterior[P, L],
+        posterior: JointModel,
         inducing_inputs: tp.Union[Int[Array, "N D"], Float[Array, "N D"]],
         variational_mean: tp.Union[Float[Array, "N 1"], None] = None,
         variational_root_covariance: tp.Union[Float[Array, "N N"], None] = None,
@@ -344,7 +343,7 @@ class GraphVariationalGaussian(VariationalGaussian[L]):
 
     def __init__(
         self,
-        posterior: AbstractPosterior[P, L],
+        posterior: JointModel,
         inducing_inputs: Int[Array, "N D"],
         variational_mean: tp.Union[Float[Array, "N 1"], None] = None,
         variational_root_covariance: tp.Union[Float[Array, "N N"], None] = None,
@@ -511,7 +510,7 @@ class NaturalVariationalGaussian(AbstractVariationalGaussian[L]):
 
     def __init__(
         self,
-        posterior: AbstractPosterior[P, L],
+        posterior: JointModel,
         inducing_inputs: Float[Array, "N D"],
         natural_vector: tp.Union[Float[Array, "M 1"], None] = None,
         natural_matrix: tp.Union[Float[Array, "M M"], None] = None,
@@ -683,7 +682,7 @@ class ExpectationVariationalGaussian(AbstractVariationalGaussian[L]):
 
     def __init__(
         self,
-        posterior: AbstractPosterior[P, L],
+        posterior: JointModel,
         inducing_inputs: Float[Array, "N D"],
         expectation_vector: tp.Union[Float[Array, "M 1"], None] = None,
         expectation_matrix: tp.Union[Float[Array, "M M"], None] = None,
@@ -848,7 +847,7 @@ class CollapsedVariationalGaussian(AbstractVariationalGaussian[GL]):
 
     def __init__(
         self,
-        posterior: AbstractPosterior[P, GL],
+        posterior: JointModel,
         inducing_inputs: Float[Array, "N D"],
         jitter: ScalarFloat = 1e-6,
     ):
@@ -1006,7 +1005,7 @@ class HeteroscedasticVariationalFamily(AbstractVariationalFamily[HL]):
 
         if noise_init is not None:
             self.noise_variational = VariationalGaussian(
-                posterior=posterior.noise_posterior,
+                posterior=posterior.noise_model,
                 inducing_inputs=noise_init.inducing_inputs,
                 variational_mean=noise_init.variational_mean,
                 variational_root_covariance=noise_init.variational_root_covariance,
@@ -1025,7 +1024,7 @@ class HeteroscedasticVariationalFamily(AbstractVariationalFamily[HL]):
                 )
 
             self.noise_variational = VariationalGaussian(
-                posterior=posterior.noise_posterior,
+                posterior=posterior.noise_model,
                 inducing_inputs=noise_inducing,
                 variational_mean=variational_mean_g,
                 variational_root_covariance=variational_root_covariance_g,

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -117,8 +117,8 @@ regression = Result(
     path="docs/examples/regression.py",
     comparisons={
         "history": (55.07405622, get_last),
-        "predictive_mean": (36.24383416, jnp.sum),
-        "predictive_std": (197.04727051, jnp.sum),
+        "predictive_mean": (37.91222107, jnp.sum),
+        "predictive_std": (202.36889441, jnp.sum),
     },
 )
 regression.test()
@@ -127,9 +127,9 @@ regression.test()
 sparse = Result(
     path="docs/examples/collapsed_vi.py",
     comparisons={
-        "history": (1924.7634809, get_last),
-        "predictive_mean": (-8.39869652, jnp.sum),
-        "predictive_std": (255.74838027, jnp.sum),
+        "history": (1851.11700608, get_last),
+        "predictive_mean": (1.37497714, jnp.sum),
+        "predictive_std": (248.32254630, jnp.sum),
     },
 )
 sparse.test()
@@ -138,9 +138,9 @@ sparse.test()
 stochastic = Result(
     path="docs/examples/uncollapsed_vi.py",
     comparisons={
-        "history": (-2678.41302494, get_last),
-        "meanf": (-54.14787028, jnp.sum),
-        "sigma": (121.4298333, jnp.sum),
+        "history": (59440.08265547, get_last),
+        "meanf": (-55.18585235, jnp.sum),
+        "sigma": (555.41381240, jnp.sum),
     },
 )
 stochastic.test()
@@ -149,7 +149,7 @@ stochastic.test()
 heteroscedastic = Result(
     path="docs/examples/heteroscedastic_inference.py",
     comparisons={
-        "history": (-141.590, get_last),
+        "history": (-139.22405213, get_last),
     },
 )
 heteroscedastic.test()

--- a/tests/integration_tests.py
+++ b/tests/integration_tests.py
@@ -46,6 +46,7 @@ class Result:
 
     def __post_init__(self):
         self.name: str = self.path.split("/")[-1].split(".")[0].replace("_", "-")
+        self.failures: list = []
 
     def _compare(
         self,
@@ -56,11 +57,14 @@ class Result:
     ):
         if variable_name == "history" and not self.compare_history:
             return
-        try:
-            value = operation(observed_variables[variable_name])
-            assert abs(true_value - value) < self.precision
-        except AssertionError as e:
-            print(e)
+        value = operation(observed_variables[variable_name])
+        if not abs(true_value - value) < self.precision:
+            message = (
+                f"{self.name}: {variable_name} drifted from golden value "
+                f"{true_value} (got {value}, precision {self.precision})"
+            )
+            print(message)
+            self.failures.append(message)
 
     def test(self):
         notebook = jupytext.read(self.path)
@@ -100,6 +104,11 @@ class Result:
             truth, op = v
             self._compare(
                 observed_variables=loc, variable_name=k, true_value=truth, operation=op
+            )
+        if self.failures:
+            raise AssertionError(
+                f"{self.name}: golden-value drift detected:\n"
+                + "\n".join(self.failures)
             )
 
 

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -2,7 +2,6 @@ from jax import config
 
 config.update("jax_enable_x64", True)
 
-import gpjax as gpx
 from gpjax.citation import (
     AbstractCitation,
     NullCitation,
@@ -21,7 +20,6 @@ from gpjax.kernels import (
     Matern52,
 )
 from gpjax.likelihoods import HeteroscedasticGaussian
-from gpjax.mean_functions import Zero
 import jax.numpy as jnp
 import pytest
 
@@ -99,7 +97,6 @@ def test_missing_citation(kernel):
 
 
 def test_heteroscedastic_citation():
-    noise_prior = gpx.gps.Prior(mean_function=Zero(), kernel=RBF())
     likelihood = HeteroscedasticGaussian()
     citation = cite(likelihood)
 

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -100,7 +100,7 @@ def test_missing_citation(kernel):
 
 def test_heteroscedastic_citation():
     noise_prior = gpx.gps.Prior(mean_function=Zero(), kernel=RBF())
-    likelihood = HeteroscedasticGaussian(num_datapoints=10, noise_prior=noise_prior)
+    likelihood = HeteroscedasticGaussian()
     citation = cite(likelihood)
 
     assert isinstance(citation, PaperCitation)

--- a/tests/test_conditioning_equivalence.py
+++ b/tests/test_conditioning_equivalence.py
@@ -39,9 +39,12 @@ def test_collapsed_elbo_equals_mll_when_z_is_x():
 
 @pytest.mark.xfail(
     strict=True,
-    reason="jitter has two owners (Prior.jitter vs the variational family's "
-    "jitter); collapsed_elbo and conjugate_mll factorise different matrices "
-    "at non-default jitter. Resolved by the v1.0 conditioning stack.",
+    reason="the variational family still carries its own jitter knob "
+    "(q.jitter enters Kzz; the model's Prior.jitter enters Sigma), so "
+    "collapsed_elbo and conjugate_mll factorise different matrices at "
+    "non-default jitter. The model-side split is fixed (see "
+    "test_predict_consistent_with_mll_nondefault_jitter); the family-side "
+    "knob unifies in the variational universalisation PR, post-natgrads.",
 )
 def test_collapsed_elbo_equals_mll_when_z_is_x_nondefault_jitter():
     posterior, data = _make(jitter=1e-3)
@@ -51,6 +54,37 @@ def test_collapsed_elbo_equals_mll_when_z_is_x_nondefault_jitter():
     elbo = gpx.objectives.collapsed_elbo(q, data)
     mll = gpx.objectives.conjugate_mll(posterior, data)
     assert jnp.allclose(elbo, mll, atol=2e-4)
+
+
+def test_predict_consistent_with_mll_nondefault_jitter():
+    """predict and the MLL must factorise the SAME matrix at any jitter.
+
+    Before v1.0, ConjugatePosterior.predict applied ``self.jitter`` to the
+    training gram while conjugate_mll applied ``prior.jitter`` — two
+    independent knobs that could legally diverge. Both quantities are now
+    views of one conditioned Posterior, so this closed-form check holds at
+    a deliberately non-default jitter.
+    """
+    jitter = 1e-3
+    model, data = _make(jitter=jitter)
+    posterior = model.condition(data)
+
+    kernel_gram = model.prior.kernel.gram(data.X).as_matrix()
+    noise_variance = 0.2**2
+    sigma = kernel_gram + (jitter + noise_variance) * jnp.eye(data.n)
+    residual = data.y[:, 0] - model.prior.mean_function(data.X)[:, 0]
+
+    quad = residual @ jnp.linalg.solve(sigma, residual)
+    _, logdet = jnp.linalg.slogdet(sigma)
+    expected_mll = -0.5 * (quad + logdet + data.n * jnp.log(2.0 * jnp.pi))
+    assert jnp.allclose(posterior.log_marginal_likelihood, expected_mll, atol=1e-8)
+
+    cross = model.prior.kernel.cross_covariance(data.X, data.X)
+    expected_mean = model.prior.mean_function(data.X)[:, 0] + cross.T @ (
+        jnp.linalg.solve(sigma, residual)
+    )
+    predictive = posterior(data.X)
+    assert jnp.allclose(predictive.mean, expected_mean, atol=1e-8)
 
 
 def test_whitened_matches_unwhitened_at_matched_parameters():

--- a/tests/test_conditioning_equivalence.py
+++ b/tests/test_conditioning_equivalence.py
@@ -21,7 +21,7 @@ def _make(jitter=1e-6):
         kernel=gpx.kernels.RBF(),
         jitter=jitter,
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=data.n, obs_stddev=0.2)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.2)
     return prior * likelihood, data
 
 

--- a/tests/test_conditioning_equivalence.py
+++ b/tests/test_conditioning_equivalence.py
@@ -54,7 +54,7 @@ def test_collapsed_elbo_equals_mll_when_z_is_x_nondefault_jitter():
 
 
 def test_whitened_matches_unwhitened_at_matched_parameters():
-    posterior, data = _make()
+    posterior, _ = _make()
     z = jnp.linspace(0.0, 1.0, 5).reshape(-1, 1)
     q_white = gpx.variational_families.WhitenedVariationalGaussian(
         posterior=posterior, inducing_inputs=z

--- a/tests/test_conditioning_equivalence.py
+++ b/tests/test_conditioning_equivalence.py
@@ -1,0 +1,113 @@
+"""Equivalence tests across independently-derived conditioning code paths.
+
+Five call sites in the library derive the conjugate conditioning algebra
+independently (predict, MLL, LOOCV, collapsed ELBO, variational predicts).
+These tests pin the mathematical identities that must hold across them, so
+that consolidating the derivations cannot silently change behaviour.
+"""
+
+import jax.numpy as jnp
+import pytest
+
+import gpjax as gpx
+
+
+def _make(jitter=1e-6):
+    x = jnp.linspace(0.0, 1.0, 12).reshape(-1, 1)
+    y = jnp.sin(3.0 * x)
+    data = gpx.Dataset(X=x, y=y)
+    prior = gpx.gps.Prior(
+        mean_function=gpx.mean_functions.Constant(),
+        kernel=gpx.kernels.RBF(),
+        jitter=jitter,
+    )
+    likelihood = gpx.likelihoods.Gaussian(num_datapoints=data.n, obs_stddev=0.2)
+    return prior * likelihood, data
+
+
+def test_collapsed_elbo_equals_mll_when_z_is_x():
+    posterior, data = _make()
+    q = gpx.variational_families.CollapsedVariationalGaussian(
+        posterior=posterior, inducing_inputs=data.X
+    )
+    elbo = gpx.objectives.collapsed_elbo(q, data)
+    mll = gpx.objectives.conjugate_mll(posterior, data)
+    # The identity is exact only in the jitter -> 0 limit: the family's jitter
+    # enters Kzz while the model's enters Sigma, so a small O(jitter/noise)
+    # discrepancy is expected even when both knobs are 1e-6.
+    assert jnp.allclose(elbo, mll, atol=2e-4)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="jitter has two owners (Prior.jitter vs the variational family's "
+    "jitter); collapsed_elbo and conjugate_mll factorise different matrices "
+    "at non-default jitter. Resolved by the v1.0 conditioning stack.",
+)
+def test_collapsed_elbo_equals_mll_when_z_is_x_nondefault_jitter():
+    posterior, data = _make(jitter=1e-3)
+    q = gpx.variational_families.CollapsedVariationalGaussian(
+        posterior=posterior, inducing_inputs=data.X
+    )
+    elbo = gpx.objectives.collapsed_elbo(q, data)
+    mll = gpx.objectives.conjugate_mll(posterior, data)
+    assert jnp.allclose(elbo, mll, atol=2e-4)
+
+
+def test_whitened_matches_unwhitened_at_matched_parameters():
+    posterior, data = _make()
+    z = jnp.linspace(0.0, 1.0, 5).reshape(-1, 1)
+    q_white = gpx.variational_families.WhitenedVariationalGaussian(
+        posterior=posterior, inducing_inputs=z
+    )
+    q_plain = gpx.variational_families.VariationalGaussian(
+        posterior=posterior, inducing_inputs=z
+    )
+    # At default parameters, whitened q(u) = N(0, I) and unwhitened
+    # q(u) = N(0, I) describe different measures UNLESS the predictive
+    # reduces identically; we instead match parameters explicitly:
+    # unwhitened (mu, sqrt) = (m(z) + Lz mu_w, Lz sqrt_w).
+    import equinox as eqx
+
+    kernel = posterior.prior.kernel
+    kzz = kernel.gram(z).as_matrix() + 1e-6 * jnp.eye(z.shape[0])
+    lz = jnp.linalg.cholesky(kzz)
+    mu_white = jnp.array([[0.3], [-0.2], [0.1], [0.4], [-0.5]])
+    sqrt_white = 0.1 * jnp.eye(5) + 0.05 * jnp.tril(jnp.ones((5, 5)), k=-1)
+
+    mean_z = posterior.prior.mean_function(z)
+    mu_plain = mean_z + lz @ mu_white
+    sqrt_plain = lz @ sqrt_white
+
+    q_white = eqx.tree_at(
+        lambda q: (q.variational_mean, q.variational_root_covariance),
+        q_white,
+        (
+            type(q_white.variational_mean)(mu_white)
+            if hasattr(type(q_white.variational_mean), "unwrap")
+            else mu_white,
+            type(q_white.variational_root_covariance)(sqrt_white)
+            if hasattr(type(q_white.variational_root_covariance), "unwrap")
+            else sqrt_white,
+        ),
+    )
+    q_plain = eqx.tree_at(
+        lambda q: (q.variational_mean, q.variational_root_covariance),
+        q_plain,
+        (
+            type(q_plain.variational_mean)(mu_plain)
+            if hasattr(type(q_plain.variational_mean), "unwrap")
+            else mu_plain,
+            type(q_plain.variational_root_covariance)(sqrt_plain)
+            if hasattr(type(q_plain.variational_root_covariance), "unwrap")
+            else sqrt_plain,
+        ),
+    )
+
+    xtest = jnp.linspace(-0.2, 1.2, 7).reshape(-1, 1)
+    dist_white = q_white(xtest)
+    dist_plain = q_plain(xtest)
+    assert jnp.allclose(dist_white.mean, dist_plain.mean, atol=1e-5)
+    assert jnp.allclose(
+        dist_white.covariance_matrix, dist_plain.covariance_matrix, atol=1e-5
+    )

--- a/tests/test_conditioning_equivalence.py
+++ b/tests/test_conditioning_equivalence.py
@@ -6,10 +6,9 @@ These tests pin the mathematical identities that must hold across them, so
 that consolidating the derivations cannot silently change behaviour.
 """
 
+import gpjax as gpx
 import jax.numpy as jnp
 import pytest
-
-import gpjax as gpx
 
 
 def _make(jitter=1e-6):

--- a/tests/test_conditioning_oracle.py
+++ b/tests/test_conditioning_oracle.py
@@ -8,9 +8,8 @@ MLL, ``collapsed_elbo`` — is validated against ``conjugate_mll``, so these
 oracles are the ground truth the rest of the suite stands on.
 """
 
-import jax.numpy as jnp
-
 import gpjax as gpx
+import jax.numpy as jnp
 
 JITTER = 1e-6
 OBS_STDDEV = 0.3
@@ -32,9 +31,7 @@ def _posterior():
     prior = gpx.gps.Prior(
         mean_function=gpx.mean_functions.Zero(), kernel=kernel, jitter=JITTER
     )
-    likelihood = gpx.likelihoods.Gaussian(
-        obs_stddev=OBS_STDDEV
-    )
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=OBS_STDDEV)
     return prior * likelihood
 
 

--- a/tests/test_conditioning_oracle.py
+++ b/tests/test_conditioning_oracle.py
@@ -1,6 +1,6 @@
 """Closed-form oracles for the conjugate GP quantities.
 
-These tests pin the *values* of ``conjugate_mll``, ``ConjugatePosterior.predict``
+These tests pin the *values* of ``conjugate_mll``, ``ConjugateModel.predict``
 and ``conjugate_loocv`` on a tiny fixed dataset, computed through an independent
 linear-algebra path (direct ``jnp.linalg.solve``/``slogdet``, never
 ``GaussianDistribution``). Everything downstream in the test suite — the Kalman
@@ -33,7 +33,7 @@ def _posterior():
         mean_function=gpx.mean_functions.Zero(), kernel=kernel, jitter=JITTER
     )
     likelihood = gpx.likelihoods.Gaussian(
-        num_datapoints=X.shape[0], obs_stddev=OBS_STDDEV
+        obs_stddev=OBS_STDDEV
     )
     return prior * likelihood
 

--- a/tests/test_conditioning_oracle.py
+++ b/tests/test_conditioning_oracle.py
@@ -1,0 +1,91 @@
+"""Closed-form oracles for the conjugate GP quantities.
+
+These tests pin the *values* of ``conjugate_mll``, ``ConjugatePosterior.predict``
+and ``conjugate_loocv`` on a tiny fixed dataset, computed through an independent
+linear-algebra path (direct ``jnp.linalg.solve``/``slogdet``, never
+``GaussianDistribution``). Everything downstream in the test suite — the Kalman
+MLL, ``collapsed_elbo`` — is validated against ``conjugate_mll``, so these
+oracles are the ground truth the rest of the suite stands on.
+"""
+
+import jax.numpy as jnp
+
+import gpjax as gpx
+
+JITTER = 1e-6
+OBS_STDDEV = 0.3
+LENGTHSCALE = 0.7
+VARIANCE = 1.3
+
+X = jnp.array([[0.0], [0.45], [1.1]])
+Y = jnp.array([[0.2], [-0.1], [0.6]])
+XTEST = jnp.array([[0.2], [0.85]])
+
+
+def _rbf(x1, x2):
+    sq_dists = (x1[:, None, 0] - x2[None, :, 0]) ** 2
+    return VARIANCE * jnp.exp(-0.5 * sq_dists / LENGTHSCALE**2)
+
+
+def _posterior():
+    kernel = gpx.kernels.RBF(lengthscale=LENGTHSCALE, variance=VARIANCE)
+    prior = gpx.gps.Prior(
+        mean_function=gpx.mean_functions.Zero(), kernel=kernel, jitter=JITTER
+    )
+    likelihood = gpx.likelihoods.Gaussian(
+        num_datapoints=X.shape[0], obs_stddev=OBS_STDDEV
+    )
+    return prior * likelihood
+
+
+def _sigma():
+    n = X.shape[0]
+    return _rbf(X, X) + (JITTER + OBS_STDDEV**2) * jnp.eye(n)
+
+
+def test_conjugate_mll_matches_closed_form():
+    posterior = _posterior()
+    data = gpx.Dataset(X=X, y=Y)
+
+    sigma = _sigma()
+    n = X.shape[0]
+    quad = Y[:, 0] @ jnp.linalg.solve(sigma, Y[:, 0])
+    _, logdet = jnp.linalg.slogdet(sigma)
+    expected = -0.5 * (quad + logdet + n * jnp.log(2.0 * jnp.pi))
+
+    actual = gpx.objectives.conjugate_mll(posterior, data)
+    assert jnp.allclose(actual, expected, atol=1e-10)
+
+
+def test_predict_matches_closed_form():
+    posterior = _posterior()
+    data = gpx.Dataset(X=X, y=Y)
+
+    sigma = _sigma()
+    kxt = _rbf(X, XTEST)
+    ktt = _rbf(XTEST, XTEST)
+    sigma_inv_y = jnp.linalg.solve(sigma, Y[:, 0])
+    expected_mean = kxt.T @ sigma_inv_y
+    expected_cov = ktt - kxt.T @ jnp.linalg.solve(sigma, kxt) + JITTER * jnp.eye(2)
+
+    predictive = posterior.predict(XTEST, data)
+    assert jnp.allclose(predictive.mean, expected_mean, atol=1e-8)
+    assert jnp.allclose(predictive.covariance_matrix, expected_cov, atol=1e-8)
+
+
+def test_loocv_matches_closed_form():
+    posterior = _posterior()
+    data = gpx.Dataset(X=X, y=Y)
+
+    sigma = _sigma()
+    sigma_inv = jnp.linalg.inv(sigma)
+    resid = Y[:, 0]
+    diag = jnp.diag(sigma_inv)
+    loo_means = resid - sigma_inv @ resid / diag
+    loo_vars = 1.0 / diag
+    expected = jnp.sum(
+        -0.5 * (jnp.log(2 * jnp.pi * loo_vars) + (resid - loo_means) ** 2 / loo_vars)
+    )
+
+    actual = gpx.objectives.conjugate_loocv(posterior, data)
+    assert jnp.allclose(actual, expected, atol=1e-8)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -207,10 +207,9 @@ def test_n_total_defaults_to_none():
 
 
 def test_get_batch_stamps_n_total():
+    from gpjax.fit import get_batch
     import jax
     import jax.random as jr
-
-    from gpjax.fit import get_batch
 
     x = jnp.linspace(0.0, 1.0, 25).reshape(-1, 1)
     dataset = Dataset(X=x, y=jnp.sin(x))

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -198,3 +198,30 @@ def test_dataset_multi_output_properties():
     D = Dataset(X=X, y=y)
     assert D.multi_output is True
     assert D.num_outputs == 3
+
+
+def test_n_total_defaults_to_none():
+    x = jnp.linspace(0.0, 1.0, 10).reshape(-1, 1)
+    dataset = Dataset(X=x, y=jnp.sin(x))
+    assert dataset.n_total is None
+
+
+def test_get_batch_stamps_n_total():
+    import jax
+    import jax.random as jr
+
+    from gpjax.fit import get_batch
+
+    x = jnp.linspace(0.0, 1.0, 25).reshape(-1, 1)
+    dataset = Dataset(X=x, y=jnp.sin(x))
+    batch = get_batch(dataset, batch_size=4, key=jr.key(0))
+    assert batch.n == 4
+    assert batch.n_total == 25
+
+    # The stamp is static aux_data: it survives pytree operations.
+    mapped = jax.tree_util.tree_map(lambda leaf: leaf, batch)
+    assert mapped.n_total == 25
+
+    # Batching a batch preserves the original full size.
+    rebatch = get_batch(batch, batch_size=2, key=jr.key(1))
+    assert rebatch.n_total == 25

--- a/tests/test_dtype.py
+++ b/tests/test_dtype.py
@@ -104,7 +104,7 @@ def test_posterior_predict_dtype(enable_x64):
 
     x_test = jnp.linspace(0, 1, 5, dtype=dtype)[:, None]
     prior = Prior(mean_function=Constant(), kernel=RBF())
-    likelihood = Gaussian(num_datapoints=D.n)
+    likelihood = Gaussian()
     posterior = prior * likelihood
 
     dist = posterior.predict(x_test, D)
@@ -128,7 +128,7 @@ def test_conjugate_mll_dtype(enable_x64):
     D = Dataset(X=x, y=y)
 
     prior = Prior(mean_function=Constant(), kernel=RBF())
-    likelihood = Gaussian(num_datapoints=D.n)
+    likelihood = Gaussian()
     posterior = prior * likelihood
 
     mll = conjugate_mll(posterior, D)

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -30,7 +30,7 @@ from gpjax.fit import (
     get_batch,
 )
 from gpjax.gps import (
-    ConjugatePosterior,
+    ConjugateModel,
     Prior,
 )
 from gpjax.kernels import RBF
@@ -187,7 +187,7 @@ def test_fit_gp_regression(n_data: int, verbose: bool) -> None:
 
     # Define GP model:
     prior = Prior(kernel=RBF(), mean_function=Constant())
-    likelihood = Gaussian(num_datapoints=n_data)
+    likelihood = Gaussian()
     posterior = prior * likelihood
 
     # Train!
@@ -202,7 +202,7 @@ def test_fit_gp_regression(n_data: int, verbose: bool) -> None:
     )
 
     # Ensure the trained model is a Gaussian process posterior
-    assert isinstance(trained_model, ConjugatePosterior)
+    assert isinstance(trained_model, ConjugateModel)
 
     # Ensure we return a history of the correct length
     assert len(history) == 15
@@ -223,7 +223,7 @@ def test_fit_lbfgs_gp_regression(n_data: int) -> None:
 
     # Define GP model:
     prior = Prior(kernel=RBF(), mean_function=Constant())
-    likelihood = Gaussian(num_datapoints=n_data)
+    likelihood = Gaussian()
     posterior = prior * likelihood
 
     # Train with BFGS!
@@ -235,7 +235,7 @@ def test_fit_lbfgs_gp_regression(n_data: int) -> None:
     )
 
     # Ensure the trained model is a Gaussian process posterior
-    assert isinstance(trained_model_bfgs, ConjugatePosterior)
+    assert isinstance(trained_model_bfgs, ConjugateModel)
 
     # Ensure we reduce the loss
     assert conjugate_mll(trained_model_bfgs, D) < conjugate_mll(posterior, D)
@@ -254,7 +254,7 @@ def test_fit_scipy_error_raises() -> None:
 
     # Define GP model with crazy mean function:
     prior = Prior(kernel=RBF(), mean_function=CrazyMean())
-    likelihood = Gaussian(num_datapoints=2)
+    likelihood = Gaussian()
     posterior = prior * likelihood
 
     with pytest.raises(scipy.optimize.OptimizeWarning):
@@ -267,7 +267,7 @@ def test_fit_scipy_error_raises() -> None:
 
     # also check fails if no given enough steps
     prior = Prior(kernel=RBF(), mean_function=Constant())
-    likelihood = Gaussian(num_datapoints=2)
+    likelihood = Gaussian()
     posterior = prior * likelihood
 
     with pytest.raises(scipy.optimize.OptimizeWarning):
@@ -294,7 +294,7 @@ def test_fit_batch(num_iters: int, batch_size: int, n_data: int, verbose: bool) 
 
     # Define GP model:
     prior = Prior(kernel=RBF(), mean_function=Constant())
-    likelihood = Gaussian(num_datapoints=n_data)
+    likelihood = Gaussian()
     posterior = prior * likelihood
 
     # Define variational family:
@@ -495,7 +495,7 @@ def test_fit_freeze_kernel_variance() -> None:
     meanf = gpx.mean_functions.Zero()
     kernel = gpx.kernels.RBF(lengthscale=1.0, variance=1.0)
     prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n)
+    likelihood = gpx.likelihoods.Gaussian()
     posterior = prior * likelihood
 
     # Record initial variance value
@@ -540,7 +540,7 @@ def test_fit_zero_mean_function_is_frozen_by_default() -> None:
     posterior = gpx.gps.Prior(
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.RBF(lengthscale=1.0, variance=1.0),
-    ) * gpx.likelihoods.Gaussian(num_datapoints=D.n)
+    ) * gpx.likelihoods.Gaussian()
 
     trained_posterior, _ = fit(
         model=posterior,
@@ -568,7 +568,7 @@ def test_fit_constant_mean_function_with_parameter() -> None:
     meanf = gpx.mean_functions.Constant(constant=Real(1.0))  # Start with mean 1.0
     kernel = gpx.kernels.RBF(lengthscale=1.0, variance=1.0)
     prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n, obs_stddev=0.1)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.1)
     posterior = prior * likelihood
 
     # Record initial mean function constant
@@ -606,7 +606,7 @@ def test_fit_constant_mean_function_frozen_with_non_trainable() -> None:
     meanf = gpx.mean_functions.Constant(constant=1.0)  # Fixed mean 1.0
     kernel = gpx.kernels.RBF(lengthscale=1.0, variance=0.1)
     prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n, obs_stddev=0.1)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.1)
     posterior = prior * likelihood
 
     # Record initial mean function constant
@@ -645,7 +645,7 @@ def test_fit_freeze_by_non_trainable() -> None:
     meanf = gpx.mean_functions.Zero()
     kernel = gpx.kernels.RBF(lengthscale=1.0, variance=1.0)
     prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n)
+    likelihood = gpx.likelihoods.Gaussian()
     posterior = prior * likelihood
 
     # Record initial values

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -537,10 +537,13 @@ def test_fit_zero_mean_function_is_frozen_by_default() -> None:
     y = jnp.full_like(X, 25.0)  # data with a large non-zero mean
     D = Dataset(X, y)
 
-    posterior = gpx.gps.Prior(
-        mean_function=gpx.mean_functions.Zero(),
-        kernel=gpx.kernels.RBF(lengthscale=1.0, variance=1.0),
-    ) * gpx.likelihoods.Gaussian()
+    posterior = (
+        gpx.gps.Prior(
+            mean_function=gpx.mean_functions.Zero(),
+            kernel=gpx.kernels.RBF(lengthscale=1.0, variance=1.0),
+        )
+        * gpx.likelihoods.Gaussian()
+    )
 
     trained_posterior, _ = fit(
         model=posterior,

--- a/tests/test_gps.py
+++ b/tests/test_gps.py
@@ -26,12 +26,12 @@ from collections.abc import Callable
 from gpjax.dataset import Dataset
 from gpjax.distributions import GaussianDistribution
 from gpjax.gps import (
-    AbstractPosterior,
-    AbstractPrior,
-    ConjugatePosterior,
-    NonConjugatePosterior,
+    JointModel,
     Prior,
-    construct_posterior,
+    ConjugateModel,
+    NonConjugateModel,
+    Prior,
+    construct_model,
 )
 from gpjax.kernels import (
     RBF,
@@ -63,13 +63,13 @@ config.update("jax_enable_x64", True)
 def test_abstract_prior():
     # Abstract prior should not be able to be instantiated.
     with pytest.raises(TypeError):
-        AbstractPrior()
+        Prior()
 
 
 def test_abstract_posterior():
     # Abstract posterior should not be able to be instantiated.
     with pytest.raises(TypeError):
-        AbstractPosterior()
+        JointModel()
 
 
 @pytest.mark.parametrize("num_datapoints", [1, 10])
@@ -85,12 +85,12 @@ def test_prior_with_diag(
 
     # Check types.
     assert isinstance(prior, Prior)
-    assert isinstance(prior, AbstractPrior)
+    assert isinstance(prior, Prior)
 
     # Query a marginal distribution at some inputs.
     inputs = jnp.linspace(-3.0, 3.0, num_datapoints).reshape(-1, 1)
-    marginal_distribution_diag = prior(inputs, return_covariance_type="diagonal")
-    marginal_distribution_full = prior(inputs, return_covariance_type="dense")
+    marginal_distribution_diag = prior(inputs, covariance="diagonal")
+    marginal_distribution_full = prior(inputs, covariance="dense")
 
     # Ensure that the marginal distribution is a Gaussian.
     assert isinstance(marginal_distribution_diag, GaussianDistribution)
@@ -122,7 +122,7 @@ def test_prior(
 
     # Check types.
     assert isinstance(prior, Prior)
-    assert isinstance(prior, AbstractPrior)
+    assert isinstance(prior, Prior)
 
     # Query a marginal distribution at some inputs.
     inputs = jnp.linspace(-3.0, 3.0, num_datapoints).reshape(-1, 1)
@@ -159,18 +159,18 @@ def test_conjugate_posterior_with_diag(
     prior = Prior(mean_function=mean_function(), kernel=kernel())
 
     # Define a likelihood.
-    likelihood = Gaussian(num_datapoints=num_datapoints)
+    likelihood = Gaussian()
 
     # Construct the posterior via the class.
-    posterior = ConjugatePosterior(prior=prior, likelihood=likelihood)
+    posterior = ConjugateModel(prior=prior, likelihood=likelihood)
 
     # Check types.
-    assert isinstance(posterior, ConjugatePosterior)
+    assert isinstance(posterior, ConjugateModel)
 
     # Query a marginal distribution of the posterior at some inputs.
     inputs = jnp.linspace(-3.0, 3.0, num_test_datapoints).reshape(-1, 1)
-    marginal_distribution_diag = posterior(inputs, D, return_covariance_type="diagonal")
-    marginal_distribution_full = posterior(inputs, D, return_covariance_type="dense")
+    marginal_distribution_diag = posterior(inputs, D, covariance="diagonal")
+    marginal_distribution_full = posterior(inputs, D, covariance="dense")
 
     # Ensure that the marginal distribution is a Gaussian.
     assert isinstance(marginal_distribution_diag, GaussianDistribution)
@@ -209,13 +209,13 @@ def test_conjugate_posterior(
     prior = Prior(mean_function=mean_function(), kernel=kernel())
 
     # Define a likelihood.
-    likelihood = Gaussian(num_datapoints=num_datapoints)
+    likelihood = Gaussian()
 
     # Construct the posterior via the class.
-    posterior = ConjugatePosterior(prior=prior, likelihood=likelihood)
+    posterior = ConjugateModel(prior=prior, likelihood=likelihood)
 
     # Check types.
-    assert isinstance(posterior, ConjugatePosterior)
+    assert isinstance(posterior, ConjugateModel)
 
     # Query a marginal distribution of the posterior at some inputs.
     inputs = jnp.linspace(-3.0, 3.0, num_test_datapoints).reshape(-1, 1)
@@ -253,13 +253,16 @@ def test_nonconjugate_posterior_with_diag(
     prior = Prior(mean_function=mean_function(), kernel=kernel())
 
     # Define a likelihood.
-    likelihood = Bernoulli(num_datapoints=num_datapoints)
+    likelihood = Bernoulli()
 
-    # Construct the posterior via the class.
-    posterior = NonConjugatePosterior(prior=prior, likelihood=likelihood)
+    # Construct the model via the class; the latent is sized on first data
+    # contact.
+    posterior = NonConjugateModel(prior=prior, likelihood=likelihood)
+    assert posterior.latent is None
+    posterior = posterior.init_latent(num_datapoints)
 
     # Check types.
-    assert isinstance(posterior, NonConjugatePosterior)
+    assert isinstance(posterior, NonConjugateModel)
 
     # Check latent values (default key is jr.key(42)).
     latent_values = jr.normal(jr.key(42), (num_datapoints, 1))
@@ -267,8 +270,8 @@ def test_nonconjugate_posterior_with_diag(
 
     # Query a marginal distribution of the posterior at some inputs.
     inputs = jnp.linspace(-3.0, 3.0, num_test_datapoints).reshape(-1, 1)
-    marginal_distribution_diag = posterior(inputs, D, return_covariance_type="diagonal")
-    marginal_distribution_full = posterior(inputs, D, return_covariance_type="dense")
+    marginal_distribution_diag = posterior(inputs, D, covariance="diagonal")
+    marginal_distribution_full = posterior(inputs, D, covariance="dense")
 
     # Ensure that the marginal distribution is a Gaussian.
     assert isinstance(marginal_distribution_diag, GaussianDistribution)
@@ -309,13 +312,16 @@ def test_nonconjugate_posterior(
     prior = Prior(mean_function=mean_function(), kernel=kernel())
 
     # Define a likelihood.
-    likelihood = Bernoulli(num_datapoints=num_datapoints)
+    likelihood = Bernoulli()
 
-    # Construct the posterior via the class.
-    posterior = NonConjugatePosterior(prior=prior, likelihood=likelihood)
+    # Construct the model via the class; the latent is sized on first data
+    # contact.
+    posterior = NonConjugateModel(prior=prior, likelihood=likelihood)
+    assert posterior.latent is None
+    posterior = posterior.init_latent(num_datapoints)
 
     # Check types.
-    assert isinstance(posterior, NonConjugatePosterior)
+    assert isinstance(posterior, NonConjugateModel)
 
     # Check latent values (default key is jr.key(42)).
     latent_values = jr.normal(jr.key(42), (num_datapoints, 1))
@@ -351,10 +357,10 @@ def test_posterior_construct(
     prior = Prior(mean_function=mean_function(), kernel=kernel())
 
     # Construct the posterior via the three methods.
-    likelihood: AbstractLikelihood = likelihood(num_datapoints=num_datapoints)
+    likelihood: AbstractLikelihood = likelihood()
     posterior_mul = prior * likelihood
     posterior_rmul = likelihood * prior
-    posterior_manual = construct_posterior(prior=prior, likelihood=likelihood)
+    posterior_manual = construct_model(prior=prior, likelihood=likelihood)
 
     # Ensure that the posterior is the same type in all three cases.
     assert type(posterior_mul) is type(posterior_rmul)
@@ -366,11 +372,11 @@ def test_posterior_construct(
 
     # If the likelihood is Gaussian, then the posterior should be conjugate.
     if isinstance(likelihood, Gaussian):
-        assert isinstance(posterior_mul, ConjugatePosterior)
+        assert isinstance(posterior_mul, ConjugateModel)
 
     # If the likelihood is Bernoulli or Poisson, then the posterior should be non-conjugate.
     if isinstance(likelihood, (Bernoulli, Poisson)):
-        assert isinstance(posterior_mul, NonConjugatePosterior)
+        assert isinstance(posterior_mul, NonConjugateModel)
 
 
 @pytest.mark.parametrize("num_datapoints", [1, 5])
@@ -432,7 +438,7 @@ def test_prior_sample_approx(num_datapoints, kernel, mean_function):
 def test_conjugate_posterior_sample_approx(num_datapoints, kernel, mean_function):
     kern = kernel(lengthscale=jnp.array([5.0, 1.0]), variance=0.1)
     p = Prior(kernel=kern, mean_function=mean_function()) * Gaussian(
-        num_datapoints=num_datapoints
+        
     )
     key = jr.key(123)
 
@@ -517,7 +523,7 @@ def test_conjugate_posterior_sample_approx_covariance_structure():
     x = jnp.linspace(0.0, 1.0, 12).reshape(-1, 1)
     y = jnp.sin(3.0 * x)
     D = Dataset(X=x, y=y)
-    posterior = prior * Gaussian(num_datapoints=D.n)
+    posterior = prior * Gaussian()
 
     grid = jnp.linspace(0.0, 1.0, 8).reshape(-1, 1)
     sample_fn = posterior.sample_approx(
@@ -526,7 +532,7 @@ def test_conjugate_posterior_sample_approx_covariance_structure():
     draws = sample_fn(grid)  # [8, 4000]
 
     empirical_cov = jnp.cov(draws)
-    exact_cov = posterior(grid, D, return_covariance_type="dense").covariance()
+    exact_cov = posterior(grid, D, covariance="dense").covariance()
 
     rel_frobenius = jnp.linalg.norm(empirical_cov - exact_cov) / jnp.linalg.norm(
         exact_cov
@@ -549,7 +555,7 @@ class TestMultiOutputPosteriorPredict:
         coreg = CoregionalizationMatrix(num_outputs=P, rank=1, key=key)
         kernel = ICMKernel(base_kernel=RBF(), coregionalization_matrix=coreg)
         prior = Prior(mean_function=Zero(), kernel=kernel)
-        lik = MultiOutputGaussian(num_datapoints=N, num_outputs=P)
+        lik = MultiOutputGaussian(num_outputs=P)
         posterior = prior * lik
         return posterior, data, N, P
 
@@ -601,7 +607,7 @@ class TestMultiOutputValidation:
 
         kernel = RBF()
         prior = Prior(mean_function=Zero(), kernel=kernel)
-        lik = MultiOutputGaussian(num_datapoints=10, num_outputs=2)
+        lik = MultiOutputGaussian(num_outputs=2)
         with pytest.raises(ValueError, match="multi-output kernel"):
             prior * lik
 
@@ -614,7 +620,7 @@ class TestMultiOutputValidation:
         coreg = CoregionalizationMatrix(num_outputs=2, rank=1, key=key)
         kernel = ICMKernel(base_kernel=RBF(), coregionalization_matrix=coreg)
         prior = Prior(mean_function=Zero(), kernel=kernel)
-        lik = Gaussian(num_datapoints=10)
+        lik = Gaussian()
         with pytest.raises(ValueError, match="MultiOutputGaussian"):
             prior * lik
 
@@ -628,8 +634,8 @@ def test_predict_diagonal_returns_diagonal_operator():
     xtest = jnp.linspace(0.0, 1.0, 10).reshape(-1, 1)
 
     # Prior
-    diag = prior(xtest, return_covariance_type="diagonal")
-    dense = prior(xtest, return_covariance_type="dense")
+    diag = prior(xtest, covariance="diagonal")
+    dense = prior(xtest, covariance="dense")
     assert isinstance(diag.scale, lx.DiagonalLinearOperator)
     assert jnp.allclose(
         diag.scale.as_matrix().diagonal(), dense.covariance().diagonal()
@@ -638,9 +644,9 @@ def test_predict_diagonal_returns_diagonal_operator():
     # Conjugate posterior (single-output)
     x = jnp.linspace(0.0, 1.0, 15).reshape(-1, 1)
     D = Dataset(X=x, y=jnp.sin(3.0 * x))
-    posterior = prior * Gaussian(num_datapoints=D.n)
-    pdiag = posterior(xtest, D, return_covariance_type="diagonal")
-    pdense = posterior(xtest, D, return_covariance_type="dense")
+    posterior = prior * Gaussian()
+    pdiag = posterior(xtest, D, covariance="diagonal")
+    pdense = posterior(xtest, D, covariance="dense")
     assert isinstance(pdiag.scale, lx.DiagonalLinearOperator)
     assert jnp.allclose(
         pdiag.scale.as_matrix().diagonal(), pdense.covariance().diagonal()
@@ -655,7 +661,7 @@ def test_predict_diagonal_jit_smoke():
     prior = Prior(mean_function=Zero(), kernel=kernel)
     xtest = jnp.linspace(0.0, 1.0, 6).reshape(-1, 1)
     for cov_type in ("dense", "diagonal"):
-        fn = jax.jit(lambda t, c=cov_type: prior(t, return_covariance_type=c).mean)
+        fn = jax.jit(lambda t, c=cov_type: prior(t, covariance=c).mean)
         _ = fn(xtest)
 
 

--- a/tests/test_gps.py
+++ b/tests/test_gps.py
@@ -26,9 +26,8 @@ from collections.abc import Callable
 from gpjax.dataset import Dataset
 from gpjax.distributions import GaussianDistribution
 from gpjax.gps import (
-    JointModel,
-    Prior,
     ConjugateModel,
+    JointModel,
     NonConjugateModel,
     Prior,
     construct_model,
@@ -437,9 +436,7 @@ def test_prior_sample_approx(num_datapoints, kernel, mean_function):
 @pytest.mark.parametrize("mean_function", [Zero, Constant])
 def test_conjugate_posterior_sample_approx(num_datapoints, kernel, mean_function):
     kern = kernel(lengthscale=jnp.array([5.0, 1.0]), variance=0.1)
-    p = Prior(kernel=kern, mean_function=mean_function()) * Gaussian(
-        
-    )
+    p = Prior(kernel=kern, mean_function=mean_function()) * Gaussian()
     key = jr.key(123)
 
     x = jr.uniform(key=key, minval=-2.0, maxval=2.0, shape=(num_datapoints, 2))

--- a/tests/test_heteroscedastic.py
+++ b/tests/test_heteroscedastic.py
@@ -16,10 +16,8 @@ import equinox as eqx
 import gpjax as gpx
 from gpjax.dataset import Dataset
 from gpjax.gps import (
-    ChainedPosterior,
-    HeteroscedasticPosterior,
+    HeteroscedasticModel,
     Prior,
-    construct_posterior,
 )
 from gpjax.kernels import RBF
 from gpjax.likelihoods import (
@@ -77,24 +75,28 @@ class SoftplusHeteroscedastic(HeteroscedasticGaussian):
         return False
 
 
-def test_construct_posterior_routing(prior, noise_prior):
-    likelihood = HeteroscedasticGaussian(num_datapoints=5, noise_prior=noise_prior)
-    posterior = construct_posterior(prior=prior, likelihood=likelihood)
-    assert isinstance(posterior, HeteroscedasticPosterior)
-    assert posterior.noise_prior is noise_prior
+def test_construct_model_routing(prior, noise_prior):
+    likelihood = HeteroscedasticGaussian()
+    with pytest.raises(ValueError, match="noise_prior"):
+        _ = prior * likelihood
 
-    chained_likelihood = SoftplusHeteroscedastic(
-        num_datapoints=5, noise_prior=noise_prior
+    posterior = HeteroscedasticModel(
+        prior=prior, likelihood=likelihood, noise_prior=noise_prior
     )
-    chained_posterior = construct_posterior(prior=prior, likelihood=chained_likelihood)
-    assert isinstance(chained_posterior, ChainedPosterior)
-    assert chained_posterior.noise_prior is noise_prior
+    assert isinstance(posterior, HeteroscedasticModel)
+    assert posterior.noise_prior is noise_prior
+    assert posterior.noise_model.prior is noise_prior
+
+    chained_posterior = HeteroscedasticModel(
+        prior=prior, likelihood=SoftplusHeteroscedastic(), noise_prior=noise_prior
+    )
+    assert isinstance(chained_posterior, HeteroscedasticModel)
 
 
 def test_likelihood_callable_compatibility(noise_prior):
     # Test that passing jnp.exp uses LogNormalTransform
     lik_exp = HeteroscedasticGaussian(
-        num_datapoints=10, noise_prior=noise_prior, noise_transform=jnp.exp
+        noise_transform=jnp.exp
     )
     assert isinstance(lik_exp.noise_transform, LogNormalTransform)
 
@@ -103,13 +105,13 @@ def test_likelihood_callable_compatibility(noise_prior):
         return jnp.square(x)
 
     lik_custom = HeteroscedasticGaussian(
-        num_datapoints=10, noise_prior=noise_prior, noise_transform=custom_transform
+        noise_transform=custom_transform
     )
     assert isinstance(lik_custom.noise_transform, SoftplusTransform)
 
 
 def test_heteroscedastic_gaussian_validation(noise_prior, dataset):
-    lik = HeteroscedasticGaussian(num_datapoints=10, noise_prior=noise_prior)
+    lik = HeteroscedasticGaussian()
     # Construct a valid GaussianDistribution to satisfy jaxtyping
     scale = lx.MatrixLinearOperator(jnp.eye(10))
     dist = gpx.distributions.GaussianDistribution(loc=jnp.zeros(10), scale=scale)
@@ -182,8 +184,8 @@ def test_softplus_transform_numerical_accuracy(mean: float, variance: float, see
 
 
 def test_heteroscedastic_variational_predict(prior, noise_prior, dataset):
-    posterior = prior * HeteroscedasticGaussian(
-        num_datapoints=dataset.n, noise_prior=noise_prior
+    posterior = HeteroscedasticModel(
+        prior=prior, likelihood=HeteroscedasticGaussian(), noise_prior=noise_prior
     )
     variational = HeteroscedasticVariationalFamily(
         posterior=posterior, inducing_inputs=dataset.X, inducing_inputs_g=dataset.X[::2]
@@ -215,8 +217,10 @@ def test_heteroscedastic_variational_predict(prior, noise_prior, dataset):
 def test_variational_family_init_structure(n_inducing: int, offset: float):
     prior = Prior(kernel=RBF(), mean_function=Zero())
     noise_prior = Prior(kernel=RBF(), mean_function=Zero())
-    likelihood = HeteroscedasticGaussian(num_datapoints=10, noise_prior=noise_prior)
-    posterior = HeteroscedasticPosterior(prior=prior, likelihood=likelihood)
+    likelihood = HeteroscedasticGaussian()
+    posterior = HeteroscedasticModel(
+        prior=prior, likelihood=likelihood, noise_prior=noise_prior
+    )
 
     inducing_inputs = jnp.linspace(0.0, 1.0, n_inducing, dtype=jnp.float64).reshape(
         -1, 1
@@ -243,8 +247,10 @@ def test_variational_family_init_structure(n_inducing: int, offset: float):
 
 
 def test_variational_family_init_errors(prior, noise_prior):
-    likelihood = HeteroscedasticGaussian(num_datapoints=10, noise_prior=noise_prior)
-    posterior = HeteroscedasticPosterior(prior=prior, likelihood=likelihood)
+    likelihood = HeteroscedasticGaussian()
+    posterior = HeteroscedasticModel(
+        prior=prior, likelihood=likelihood, noise_prior=noise_prior
+    )
 
     # Case 1: No inputs provided
     with pytest.raises(
@@ -254,8 +260,10 @@ def test_variational_family_init_errors(prior, noise_prior):
 
 
 def test_variational_family_predict_return_type(prior, noise_prior):
-    likelihood = HeteroscedasticGaussian(num_datapoints=10, noise_prior=noise_prior)
-    posterior = HeteroscedasticPosterior(prior=prior, likelihood=likelihood)
+    likelihood = HeteroscedasticGaussian()
+    posterior = HeteroscedasticModel(
+        prior=prior, likelihood=likelihood, noise_prior=noise_prior
+    )
 
     n_inducing = 5
     inducing_inputs = jnp.linspace(0, 1, n_inducing).reshape(-1, 1)
@@ -279,8 +287,10 @@ def test_variational_family_predict_return_type(prior, noise_prior):
 
 def test_heteroscedastic_elbo_gradients(dataset, prior, noise_prior):
     def _build_variational(likelihood_cls: type[HeteroscedasticGaussian]):
-        likelihood = likelihood_cls(num_datapoints=dataset.n, noise_prior=noise_prior)
-        posterior = prior * likelihood
+        likelihood = likelihood_cls()
+        posterior = HeteroscedasticModel(
+            prior=prior, likelihood=likelihood, noise_prior=noise_prior
+        )
         return HeteroscedasticVariationalFamily(
             posterior=posterior, inducing_inputs=dataset.X
         )
@@ -302,10 +312,10 @@ def test_heteroscedastic_elbo_gradients(dataset, prior, noise_prior):
 
 
 def test_jit_prediction(prior, noise_prior, dataset):
-    likelihood = HeteroscedasticGaussian(
-        num_datapoints=dataset.n, noise_prior=noise_prior
+    likelihood = HeteroscedasticGaussian()
+    posterior = HeteroscedasticModel(
+        prior=prior, likelihood=likelihood, noise_prior=noise_prior
     )
-    posterior = prior * likelihood
     q = HeteroscedasticVariationalFamily(posterior=posterior, inducing_inputs=dataset.X)
 
     # JIT compile the predict call via a wrapper function
@@ -336,9 +346,7 @@ def test_jit_prediction(prior, noise_prior, dataset):
 
 def test_jit_likelihood_prediction(dataset, prior, noise_prior):
     # Separate test for likelihood prediction to keep things clean
-    likelihood = HeteroscedasticGaussian(
-        num_datapoints=dataset.n, noise_prior=noise_prior
-    )
+    likelihood = HeteroscedasticGaussian()
 
     # JIT compile likelihood prediction
     # We pass arrays and reconstruct distributions inside to ensure Pytree safety
@@ -361,8 +369,10 @@ def test_jit_likelihood_prediction(dataset, prior, noise_prior):
 
 def test_predictive_variance_tracks_noise(prior, noise_prior):
     x = jnp.array([[-1.0], [1.0]])
-    likelihood = HeteroscedasticGaussian(num_datapoints=2, noise_prior=noise_prior)
-    posterior = prior * likelihood
+    likelihood = HeteroscedasticGaussian()
+    posterior = HeteroscedasticModel(
+        prior=prior, likelihood=likelihood, noise_prior=noise_prior
+    )
 
     variational = HeteroscedasticVariationalFamily(
         posterior=posterior,
@@ -412,7 +422,7 @@ def test_link_function_requires_the_noise_latent(noise_prior):
     Previously this silently returned N(y | f, σ²(0)) — the prior-noise density
     rather than the Lázaro-Gredilla & Titsias (2011) conditional N(y | f, σ²(g)).
     """
-    likelihood = HeteroscedasticGaussian(num_datapoints=3, noise_prior=noise_prior)
+    likelihood = HeteroscedasticGaussian()
     f = jnp.array([0.5, -0.2, 1.0])
 
     with pytest.raises(ValueError, match="noise latent"):
@@ -421,7 +431,7 @@ def test_link_function_requires_the_noise_latent(noise_prior):
 
 def test_link_function_uses_the_supplied_noise_latent(noise_prior):
     """Given `g`, the scale must be σ(g) — the whole point of the likelihood."""
-    likelihood = HeteroscedasticGaussian(num_datapoints=3, noise_prior=noise_prior)
+    likelihood = HeteroscedasticGaussian()
     f = jnp.array([0.5, -0.2, 1.0])
 
     for g_value in (-2.0, 0.0, 2.0):
@@ -434,7 +444,7 @@ def test_link_function_uses_the_supplied_noise_latent(noise_prior):
 
 def test_link_function_scale_varies_with_the_noise_latent(noise_prior):
     """A heteroscedastic scale that ignores g is the bug in #670."""
-    likelihood = HeteroscedasticGaussian(num_datapoints=3, noise_prior=noise_prior)
+    likelihood = HeteroscedasticGaussian()
     f = jnp.zeros(3)
 
     low = likelihood.link_function(f, jnp.full_like(f, -2.0)).scale
@@ -458,7 +468,7 @@ def test_heteroscedastic_subclass_cannot_silently_use_prior_noise(noise_prior):
     class BareHeteroscedastic(HeteroscedasticGaussian):
         expected_log_likelihood = AbstractLikelihood.expected_log_likelihood
 
-    likelihood = BareHeteroscedastic(num_datapoints=3, noise_prior=noise_prior)
+    likelihood = BareHeteroscedastic()
     y = jnp.zeros((3, 1))
     mean = jnp.zeros((3, 1))
     variance = jnp.ones((3, 1))
@@ -469,7 +479,7 @@ def test_heteroscedastic_subclass_cannot_silently_use_prior_noise(noise_prior):
 
 def test_sanctioned_heteroscedastic_path_is_unaffected(noise_prior):
     """`HeteroscedasticGaussian.expected_log_likelihood` still works via g moments."""
-    likelihood = HeteroscedasticGaussian(num_datapoints=3, noise_prior=noise_prior)
+    likelihood = HeteroscedasticGaussian()
     y = jnp.zeros((3, 1))
     mean = jnp.zeros((3, 1))
     variance = jnp.ones((3, 1))

--- a/tests/test_heteroscedastic.py
+++ b/tests/test_heteroscedastic.py
@@ -95,18 +95,14 @@ def test_construct_model_routing(prior, noise_prior):
 
 def test_likelihood_callable_compatibility(noise_prior):
     # Test that passing jnp.exp uses LogNormalTransform
-    lik_exp = HeteroscedasticGaussian(
-        noise_transform=jnp.exp
-    )
+    lik_exp = HeteroscedasticGaussian(noise_transform=jnp.exp)
     assert isinstance(lik_exp.noise_transform, LogNormalTransform)
 
     # Test that passing a custom callable uses SoftplusTransform (default fallback logic)
     def custom_transform(x):
         return jnp.square(x)
 
-    lik_custom = HeteroscedasticGaussian(
-        noise_transform=custom_transform
-    )
+    lik_custom = HeteroscedasticGaussian(noise_transform=custom_transform)
     assert isinstance(lik_custom.noise_transform, SoftplusTransform)
 
 

--- a/tests/test_integration_equinox.py
+++ b/tests/test_integration_equinox.py
@@ -27,7 +27,7 @@ def test_full_gp_training_roundtrip():
     kernel = gpx.kernels.RBF()
     meanf = gpx.mean_functions.Zero()
     prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n)
+    likelihood = gpx.likelihoods.Gaussian()
     posterior = prior * likelihood
 
     nmll = lambda p, d: -gpx.objectives.conjugate_mll(p, d)
@@ -58,7 +58,7 @@ def test_parameter_freezing_with_non_trainable():
 
     meanf = gpx.mean_functions.Zero()
     prior = gpx.gps.Prior(mean_function=meanf, kernel=frozen_kernel)
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=10)
+    likelihood = gpx.likelihoods.Gaussian()
     posterior = prior * likelihood
 
     X = jnp.linspace(0, 1, 10)[:, None]
@@ -89,7 +89,7 @@ def test_non_conjugate_gp_training():
     kernel = gpx.kernels.RBF()
     meanf = gpx.mean_functions.Zero()
     prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-    likelihood = gpx.likelihoods.Bernoulli(num_datapoints=D.n)
+    likelihood = gpx.likelihoods.Bernoulli()
     posterior = prior * likelihood
 
     nmll = lambda p, d: -gpx.objectives.non_conjugate_mll(p, d)
@@ -114,7 +114,7 @@ def test_lbfgs_training():
     kernel = gpx.kernels.RBF()
     meanf = gpx.mean_functions.Zero()
     prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n)
+    likelihood = gpx.likelihoods.Gaussian()
     posterior = prior * likelihood
 
     nmll = lambda p, d: -gpx.objectives.conjugate_mll(p, d)
@@ -132,7 +132,7 @@ def test_kernel_composition():
     kernel = gpx.kernels.RBF() + gpx.kernels.Matern32()
     meanf = gpx.mean_functions.Zero()
     prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n)
+    likelihood = gpx.likelihoods.Gaussian()
     posterior = prior * likelihood
 
     nmll = lambda p, d: -gpx.objectives.conjugate_mll(p, d)
@@ -158,7 +158,7 @@ def test_jit_prediction():
     kernel = gpx.kernels.RBF()
     meanf = gpx.mean_functions.Zero()
     prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n)
+    likelihood = gpx.likelihoods.Gaussian()
     posterior = prior * likelihood
 
     @jax.jit
@@ -180,7 +180,7 @@ def test_grad_through_model():
     kernel = gpx.kernels.RBF()
     meanf = gpx.mean_functions.Zero()
     prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=D.n)
+    likelihood = gpx.likelihoods.Gaussian()
     posterior = prior * likelihood
 
     params, static = eqx.partition(posterior, eqx.is_array)

--- a/tests/test_integrators.py
+++ b/tests/test_integrators.py
@@ -59,7 +59,7 @@ def test_quadrature(jit: bool, num_points: int):
 )
 def test_analytical_gaussian(jit: bool, params: tuple[float, float]):
     obs_stddev, expected = params
-    likelihood = Gaussian(num_datapoints=1, obs_stddev=jnp.array([obs_stddev]))
+    likelihood = Gaussian(obs_stddev=jnp.array([obs_stddev]))
     mu = jnp.array([[0.0]])
     variance = jnp.array([[1.0]])
     y = jnp.array([[1.0]])
@@ -81,7 +81,7 @@ def test_bernoulli_quadrature(jit: bool, params: tuple[float, float]):
     mu, variance, expected = params
     mu = jnp.atleast_2d(mu)
     variance = jnp.atleast_2d(variance)
-    likelihood = Bernoulli(num_datapoints=1)
+    likelihood = Bernoulli()
     y = jnp.array([[1.0]])
 
     @jax.jit

--- a/tests/test_jit_compatibility.py
+++ b/tests/test_jit_compatibility.py
@@ -112,7 +112,7 @@ def test_prior_predict_jit(test_inputs):
 
 def test_conjugate_posterior_predict_jit(train_data, test_inputs):
     prior = Prior(mean_function=Constant(), kernel=RBF())
-    likelihood = Gaussian(num_datapoints=train_data.n)
+    likelihood = Gaussian()
     posterior = prior * likelihood
 
     def predict_fn(x_test, data):

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -65,9 +65,7 @@ def test_gaussian_likelihood(n: int, obs_stddev: float):
 
     # Check predictive mean and variance.
     assert (pred_dist.mean == latent_mean).all()
-    noise_matrix = (
-        jnp.eye(n) * likelihood.obs_stddev.unwrap() ** 2
-    )
+    noise_matrix = jnp.eye(n) * likelihood.obs_stddev.unwrap() ** 2
     assert np.allclose(pred_dist.covariance_matrix, latent_cov + noise_matrix)
 
 

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -53,7 +53,7 @@ def _compute_latent_dist(
 @pytest.mark.parametrize("obs_stddev", [0.1, 0.5, 1.0, 0.0])
 def test_gaussian_likelihood(n: int, obs_stddev: float):
     x = jnp.linspace(-3.0, 3.0).reshape(-1, 1)
-    likelihood = Gaussian(num_datapoints=n, obs_stddev=obs_stddev)
+    likelihood = Gaussian(obs_stddev=obs_stddev)
 
     assert isinstance(likelihood.link_function, Callable)
     assert isinstance(likelihood.link_function(x), npd.Normal)
@@ -66,7 +66,7 @@ def test_gaussian_likelihood(n: int, obs_stddev: float):
     # Check predictive mean and variance.
     assert (pred_dist.mean == latent_mean).all()
     noise_matrix = (
-        jnp.eye(likelihood.num_datapoints) * likelihood.obs_stddev.unwrap() ** 2
+        jnp.eye(n) * likelihood.obs_stddev.unwrap() ** 2
     )
     assert np.allclose(pred_dist.covariance_matrix, latent_cov + noise_matrix)
 
@@ -74,7 +74,7 @@ def test_gaussian_likelihood(n: int, obs_stddev: float):
 @pytest.mark.parametrize("n", [1, 2, 10])
 def test_bernoulli_likelihood(n: int):
     x = jnp.linspace(-3.0, 3.0).reshape(-1, 1)
-    likelihood = Bernoulli(num_datapoints=n)
+    likelihood = Bernoulli()
 
     assert isinstance(likelihood.link_function, Callable)
     assert isinstance(likelihood.link_function(x), npd.BernoulliProbs)
@@ -93,7 +93,7 @@ def test_bernoulli_likelihood(n: int):
 @pytest.mark.parametrize("n", [1, 2, 10])
 def test_poisson_likelihood(n: int):
     x = jnp.linspace(-3.0, 3.0).reshape(-1, 1)
-    likelihood = Poisson(num_datapoints=n)
+    likelihood = Poisson()
 
     assert isinstance(likelihood.link_function, Callable)
     assert isinstance(likelihood.link_function(x), npd.Poisson)
@@ -113,7 +113,7 @@ class TestMultiOutputGaussian:
         """Scalar obs_stddev broadcasts to [P] vector."""
         from gpjax.likelihoods import MultiOutputGaussian
 
-        lik = MultiOutputGaussian(num_datapoints=10, num_outputs=3, obs_stddev=0.5)
+        lik = MultiOutputGaussian(num_outputs=3, obs_stddev=0.5)
         assert lik.obs_stddev.unwrap().shape == (3,)
         assert jnp.allclose(lik.obs_stddev.unwrap(), jnp.full(3, 0.5))
 
@@ -122,14 +122,14 @@ class TestMultiOutputGaussian:
         from gpjax.likelihoods import MultiOutputGaussian
 
         noise = jnp.array([0.1, 0.2, 0.3])
-        lik = MultiOutputGaussian(num_datapoints=10, num_outputs=3, obs_stddev=noise)
+        lik = MultiOutputGaussian(num_outputs=3, obs_stddev=noise)
         assert jnp.allclose(lik.obs_stddev.unwrap(), noise)
 
     def test_noise_vector_shape(self):
         """noise_vector() returns [NP] in output-major order."""
         from gpjax.likelihoods import MultiOutputGaussian
 
-        lik = MultiOutputGaussian(num_datapoints=10, num_outputs=3, obs_stddev=1.0)
+        lik = MultiOutputGaussian(num_outputs=3, obs_stddev=1.0)
         nv = lik.noise_vector(10)
         assert nv.shape == (30,)
 
@@ -138,7 +138,7 @@ class TestMultiOutputGaussian:
         from gpjax.likelihoods import MultiOutputGaussian
 
         noise = jnp.array([1.0, 2.0])
-        lik = MultiOutputGaussian(num_datapoints=3, num_outputs=2, obs_stddev=noise)
+        lik = MultiOutputGaussian(num_outputs=2, obs_stddev=noise)
         nv = lik.noise_vector(3)
         # Output-major: [σ₁² repeated N, σ₂² repeated N]
         expected = jnp.array([1.0, 1.0, 1.0, 4.0, 4.0, 4.0])
@@ -148,5 +148,5 @@ class TestMultiOutputGaussian:
         """MultiOutputGaussian is a Gaussian subclass for posterior dispatch."""
         from gpjax.likelihoods import MultiOutputGaussian
 
-        lik = MultiOutputGaussian(num_datapoints=10, num_outputs=2)
+        lik = MultiOutputGaussian(num_outputs=2)
         assert isinstance(lik, Gaussian)

--- a/tests/test_likelihoods_diagonal_fast_path.py
+++ b/tests/test_likelihoods_diagonal_fast_path.py
@@ -50,7 +50,7 @@ def test_gaussian_predict_preserves_diagonal_scale():
     diag_scale = lx.DiagonalLinearOperator(jnp.array([0.5, 1.0, 2.0]))
     dist_in = GaussianDistribution(mean, diag_scale)
 
-    likelihood = Gaussian(num_datapoints=3, obs_stddev=0.1)
+    likelihood = Gaussian(obs_stddev=0.1)
     dist_out = likelihood.predict(dist_in)
 
     assert isinstance(dist_out, GaussianDistribution)
@@ -68,7 +68,7 @@ def test_gaussian_predict_tagged_diagonal_preserves_diagonal_scale():
     tagged = lx.TaggedLinearOperator(diag, lx.positive_semidefinite_tag)
     dist_in = GaussianDistribution(mean, tagged)
 
-    likelihood = Gaussian(num_datapoints=2, obs_stddev=0.5)
+    likelihood = Gaussian(obs_stddev=0.5)
     dist_out = likelihood.predict(dist_in)
 
     assert isinstance(dist_out, GaussianDistribution)
@@ -84,7 +84,7 @@ def test_gaussian_predict_dense_returns_gaussian_distribution_with_matrix_scale(
     dense = lx.MatrixLinearOperator(cov)
     dist_in = GaussianDistribution(mean, dense)
 
-    likelihood = Gaussian(num_datapoints=2, obs_stddev=0.1)
+    likelihood = Gaussian(obs_stddev=0.1)
     dist_out = likelihood.predict(dist_in)
 
     assert isinstance(dist_out, GaussianDistribution)
@@ -99,7 +99,7 @@ def test_gaussian_predict_is_numpyro_compatible():
     latent = GaussianDistribution(
         loc=jnp.zeros(4), scale=lx.DiagonalLinearOperator(jnp.ones(4))
     )
-    predictive = gpx.likelihoods.Gaussian(num_datapoints=4, obs_stddev=0.1).predict(
+    predictive = gpx.likelihoods.Gaussian(obs_stddev=0.1).predict(
         latent
     )
     assert predictive.mean.shape == (4,)
@@ -119,10 +119,10 @@ def test_gaussian_family_predict_returns_gaussian_distribution(likelihood_cls):
     )
     if likelihood_cls is MultiOutputGaussian:
         likelihood = likelihood_cls(
-            num_datapoints=n_points, num_outputs=1, obs_stddev=0.5
+            num_outputs=1, obs_stddev=0.5
         )
     else:
-        likelihood = likelihood_cls(num_datapoints=n_points, obs_stddev=0.5)
+        likelihood = likelihood_cls(obs_stddev=0.5)
     predictive = likelihood.predict(latent)
     assert isinstance(predictive, GaussianDistribution)
 
@@ -130,7 +130,7 @@ def test_gaussian_family_predict_returns_gaussian_distribution(likelihood_cls):
 def test_heteroscedastic_predict_returns_gaussian_distribution():
     """Lock the return-type contract for HeteroscedasticGaussian.predict."""
     noise_prior = Prior(kernel=RBF(), mean_function=Zero())
-    likelihood = HeteroscedasticGaussian(num_datapoints=2, noise_prior=noise_prior)
+    likelihood = HeteroscedasticGaussian()
 
     signal_dist = GaussianDistribution(
         loc=jnp.zeros(2), scale=lx.MatrixLinearOperator(jnp.eye(2))

--- a/tests/test_likelihoods_diagonal_fast_path.py
+++ b/tests/test_likelihoods_diagonal_fast_path.py
@@ -99,9 +99,7 @@ def test_gaussian_predict_is_numpyro_compatible():
     latent = GaussianDistribution(
         loc=jnp.zeros(4), scale=lx.DiagonalLinearOperator(jnp.ones(4))
     )
-    predictive = gpx.likelihoods.Gaussian(obs_stddev=0.1).predict(
-        latent
-    )
+    predictive = gpx.likelihoods.Gaussian(obs_stddev=0.1).predict(latent)
     assert predictive.mean.shape == (4,)
     assert bool(jnp.all(predictive.variance > 0))
     sample = predictive.sample(jr.key(0))
@@ -118,9 +116,7 @@ def test_gaussian_family_predict_returns_gaussian_distribution(likelihood_cls):
         scale=lx.DiagonalLinearOperator(jnp.ones(n_points)),
     )
     if likelihood_cls is MultiOutputGaussian:
-        likelihood = likelihood_cls(
-            num_outputs=1, obs_stddev=0.5
-        )
+        likelihood = likelihood_cls(num_outputs=1, obs_stddev=0.5)
     else:
         likelihood = likelihood_cls(obs_stddev=0.5)
     predictive = likelihood.predict(latent)

--- a/tests/test_likelihoods_diagonal_fast_path.py
+++ b/tests/test_likelihoods_diagonal_fast_path.py
@@ -2,15 +2,12 @@
 
 import gpjax as gpx
 from gpjax.distributions import GaussianDistribution
-from gpjax.gps import Prior
-from gpjax.kernels import RBF
 from gpjax.likelihoods import (
     Gaussian,
     HeteroscedasticGaussian,
     MultiOutputGaussian,
     _diagonal_scale,
 )
-from gpjax.mean_functions import Zero
 import jax.numpy as jnp
 import jax.random as jr
 import lineax as lx
@@ -125,7 +122,6 @@ def test_gaussian_family_predict_returns_gaussian_distribution(likelihood_cls):
 
 def test_heteroscedastic_predict_returns_gaussian_distribution():
     """Lock the return-type contract for HeteroscedasticGaussian.predict."""
-    noise_prior = Prior(kernel=RBF(), mean_function=Zero())
     likelihood = HeteroscedasticGaussian()
 
     signal_dist = GaussianDistribution(

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -264,3 +264,19 @@ def test_kronecker_structures():
     kron = Kronecker(A=A, B=B)
     assert kron.in_structure().shape == (6,)
     assert kron.out_structure().shape == (6,)
+
+
+def test_stabilised_cholesky_identity():
+    from gpjax.linalg.utils import stabilised_cholesky
+
+    factor = stabilised_cholesky(jnp.eye(3), 1e-2)
+    assert jnp.allclose(factor, jnp.sqrt(1.01) * jnp.eye(3), atol=1e-12)
+
+
+def test_stabilised_cholesky_reconstructs():
+    from gpjax.linalg.utils import stabilised_cholesky
+
+    root = jnp.array([[1.0, 0.0], [0.4, 0.8]])
+    psd = root @ root.T
+    factor = stabilised_cholesky(psd, 1e-3)
+    assert jnp.allclose(factor @ factor.T, psd + 1e-3 * jnp.eye(2), atol=1e-10)

--- a/tests/test_mean_functions.py
+++ b/tests/test_mean_functions.py
@@ -99,9 +99,7 @@ def test_zero_mean_remains_zero() -> None:
     y = jnp.full((20, 1), 50.0, dtype=jnp.float64)  # dataset with a non-zero mean
     train_data = Dataset(X=x, y=y)
 
-    posterior = Prior(mean_function=Zero(), kernel=RBF()) * Gaussian(
-        
-    )
+    posterior = Prior(mean_function=Zero(), kernel=RBF()) * Gaussian()
 
     optimised, _ = fit(
         model=posterior,

--- a/tests/test_mean_functions.py
+++ b/tests/test_mean_functions.py
@@ -100,7 +100,7 @@ def test_zero_mean_remains_zero() -> None:
     train_data = Dataset(X=x, y=y)
 
     posterior = Prior(mean_function=Zero(), kernel=RBF()) * Gaussian(
-        num_datapoints=train_data.n
+        
     )
 
     optimised, _ = fit(

--- a/tests/test_multioutput_integration.py
+++ b/tests/test_multioutput_integration.py
@@ -29,7 +29,7 @@ class TestICMEndToEnd:
         )
         meanf = gpx.mean_functions.Zero()
         prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-        lik = gpx.likelihoods.MultiOutputGaussian(num_datapoints=N, num_outputs=P)
+        lik = gpx.likelihoods.MultiOutputGaussian(num_outputs=P)
         posterior = prior * lik
 
         # Verify MLL is computable and finite
@@ -69,7 +69,7 @@ class TestICMEndToEnd:
             prior = gpx.gps.Prior(
                 mean_function=gpx.mean_functions.Zero(), kernel=kernel
             )
-            lik = gpx.likelihoods.MultiOutputGaussian(num_datapoints=15, num_outputs=2)
+            lik = gpx.likelihoods.MultiOutputGaussian(num_outputs=2)
             posterior = prior * lik
 
             mll = gpx.objectives.conjugate_mll(posterior, D)
@@ -97,7 +97,7 @@ class TestICMEndToEnd:
             coregionalization_matrix=coreg,
         )
         prior = gpx.gps.Prior(mean_function=gpx.mean_functions.Zero(), kernel=kernel)
-        lik = gpx.likelihoods.MultiOutputGaussian(num_datapoints=N, num_outputs=P)
+        lik = gpx.likelihoods.MultiOutputGaussian(num_outputs=P)
         posterior = prior * lik
 
         mll = gpx.objectives.conjugate_mll(posterior, D)
@@ -133,7 +133,7 @@ class TestLCMEndToEnd:
         )
         meanf = gpx.mean_functions.Zero()
         prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-        lik = gpx.likelihoods.MultiOutputGaussian(num_datapoints=N, num_outputs=P)
+        lik = gpx.likelihoods.MultiOutputGaussian(num_outputs=P)
         posterior = prior * lik
 
         mll = gpx.objectives.conjugate_mll(posterior, D)
@@ -171,7 +171,7 @@ class TestLCMEndToEnd:
 
         meanf = gpx.mean_functions.Zero()
         prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-        lik = gpx.likelihoods.MultiOutputGaussian(num_datapoints=N, num_outputs=P)
+        lik = gpx.likelihoods.MultiOutputGaussian(num_outputs=P)
         posterior = prior * lik
 
         mll = gpx.objectives.conjugate_mll(posterior, D)
@@ -202,7 +202,7 @@ class TestLCMEndToEnd:
         )
 
         prior = gpx.gps.Prior(mean_function=gpx.mean_functions.Zero(), kernel=kernel)
-        lik = gpx.likelihoods.MultiOutputGaussian(num_datapoints=N, num_outputs=P)
+        lik = gpx.likelihoods.MultiOutputGaussian(num_outputs=P)
         posterior = prior * lik
 
         mll = gpx.objectives.conjugate_mll(posterior, D)
@@ -233,7 +233,7 @@ class TestLCMEndToEnd:
         icm_prior = gpx.gps.Prior(
             mean_function=gpx.mean_functions.Zero(), kernel=icm_kernel
         )
-        icm_lik = gpx.likelihoods.MultiOutputGaussian(num_datapoints=N, num_outputs=P)
+        icm_lik = gpx.likelihoods.MultiOutputGaussian(num_outputs=P)
         icm_post = icm_prior * icm_lik
         icm_mll = gpx.objectives.conjugate_mll(icm_post, D)
 
@@ -245,7 +245,7 @@ class TestLCMEndToEnd:
         lcm_prior = gpx.gps.Prior(
             mean_function=gpx.mean_functions.Zero(), kernel=lcm_kernel
         )
-        lcm_lik = gpx.likelihoods.MultiOutputGaussian(num_datapoints=N, num_outputs=P)
+        lcm_lik = gpx.likelihoods.MultiOutputGaussian(num_outputs=P)
         lcm_post = lcm_prior * lcm_lik
         lcm_mll = gpx.objectives.conjugate_mll(lcm_post, D)
 

--- a/tests/test_numerical_stability.py
+++ b/tests/test_numerical_stability.py
@@ -126,7 +126,7 @@ class TestPosteriorPredictionStability:
         """Standard prediction should produce finite mean and covariance."""
         kernel = _make_kernel(kernel_cls)
         prior = gpx.gps.Prior(mean_function=Zero(), kernel=kernel)
-        likelihood = gpx.likelihoods.Gaussian(num_datapoints=20)
+        likelihood = gpx.likelihoods.Gaussian()
         posterior = prior * likelihood
 
         x_train = jnp.linspace(0.0, 1.0, 20).reshape(-1, 1)
@@ -148,7 +148,7 @@ class TestPosteriorPredictionStability:
         """Prediction with noisy data should stay finite."""
         kernel = _make_kernel(kernel_cls)
         prior = gpx.gps.Prior(mean_function=Zero(), kernel=kernel)
-        likelihood = gpx.likelihoods.Gaussian(num_datapoints=30)
+        likelihood = gpx.likelihoods.Gaussian()
         posterior = prior * likelihood
 
         key = jr.key(42)
@@ -167,7 +167,7 @@ class TestPosteriorPredictionStability:
         """Predictions far from training data should stay finite."""
         kernel = _make_kernel(kernel_cls)
         prior = gpx.gps.Prior(mean_function=Zero(), kernel=kernel)
-        likelihood = gpx.likelihoods.Gaussian(num_datapoints=10)
+        likelihood = gpx.likelihoods.Gaussian()
         posterior = prior * likelihood
 
         x_train = jnp.linspace(0.0, 1.0, 10).reshape(-1, 1)
@@ -186,7 +186,7 @@ class TestPosteriorPredictionStability:
         """Diagonal covariance prediction should stay finite."""
         kernel = _make_kernel(kernel_cls)
         prior = gpx.gps.Prior(mean_function=Zero(), kernel=kernel)
-        likelihood = gpx.likelihoods.Gaussian(num_datapoints=20)
+        likelihood = gpx.likelihoods.Gaussian()
         posterior = prior * likelihood
 
         x_train = jnp.linspace(0.0, 1.0, 20).reshape(-1, 1)
@@ -194,7 +194,7 @@ class TestPosteriorPredictionStability:
         D = gpx.Dataset(X=x_train, y=y_train)
 
         x_test = jnp.linspace(0.0, 1.0, 10).reshape(-1, 1)
-        pred_dist = posterior.predict(x_test, D, return_covariance_type="diagonal")
+        pred_dist = posterior.predict(x_test, D, covariance="diagonal")
 
         assert jnp.all(jnp.isfinite(pred_dist.mean))
         assert jnp.all(jnp.isfinite(pred_dist.covariance()))
@@ -204,7 +204,7 @@ class TestPosteriorPredictionStability:
         """Diagonal of predictive covariance should be non-negative."""
         kernel = _make_kernel(kernel_cls)
         prior = gpx.gps.Prior(mean_function=Zero(), kernel=kernel)
-        likelihood = gpx.likelihoods.Gaussian(num_datapoints=15)
+        likelihood = gpx.likelihoods.Gaussian()
         posterior = prior * likelihood
 
         x_train = jnp.linspace(0.0, 1.0, 15).reshape(-1, 1)

--- a/tests/test_numpyro_extras.py
+++ b/tests/test_numpyro_extras.py
@@ -25,7 +25,7 @@ def test_numpyro_sample_into_gpjax_conjugate_mll():
         kernel = gpx.kernels.RBF(lengthscale=lengthscale, variance=variance)
         meanf = gpx.mean_functions.Constant()
         prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-        likelihood = gpx.likelihoods.Gaussian(num_datapoints=10, obs_stddev=obs_noise)
+        likelihood = gpx.likelihoods.Gaussian(obs_stddev=obs_noise)
         posterior = prior * likelihood
 
         mll_value = gpx.objectives.conjugate_mll(posterior, D)

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -60,7 +60,7 @@ def test_conjugate_mll(n_points: int, n_dims: int, key_val: int):
         kernel=gpx.kernels.RBF(active_dims=list(range(n_dims))),
         mean_function=gpx.mean_functions.Constant(),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n_points)
+    likelihood = gpx.likelihoods.Gaussian()
     post = p * likelihood
 
     # test simple call
@@ -100,7 +100,7 @@ def test_conjugate_loocv(n_points, n_dims, key_val):
         kernel=gpx.kernels.RBF(active_dims=list(range(n_dims))),
         mean_function=gpx.mean_functions.Constant(),
     )
-    likelihood = Gaussian(num_datapoints=n_points)
+    likelihood = Gaussian()
     post = p * likelihood
 
     # test simple call
@@ -140,8 +140,8 @@ def test_non_conjugate_mll(n_points, n_dims, key_val):
         kernel=gpx.kernels.RBF(active_dims=list(range(n_dims))),
         mean_function=gpx.mean_functions.Constant(),
     )
-    likelihood = gpx.likelihoods.Bernoulli(num_datapoints=n_points)
-    post = p * likelihood
+    likelihood = gpx.likelihoods.Bernoulli()
+    post = (p * likelihood).init_latent(D.n)
 
     # test simple call
     res_simple = -non_conjugate_mll(post, D)
@@ -181,7 +181,7 @@ def test_collapsed_elbo(n_points, n_dims, key_val):
         kernel=gpx.kernels.RBF(active_dims=list(range(n_dims))),
         mean_function=gpx.mean_functions.Constant(),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n_points)
+    likelihood = gpx.likelihoods.Gaussian()
     q = gpx.variational_families.CollapsedVariationalGaussian(
         posterior=p * likelihood, inducing_inputs=z
     )
@@ -215,9 +215,9 @@ def test_elbo(n_points, n_dims, key_val, binary: bool):
         mean_function=gpx.mean_functions.Constant(),
     )
     if binary:
-        likelihood = gpx.likelihoods.Bernoulli(num_datapoints=n_points)
+        likelihood = gpx.likelihoods.Bernoulli()
     else:
-        likelihood = gpx.likelihoods.Gaussian(num_datapoints=n_points)
+        likelihood = gpx.likelihoods.Gaussian()
     post = p * likelihood
 
     q = gpx.variational_families.VariationalGaussian(posterior=post, inducing_inputs=z)
@@ -265,7 +265,7 @@ class TestMultiOutputConjugateMLL:
         kernel = ICMKernel(base_kernel=RBF(), coregionalization_matrix=coreg)
         meanf = Zero()
         prior = Prior(mean_function=meanf, kernel=kernel)
-        lik = MultiOutputGaussian(num_datapoints=N, num_outputs=P)
+        lik = MultiOutputGaussian(num_outputs=P)
         posterior = prior * lik
         return posterior, data
 
@@ -295,7 +295,7 @@ class TestMultiOutputConjugateMLL:
 
         kernel = RBF()
         prior = Prior(mean_function=Zero(), kernel=kernel)
-        lik = Gaussian(num_datapoints=20)
+        lik = Gaussian()
         posterior = prior * lik
         mll = conjugate_mll(posterior, data)
         assert jnp.isfinite(mll)
@@ -321,7 +321,7 @@ def test_conjugate_loocv_multioutput_matches_brute_force():
     coreg = CoregionalizationMatrix(num_outputs=P, rank=1, key=key)
     kernel = ICMKernel(base_kernel=RBF(), coregionalization_matrix=coreg)
     prior = Prior(mean_function=Zero(), kernel=kernel)
-    lik = MultiOutputGaussian(num_datapoints=N, num_outputs=P)
+    lik = MultiOutputGaussian(num_outputs=P)
     posterior = paramax.unwrap(prior * lik)
 
     # --- Independent brute-force reference on the full [NP, NP] system ---

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -214,10 +214,7 @@ def test_elbo(n_points, n_dims, key_val, binary: bool):
         kernel=gpx.kernels.RBF(active_dims=list(range(n_dims))),
         mean_function=gpx.mean_functions.Constant(),
     )
-    if binary:
-        likelihood = gpx.likelihoods.Bernoulli()
-    else:
-        likelihood = gpx.likelihoods.Gaussian()
+    likelihood = gpx.likelihoods.Bernoulli() if binary else gpx.likelihoods.Gaussian()
     post = p * likelihood
 
     q = gpx.variational_families.VariationalGaussian(posterior=post, inducing_inputs=z)

--- a/tests/test_state_space/test_filter.py
+++ b/tests/test_state_space/test_filter.py
@@ -138,7 +138,7 @@ def test_kalman_filter_matches_dense_mll_on_matern12(jitter):
         kernel=gpx.kernels.Matern12(lengthscale=lengthscale, variance=variance),
         jitter=jitter,
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=obs_stddev)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
     posterior = prior * likelihood
     dense_mll = gpx.objectives.conjugate_mll(posterior, train_data)
 

--- a/tests/test_state_space/test_fit.py
+++ b/tests/test_state_space/test_fit.py
@@ -61,7 +61,7 @@ def test_fit_scipy_recovers_matern52_hyperparameters_at_N_2000():
             lengthscale=init_lengthscale, variance=init_variance
         ),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=init_obs_stddev)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=init_obs_stddev)
     posterior = prior * likelihood
 
     fitted_posterior, history = fit_scipy(
@@ -91,9 +91,9 @@ def test_fit_scipy_returns_state_space_posterior_type():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern12(lengthscale=1.0, variance=1.0),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=0.3)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.3)
     posterior = prior * likelihood
-    from gpjax.state_space.gps import StateSpaceConjugatePosterior
+    from gpjax.state_space.gps import StateSpaceConjugateModel
 
     fitted_posterior, _ = fit_scipy(
         model=posterior,
@@ -101,7 +101,7 @@ def test_fit_scipy_returns_state_space_posterior_type():
         max_iters=10,
         verbose=False,
     )
-    assert isinstance(fitted_posterior, StateSpaceConjugatePosterior)
+    assert isinstance(fitted_posterior, StateSpaceConjugateModel)
 
 
 def test_fit_scipy_warns_on_unsorted_input_and_sorts_internally():
@@ -116,7 +116,7 @@ def test_fit_scipy_warns_on_unsorted_input_and_sorts_internally():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern12(lengthscale=1.0, variance=1.0),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=0.3)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.3)
     posterior = prior * likelihood
     with pytest.warns(UserWarning, match=r"unsorted|sort"):
         fit_scipy(model=posterior, train_data=train_data, max_iters=10, verbose=False)
@@ -139,16 +139,16 @@ def test_fit_lbfgs_returns_state_space_posterior_type():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern12(lengthscale=1.0, variance=1.0),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=0.3)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.3)
     posterior = prior * likelihood
-    from gpjax.state_space.gps import StateSpaceConjugatePosterior
+    from gpjax.state_space.gps import StateSpaceConjugateModel
 
     fitted_posterior, _ = fit_lbfgs(
         model=posterior,
         train_data=train_data,
         max_iters=10,
     )
-    assert isinstance(fitted_posterior, StateSpaceConjugatePosterior)
+    assert isinstance(fitted_posterior, StateSpaceConjugateModel)
 
 
 def test_fit_optax_runs_full_batch():
@@ -160,9 +160,9 @@ def test_fit_optax_runs_full_batch():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern12(lengthscale=1.0, variance=1.0),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=0.3)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.3)
     posterior = prior * likelihood
-    from gpjax.state_space.gps import StateSpaceConjugatePosterior
+    from gpjax.state_space.gps import StateSpaceConjugateModel
 
     fitted_posterior, history = fit(
         model=posterior,
@@ -171,7 +171,7 @@ def test_fit_optax_runs_full_batch():
         num_iters=10,
         verbose=False,
     )
-    assert isinstance(fitted_posterior, StateSpaceConjugatePosterior)
+    assert isinstance(fitted_posterior, StateSpaceConjugateModel)
     assert history.shape == (10,)
 
 
@@ -183,7 +183,7 @@ def test_fit_rejects_minibatch_with_value_error():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern12(lengthscale=1.0, variance=1.0),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=0.3)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.3)
     posterior = prior * likelihood
     with pytest.raises(ValueError, match=r"batch_size|full[- ]batch"):
         fit(
@@ -227,7 +227,7 @@ def test_paramax_non_trainable_freezes_lengthscale():
         mean_function=gpx.mean_functions.Zero(),
         kernel=frozen_kernel,
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=init_obs_stddev)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=init_obs_stddev)
     posterior = prior * likelihood
 
     fitted_posterior, _ = fit_scipy(

--- a/tests/test_state_space/test_gps.py
+++ b/tests/test_state_space/test_gps.py
@@ -1,8 +1,8 @@
-"""Tests for StateSpacePrior and StateSpaceConjugatePosterior."""
+"""Tests for StateSpacePrior and StateSpaceConjugateModel."""
 
 import gpjax as gpx
 from gpjax.distributions import GaussianDistribution
-from gpjax.state_space.gps import StateSpaceConjugatePosterior, StateSpacePrior
+from gpjax.state_space.gps import StateSpaceConjugateModel, StateSpacePrior
 import jax.numpy as jnp
 import lineax as lx
 import numpy as np
@@ -33,7 +33,7 @@ def test_state_space_prior_predict_dense_raises():
     )
     Xtest = jnp.array([[0.0], [1.0]])
     with pytest.raises(NotImplementedError, match=r"diagonal|dense"):
-        prior.predict(Xtest, return_covariance_type="dense")
+        prior.predict(Xtest, covariance="dense")
 
 
 def test_state_space_prior_jitter_is_added_to_marginal_variance():
@@ -67,8 +67,8 @@ def test_state_space_conjugate_posterior_construction():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern12(lengthscale=1.0, variance=1.0),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=10, obs_stddev=0.2)
-    posterior = StateSpaceConjugatePosterior(prior=prior, likelihood=likelihood)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.2)
+    posterior = StateSpaceConjugateModel(prior=prior, likelihood=likelihood)
     assert posterior.prior is prior
     assert posterior.likelihood is likelihood
 
@@ -78,15 +78,15 @@ def test_state_space_conjugate_posterior_predict_dense_raises():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern12(lengthscale=1.0, variance=1.0),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=5, obs_stddev=0.1)
-    posterior = StateSpaceConjugatePosterior(prior=prior, likelihood=likelihood)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.1)
+    posterior = StateSpaceConjugateModel(prior=prior, likelihood=likelihood)
 
     train_X = jnp.linspace(0.0, 1.0, 5).reshape(-1, 1)
     train_y = jnp.zeros((5, 1))
     train_data = gpx.Dataset(X=train_X, y=train_y)
     Xtest = jnp.array([[0.5]])
     with pytest.raises(NotImplementedError, match=r"diagonal|dense"):
-        posterior.predict(Xtest, train_data, return_covariance_type="dense")
+        posterior.predict(Xtest, train_data, covariance="dense")
 
 
 def test_state_space_prior_times_gaussian_returns_state_space_posterior():
@@ -94,9 +94,9 @@ def test_state_space_prior_times_gaussian_returns_state_space_posterior():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern12(lengthscale=1.0, variance=1.0),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=5, obs_stddev=0.2)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.2)
     posterior = prior * likelihood
-    assert isinstance(posterior, StateSpaceConjugatePosterior)
+    assert isinstance(posterior, StateSpaceConjugateModel)
     assert posterior.prior is prior
 
 
@@ -105,7 +105,7 @@ def test_state_space_prior_times_bernoulli_raises_type_error():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern12(lengthscale=1.0, variance=1.0),
     )
-    likelihood = gpx.likelihoods.Bernoulli(num_datapoints=5)
+    likelihood = gpx.likelihoods.Bernoulli()
     with pytest.raises(TypeError, match=r"Gaussian|conjugate"):
         prior * likelihood
 
@@ -115,7 +115,7 @@ def test_state_space_prior_times_multioutput_gaussian_raises():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern12(lengthscale=1.0, variance=1.0),
     )
-    likelihood = gpx.likelihoods.MultiOutputGaussian(num_datapoints=5, num_outputs=2)
+    likelihood = gpx.likelihoods.MultiOutputGaussian(num_outputs=2)
     with pytest.raises(TypeError, match=r"single|MultiOutput|scalar"):
         prior * likelihood
 
@@ -125,7 +125,7 @@ def test_state_space_prior_times_gaussian_with_array_obs_stddev_raises():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern12(lengthscale=1.0, variance=1.0),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=3, obs_stddev=jnp.ones(3))
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=jnp.ones(3))
     with pytest.raises(ValueError, match=r"scalar|obs_stddev"):
         prior * likelihood
 
@@ -138,9 +138,9 @@ def test_state_space_predict_rejects_dense_with_actionable_message():
     posterior = StateSpacePrior(
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern32(lengthscale=1.0, variance=1.0),
-    ) * gpx.likelihoods.Gaussian(num_datapoints=10, obs_stddev=0.1)
+    ) * gpx.likelihoods.Gaussian(obs_stddev=0.1)
 
     with pytest.raises(NotImplementedError, match=r"diagonal-only|follow-up|v1"):
         posterior.predict(
-            jnp.linspace(0, 5, 4).reshape(-1, 1), data, return_covariance_type="dense"
+            jnp.linspace(0, 5, 4).reshape(-1, 1), data, covariance="dense"
         )

--- a/tests/test_state_space/test_imports.py
+++ b/tests/test_state_space/test_imports.py
@@ -5,7 +5,7 @@ def test_state_space_package_imports():
     import gpjax.state_space as gpx_ss
 
     expected_public = {
-        "StateSpaceConjugatePosterior",
+        "StateSpaceConjugateModel",
         "StateSpacePrior",
         "TruncatedPeriodic",
         "fit",

--- a/tests/test_state_space/test_objectives.py
+++ b/tests/test_state_space/test_objectives.py
@@ -187,9 +187,7 @@ def test_state_space_mll_gradient_through_obs_stddev_is_finite():
             mean_function=gpx.mean_functions.Zero(),
             kernel=gpx.kernels.Matern12(lengthscale=lengthscale, variance=variance),
         )
-        likelihood = gpx.likelihoods.Gaussian(
-            obs_stddev=obs_stddev_value
-        )
+        likelihood = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev_value)
         posterior = prior * likelihood
         return -state_space_mll(posterior, train_data)
 

--- a/tests/test_state_space/test_objectives.py
+++ b/tests/test_state_space/test_objectives.py
@@ -29,7 +29,7 @@ def test_state_space_mll_matches_conjugate_mll_on_matern12(jitter):
         kernel=gpx.kernels.Matern12(lengthscale=lengthscale, variance=variance),
         jitter=jitter,
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=obs_stddev)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
     ss_posterior = ss_prior * likelihood
 
     ss_mll = state_space_mll(ss_posterior, train_data)
@@ -51,7 +51,7 @@ def test_state_space_mll_returns_scalar():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern32(lengthscale=1.0, variance=1.0),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=10, obs_stddev=0.3)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.3)
     posterior = ss_prior * likelihood
     X, y = _build_matern12_dataset(n=10, lengthscale=1.0, variance=1.0, obs_stddev=0.3)
     train_data = gpx.Dataset(X=X.reshape(-1, 1), y=y.reshape(-1, 1))
@@ -78,7 +78,7 @@ def test_state_space_mll_residualises_constant_mean():
         mean_function=gpx.mean_functions.Constant(constant=jnp.array(constant_offset)),
         kernel=gpx.kernels.Matern12(lengthscale=lengthscale, variance=variance),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=obs_stddev)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
     posterior = ss_prior * likelihood
     ss_mll = state_space_mll(posterior, train_data)
 
@@ -113,7 +113,7 @@ def test_state_space_mll_observation_mask_equivalent_to_dropping():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern12(lengthscale=lengthscale, variance=variance),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=obs_stddev)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
     posterior = ss_prior * likelihood
 
     masked_mll = state_space_mll(posterior, train_data, observation_mask=is_observed)
@@ -123,9 +123,7 @@ def test_state_space_mll_observation_mask_equivalent_to_dropping():
     X_kept = X[keep_mask]
     y_kept = y[keep_mask]
     train_data_kept = gpx.Dataset(X=X_kept.reshape(-1, 1), y=y_kept.reshape(-1, 1))
-    likelihood_kept = gpx.likelihoods.Gaussian(
-        num_datapoints=int(keep_mask.sum()), obs_stddev=obs_stddev
-    )
+    likelihood_kept = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
     posterior_kept = ss_prior * likelihood_kept
     dropped_mll = state_space_mll(posterior_kept, train_data_kept)
 
@@ -165,7 +163,7 @@ def test_state_space_mll_gradient_through_kernel_hyperparameters_is_finite(
             mean_function=gpx.mean_functions.Zero(),
             kernel=kernel,
         )
-        likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=obs_stddev)
+        likelihood = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
         posterior = prior * likelihood
         return -state_space_mll(posterior, train_data)
 
@@ -190,7 +188,7 @@ def test_state_space_mll_gradient_through_obs_stddev_is_finite():
             kernel=gpx.kernels.Matern12(lengthscale=lengthscale, variance=variance),
         )
         likelihood = gpx.likelihoods.Gaussian(
-            num_datapoints=n, obs_stddev=obs_stddev_value
+            obs_stddev=obs_stddev_value
         )
         posterior = prior * likelihood
         return -state_space_mll(posterior, train_data)

--- a/tests/test_state_space/test_prediction.py
+++ b/tests/test_state_space/test_prediction.py
@@ -135,9 +135,7 @@ def test_state_space_posterior_predict_smoothed_matches_dense_gp(kernel_class, j
         jitter=jitter,
     )
     dense_posterior = dense_prior * likelihood
-    dense_dist = dense_posterior.predict(
-        Xtest, train_data, covariance="diagonal"
-    )
+    dense_dist = dense_posterior.predict(Xtest, train_data, covariance="diagonal")
     dense_means = np.asarray(dense_dist.mean)
     dense_variances = np.asarray(dense_dist.variance)
 
@@ -278,9 +276,7 @@ def test_state_space_posterior_predict_filter_dense_raises():
     posterior = ss_prior * likelihood
     train_data = gpx.Dataset(X=X.reshape(-1, 1), y=y.reshape(-1, 1))
     with pytest.raises(NotImplementedError, match=r"diagonal|dense"):
-        posterior.predict_filter(
-            jnp.array([[0.5]]), train_data, covariance="dense"
-        )
+        posterior.predict_filter(jnp.array([[0.5]]), train_data, covariance="dense")
 
 
 def test_state_space_posterior_predict_filter_runs_and_returns_diagonal():
@@ -342,17 +338,13 @@ def test_state_space_predict_filter_uses_only_past_observations():
     y_prefix = y_train[prefix_mask].reshape(-1, 1)
     prefix_data = gpx.Dataset(X=X_prefix, y=y_prefix)
     n_prefix = X_prefix.shape[0]
-    likelihood_prefix = gpx.likelihoods.Gaussian(
-        obs_stddev=obs_stddev
-    )
+    likelihood_prefix = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
     dense_prior = gpx.gps.Prior(
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern12(lengthscale=lengthscale, variance=variance),
     )
     dense_posterior = dense_prior * likelihood_prefix
-    dense_dist = dense_posterior.predict(
-        Xtest, prefix_data, covariance="diagonal"
-    )
+    dense_dist = dense_posterior.predict(Xtest, prefix_data, covariance="diagonal")
 
     np.testing.assert_allclose(
         np.asarray(filtered_dist.mean), np.asarray(dense_dist.mean), atol=1e-5
@@ -391,9 +383,7 @@ def test_state_space_predict_smoothed_with_constant_mean_function():
         kernel=gpx.kernels.Matern12(lengthscale=lengthscale, variance=variance),
     )
     dense_posterior = dense_prior * likelihood
-    dense_dist = dense_posterior.predict(
-        Xtest, train_data, covariance="diagonal"
-    )
+    dense_dist = dense_posterior.predict(Xtest, train_data, covariance="diagonal")
     dense_means = np.asarray(dense_dist.mean)
 
     np.testing.assert_allclose(ss_means, dense_means, atol=1e-5, rtol=1e-6)

--- a/tests/test_state_space/test_prediction.py
+++ b/tests/test_state_space/test_prediction.py
@@ -337,7 +337,6 @@ def test_state_space_predict_filter_uses_only_past_observations():
     X_prefix = X_train[prefix_mask].reshape(-1, 1)
     y_prefix = y_train[prefix_mask].reshape(-1, 1)
     prefix_data = gpx.Dataset(X=X_prefix, y=y_prefix)
-    n_prefix = X_prefix.shape[0]
     likelihood_prefix = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
     dense_prior = gpx.gps.Prior(
         mean_function=gpx.mean_functions.Zero(),

--- a/tests/test_state_space/test_prediction.py
+++ b/tests/test_state_space/test_prediction.py
@@ -97,7 +97,7 @@ def test_merge_grids_train_observation_mask_propagates():
 )
 @pytest.mark.parametrize("jitter", [0.0, 1e-6])
 def test_state_space_posterior_predict_smoothed_matches_dense_gp(kernel_class, jitter):
-    """StateSpaceConjugatePosterior.predict matches dense GP at training-and-test."""
+    """StateSpaceConjugateModel.predict matches dense GP at training-and-test."""
     lengthscale = 1.5
     variance = 0.8
     obs_stddev = 0.2
@@ -119,7 +119,7 @@ def test_state_space_posterior_predict_smoothed_matches_dense_gp(kernel_class, j
         kernel=kernel,
         jitter=jitter,
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n_train, obs_stddev=obs_stddev)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
     ss_posterior = ss_prior * likelihood
     train_data = gpx.Dataset(X=X_train.reshape(-1, 1), y=y_train.reshape(-1, 1))
 
@@ -136,7 +136,7 @@ def test_state_space_posterior_predict_smoothed_matches_dense_gp(kernel_class, j
     )
     dense_posterior = dense_prior * likelihood
     dense_dist = dense_posterior.predict(
-        Xtest, train_data, return_covariance_type="diagonal"
+        Xtest, train_data, covariance="diagonal"
     )
     dense_means = np.asarray(dense_dist.mean)
     dense_variances = np.asarray(dense_dist.variance)
@@ -153,7 +153,7 @@ def test_state_space_posterior_predict_smoothed_returns_diagonal_distribution():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern32(lengthscale=1.0, variance=1.0),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=0.2)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.2)
     posterior = ss_prior * likelihood
     train_data = gpx.Dataset(X=X.reshape(-1, 1), y=y.reshape(-1, 1))
     Xtest = jnp.linspace(0.0, 10.0, 5).reshape(-1, 1)
@@ -184,7 +184,7 @@ def test_state_space_posterior_predict_observation_mask_equivalent_to_dropping()
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern12(lengthscale=lengthscale, variance=variance),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n_train, obs_stddev=obs_stddev)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
     posterior_with_mask = ss_prior * likelihood
     train_data = gpx.Dataset(X=X_train.reshape(-1, 1), y=y_train.reshape(-1, 1))
     masked_dist = posterior_with_mask.predict(
@@ -196,9 +196,7 @@ def test_state_space_posterior_predict_observation_mask_equivalent_to_dropping()
     X_kept = X_train[keep]
     y_kept = y_train[keep]
     train_data_kept = gpx.Dataset(X=X_kept.reshape(-1, 1), y=y_kept.reshape(-1, 1))
-    likelihood_kept = gpx.likelihoods.Gaussian(
-        num_datapoints=int(keep.sum()), obs_stddev=obs_stddev
-    )
+    likelihood_kept = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
     posterior_kept = ss_prior * likelihood_kept
     dropped_dist = posterior_kept.predict(Xtest, train_data_kept)
 
@@ -228,7 +226,7 @@ def test_state_space_posterior_predict_preserves_caller_order_unsorted_test_inpu
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern12(lengthscale=lengthscale, variance=variance),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n_train, obs_stddev=obs_stddev)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
     posterior = ss_prior * likelihood
     train_data = gpx.Dataset(X=X_train.reshape(-1, 1), y=y_train.reshape(-1, 1))
 
@@ -260,7 +258,7 @@ def test_state_space_posterior_predict_handles_test_at_train_timestamp():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern12(lengthscale=1.0, variance=1.0),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=0.1)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.1)
     posterior = ss_prior * likelihood
     train_data = gpx.Dataset(X=X_train, y=y_train)
     dist = posterior.predict(Xtest, train_data)
@@ -276,12 +274,12 @@ def test_state_space_posterior_predict_filter_dense_raises():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern12(lengthscale=1.0, variance=1.0),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=0.2)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.2)
     posterior = ss_prior * likelihood
     train_data = gpx.Dataset(X=X.reshape(-1, 1), y=y.reshape(-1, 1))
     with pytest.raises(NotImplementedError, match=r"diagonal|dense"):
         posterior.predict_filter(
-            jnp.array([[0.5]]), train_data, return_covariance_type="dense"
+            jnp.array([[0.5]]), train_data, covariance="dense"
         )
 
 
@@ -299,7 +297,7 @@ def test_state_space_posterior_predict_filter_runs_and_returns_diagonal():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern12(lengthscale=lengthscale, variance=variance),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=obs_stddev)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
     posterior = ss_prior * likelihood
     train_data = gpx.Dataset(X=X_train.reshape(-1, 1), y=y_train.reshape(-1, 1))
     dist = posterior.predict_filter(Xtest, train_data)
@@ -333,7 +331,7 @@ def test_state_space_predict_filter_uses_only_past_observations():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern12(lengthscale=lengthscale, variance=variance),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=obs_stddev)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
     posterior = ss_prior * likelihood
     train_data = gpx.Dataset(X=X_train.reshape(-1, 1), y=y_train.reshape(-1, 1))
     filtered_dist = posterior.predict_filter(Xtest, train_data)
@@ -345,7 +343,7 @@ def test_state_space_predict_filter_uses_only_past_observations():
     prefix_data = gpx.Dataset(X=X_prefix, y=y_prefix)
     n_prefix = X_prefix.shape[0]
     likelihood_prefix = gpx.likelihoods.Gaussian(
-        num_datapoints=n_prefix, obs_stddev=obs_stddev
+        obs_stddev=obs_stddev
     )
     dense_prior = gpx.gps.Prior(
         mean_function=gpx.mean_functions.Zero(),
@@ -353,7 +351,7 @@ def test_state_space_predict_filter_uses_only_past_observations():
     )
     dense_posterior = dense_prior * likelihood_prefix
     dense_dist = dense_posterior.predict(
-        Xtest, prefix_data, return_covariance_type="diagonal"
+        Xtest, prefix_data, covariance="diagonal"
     )
 
     np.testing.assert_allclose(
@@ -381,7 +379,7 @@ def test_state_space_predict_smoothed_with_constant_mean_function():
         mean_function=gpx.mean_functions.Constant(constant=jnp.array(constant_offset)),
         kernel=gpx.kernels.Matern12(lengthscale=lengthscale, variance=variance),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=obs_stddev)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
     posterior = ss_prior * likelihood
     train_data = gpx.Dataset(X=X_train.reshape(-1, 1), y=y_train_offset.reshape(-1, 1))
     ss_dist = posterior.predict(Xtest, train_data)
@@ -394,7 +392,7 @@ def test_state_space_predict_smoothed_with_constant_mean_function():
     )
     dense_posterior = dense_prior * likelihood
     dense_dist = dense_posterior.predict(
-        Xtest, train_data, return_covariance_type="diagonal"
+        Xtest, train_data, covariance="diagonal"
     )
     dense_means = np.asarray(dense_dist.mean)
 
@@ -418,7 +416,7 @@ def test_state_space_predict_filter_with_constant_mean_function():
         mean_function=gpx.mean_functions.Constant(constant=jnp.array(constant_offset)),
         kernel=gpx.kernels.Matern12(lengthscale=lengthscale, variance=variance),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=obs_stddev)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
     posterior = ss_prior * likelihood
     train_data = gpx.Dataset(X=X_train.reshape(-1, 1), y=y_train_offset.reshape(-1, 1))
     dist = posterior.predict_filter(Xtest, train_data)

--- a/tests/test_state_space/test_properties.py
+++ b/tests/test_state_space/test_properties.py
@@ -70,7 +70,7 @@ def _build_matern_posterior(kernel_class, lengthscale, variance, obs_stddev, n):
         mean_function=gpx.mean_functions.Zero(),
         kernel=kernel_class(lengthscale=lengthscale, variance=variance),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=obs_stddev)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
     return prior * likelihood
 
 

--- a/tests/test_state_space/test_slow.py
+++ b/tests/test_state_space/test_slow.py
@@ -54,9 +54,7 @@ def test_state_space_mll_forward_finite_at_N_100k():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern52(lengthscale=lengthscale, variance=variance),
     )
-    likelihood_subset = gpx.likelihoods.Gaussian(
-        obs_stddev=obs_stddev
-    )
+    likelihood_subset = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
     posterior_subset = prior_subset * likelihood_subset
 
     mll_ss_subset = state_space_mll(posterior_subset, train_subset)

--- a/tests/test_state_space/test_slow.py
+++ b/tests/test_state_space/test_slow.py
@@ -37,7 +37,7 @@ def test_state_space_mll_forward_finite_at_N_100k():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern52(lengthscale=lengthscale, variance=variance),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=obs_stddev)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
     posterior = prior * likelihood
 
     mll_full = state_space_mll(posterior, train_data)
@@ -55,7 +55,7 @@ def test_state_space_mll_forward_finite_at_N_100k():
         kernel=gpx.kernels.Matern52(lengthscale=lengthscale, variance=variance),
     )
     likelihood_subset = gpx.likelihoods.Gaussian(
-        num_datapoints=n_subset, obs_stddev=obs_stddev
+        obs_stddev=obs_stddev
     )
     posterior_subset = prior_subset * likelihood_subset
 
@@ -97,7 +97,7 @@ def test_state_space_mll_reverse_mode_grad_at_N_100k_with_truncated_periodic():
             truncation_order=10,
         )
         prior = StateSpacePrior(mean_function=gpx.mean_functions.Zero(), kernel=kernel)
-        likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=0.2)
+        likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.2)
         posterior = prior * likelihood
         return -state_space_mll(posterior, train_data)
 
@@ -257,7 +257,7 @@ def test_state_space_mll_extreme_regimes_finite(obs_stddev, lengthscale, time_ra
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern32(lengthscale=lengthscale, variance=1.0),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=obs_stddev)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
     posterior = prior * likelihood
 
     mll = state_space_mll(posterior, train_data)
@@ -297,7 +297,7 @@ def test_state_space_mll_finite_with_float32_inputs():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern12(lengthscale=1.0, variance=1.0),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=0.3)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=0.3)
     posterior = prior * likelihood
 
     train_data_64 = gpx.Dataset(X=X64, y=y64)

--- a/tests/test_state_space/test_smoother.py
+++ b/tests/test_state_space/test_smoother.py
@@ -56,7 +56,7 @@ def test_rts_smoother_marginals_match_dense_gp_posterior(jitter):
         kernel=gpx.kernels.Matern12(lengthscale=lengthscale, variance=variance),
         jitter=jitter,
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n, obs_stddev=obs_stddev)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
     posterior = prior * likelihood
     latent_dist = posterior.predict(X.reshape(-1, 1), train_data=train_data)
     dense_means = np.asarray(latent_dist.mean)
@@ -182,7 +182,7 @@ def test_smoother_is_finite_under_near_noiseless_dense_sampling():
         mean_function=gpx.mean_functions.Zero(),
         kernel=gpx.kernels.Matern52(lengthscale=0.05, variance=1.0),
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=200, obs_stddev=1e-4)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=1e-4)
     posterior = prior * likelihood
 
     test_times = jnp.linspace(0.0, 1.0, 50).reshape(-1, 1)

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -172,7 +172,7 @@ def test_collect_marks_and_unwraps_frozen_parameter():
 
 def test_collect_variational_family_lower_cholesky():
     prior = Prior(mean_function=Zero(), kernel=RBF())
-    posterior = prior * Gaussian(num_datapoints=5)
+    posterior = prior * Gaussian()
     q = gpx.variational_families.VariationalGaussian(
         posterior=posterior, inducing_inputs=jnp.linspace(-3, 3, 5).reshape(-1, 1)
     )
@@ -318,9 +318,9 @@ def test_summary_mixin_mimebundle_has_text_and_html():
     [
         lambda: RBF(),
         lambda: Zero(),
-        lambda: Gaussian(num_datapoints=5),
+        lambda: Gaussian(),
         lambda: Prior(mean_function=Zero(), kernel=RBF()),
-        lambda: Prior(mean_function=Zero(), kernel=RBF()) * Gaussian(num_datapoints=5),
+        lambda: Prior(mean_function=Zero(), kernel=RBF()) * Gaussian(),
     ],
 )
 def test_abstract_bases_have_rich_protocol(model_fn):
@@ -331,7 +331,7 @@ def test_abstract_bases_have_rich_protocol(model_fn):
 
 def test_variational_family_has_rich_protocol():
     prior = Prior(mean_function=Zero(), kernel=RBF())
-    posterior = prior * Gaussian(num_datapoints=5)
+    posterior = prior * Gaussian()
     q = gpx.variational_families.VariationalGaussian(
         posterior=posterior, inducing_inputs=jnp.linspace(-3, 3, 5).reshape(-1, 1)
     )

--- a/tests/test_variational_families.py
+++ b/tests/test_variational_families.py
@@ -18,7 +18,7 @@ from collections.abc import Callable
 import equinox as eqx
 import gpjax as gpx
 import gpjax.distributions
-from gpjax.gps import AbstractPosterior
+from gpjax.gps import JointModel
 import gpjax.linalg.utils
 from gpjax.parameters import (
     LowerTriangular,
@@ -66,7 +66,7 @@ def test_abstract_variational_family():
     class DummyPosterior:
         @property
         def __class__(self) -> type:
-            return AbstractPosterior
+            return JointModel
 
     class DummyVariationalFamily(AbstractVariationalFamily):
         def predict(self, x: Float[Array, "N D"]) -> npd.MultivariateNormal:
@@ -129,7 +129,7 @@ def test_variational_gaussians(
     prior = gpx.gps.Prior(
         kernel=gpx.kernels.RBF(), mean_function=gpx.mean_functions.Constant()
     )
-    likelihood = gpx.likelihoods.Gaussian(123)
+    likelihood = gpx.likelihoods.Gaussian()
     inducing_inputs = jnp.linspace(-5.0, 5.0, n_inducing).reshape(-1, 1)
 
     test_inputs = jnp.linspace(-5.0, 5.0, n_test).reshape(-1, 1)
@@ -204,7 +204,7 @@ def test_graph_variational_gaussian(
     )
     meanf = gpx.mean_functions.Constant()
     prior = gpx.gps.Prior(mean_function=meanf, kernel=kernel)
-    likelihood = gpx.likelihoods.Bernoulli(num_datapoints=G.number_of_nodes())
+    likelihood = gpx.likelihoods.Bernoulli()
 
     inducing_inputs = jnp.array(
         np.random.randint(low=1, high=100, size=(n_inducing, 1))
@@ -256,7 +256,7 @@ def test_collapsed_variational_gaussian(
     test_inputs = jnp.linspace(-5.0, 5.0, n_test).reshape(-1, 1)
     test_inputs = jnp.hstack([test_inputs] * point_dim)
 
-    posterior = prior * gpx.likelihoods.Gaussian(num_datapoints=D.n)
+    posterior = prior * gpx.likelihoods.Gaussian()
 
     variational_family = CollapsedVariationalGaussian(
         posterior=posterior,
@@ -266,7 +266,7 @@ def test_collapsed_variational_gaussian(
     # We should raise an error for non-Gaussian likelihoods:
     with pytest.raises(TypeError):
         CollapsedVariationalGaussian(
-            posterior=prior * gpx.likelihoods.Bernoulli(num_datapoints=D.n),
+            posterior=prior * gpx.likelihoods.Bernoulli(),
             inducing_inputs=inducing_inputs,
         )
 
@@ -322,7 +322,7 @@ def _build_kl_family(
     kernel = gpx.kernels.RBF(lengthscale=jnp.array(0.7), variance=jnp.array(1.3))
     mean_function = gpx.mean_functions.Constant(jnp.array([0.4]))
     prior = gpx.gps.Prior(kernel=kernel, mean_function=mean_function)
-    posterior = prior * gpx.likelihoods.Gaussian(num_datapoints=20)
+    posterior = prior * gpx.likelihoods.Gaussian()
     inducing_inputs = jnp.linspace(-3.0, 3.0, num_inducing).reshape(-1, 1)
     return family(
         posterior=posterior,


### PR DESCRIPTION
## Summary

Stack PR 2/10 for v1.0 — the conditioning architecture itself, stacked on #743 (safety net). Design settled in the 2026-08-06 architecture-review + grilling session; recorded in **ADR-0001** (`docs/adr/0001-conditioning-architecture.md`, the repo's first ADR) and the new **CONTEXT.md** glossary.

### The API now reads as the maths

```python
prior      = gpx.Prior(kernel=kernel, mean_function=mean)   # p(f)
likelihood = gpx.likelihoods.Gaussian()                     # p(y|f) — pure conditional
model      = prior * likelihood                             # p(f, y) — JointModel, the trainable object
model, _   = gpx.fit_scipy(model=model, objective=nmll, train_data=D)
posterior  = model.condition(D)                             # p(f|D) — also: model | D
posterior(xtest, covariance="diagonal")                     # predictive
posterior.log_marginal_likelihood                           # p(D), same cached factor
```

### What changed

- **`gpjax/conditioning.py`** — the deep module. One home for stabilise → factor → solve → moments (previously eleven independent derivations across `gps.py`, `objectives.py`, `variational_families.py`, `models/oilmm.py`). `Posterior` is an immutable pytree caching the Cholesky factor + representer weights; the predictive, evidence, `loo`, and pathwise `sample_approx` are views of it.
- **Jitter has one owner**: `Prior.jitter`, applied exactly once via the new `linalg.stabilised_cholesky` seam. Previously `predict` mixed two knobs *within one function* and could factorise a different matrix than `conjugate_mll`.
- **`JointModel` hierarchy** replaces the posterior classes: `ConjugateModel`, `NonConjugateModel` (latent lazily sized at data contact), `HeteroscedasticModel` (owns `noise_prior` — likelihoods are pure conditionals again; the `likelihoods → gps` circular import dies). Deleted as failed deletion-tests: `AbstractPrior`, `AbstractPosterior`, `LatentPosterior`, `ChainedPosterior`.
- **`num_datapoints` is gone** from every likelihood (research: `plans/2026-08-06-drop-num-datapoints-research.md`): `Dataset.n_total` (static aux_data, stamped by `get_batch`) now feeds the minibatch ELBO scale — it can no longer be silently wrong.
- **Objectives are views**: `conjugate_mll` ≡ `model.condition(D).log_marginal_likelihood`; LOOCV sums `posterior.loo()`. OILMM's inline-MLL JIT workaround is deleted.
- **`sample_approx` reuses the cached factor** and refuses multi-output loudly (previously broadcast silently wrong shapes).
- **Sugar kept**: `model.predict(x, D)` / `model(x, D)` ≡ `model.condition(D)(x)` — one line, documented as such. `return_covariance_type` → `covariance`.
- Docs/examples migrated; `docs/migration.md` has the full 0.18 → 1.0 table; the regression example narrates `condition`.

### The safety net paid off mid-flight
The strict-xfail from #743 (predict/MLL divergence at non-default jitter) is expected to flip for the model-side split; the collapsed-ELBO variant stays xfailed until the variational stack PR unifies the family-side knob — its reason string now says exactly that.

### Sequencing
Variational universalisation (families conditioning through the same module, `posterior` field → `model`) is stack PR 3, **after** the natgrads stack (#714–#730) merges — it rewrites `variational_families.py`. Tonight's PR touches that file mechanically only.

## Test plan
- `uv run poe all-tests` green (one local-only exception: `review_real-notebooks.md`, an untracked scratch file at repo root whose old-API snippets the markdown checker globs; absent in CI).
- `uv run python tests/integration_tests.py` — all four examples hit the goldens pinned in #743 (no behaviour change).
- New: conditioning oracle tests now also exercised through `condition()` directly.

Stacked on #743. Do not merge yet — the stack lands together as v1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019d7TF7oQt2Du4EQ74bMBQB
