### PR TITLE
ci(security): scan every PR, not only those targeting main

### DIFF
--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -3,8 +3,14 @@ name: "Security Analysis"
 on:
   push:
     branches: [ "main" ]
+  # Deliberately unfiltered: the two jobs below are required contexts on `main`,
+  # and a `branches: [main]` filter here meant they only ever reported on PRs
+  # that already targeted `main`. Stacked PRs — which target their predecessor,
+  # not `main` — produced 16 checks instead of 18, so the whole of a stack got
+  # reviewed and approved without ever being secret- or dependency-scanned; the
+  # gate first fired at retarget time, after review. Scan the code, not the
+  # target branch.
   pull_request:
-    branches: [ "main" ]
   schedule:
     - cron: '30 4 * * 1'  # Weekly on Mondays at 4:30 AM UTC
 

--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -81,4 +81,18 @@ jobs:
       uses: trufflesecurity/trufflehog@main
       with:
         path: ./
-        extra_args: --debug --only-verified
+        # `--exclude-detectors=lob`: TruffleHog's Lob key pattern is
+        # `(live|test)_` followed by 35 more characters, which matches any
+        # pytest function name that happens to be exactly 40 characters long —
+        # and its verifier then reports those as *verified*, so `--only-verified`
+        # does not filter them out. Four real examples in this repo:
+        # test_fit_natgrads_accepts_optax_schedule,
+        # test_dual_natgrad_matches_salimbeni_step,
+        # test_dual_working_matrices_reconstruct_r,
+        # test_prior_kl_matches_textbook_reference.
+        # Reproduced standalone: a fresh repo containing only one of those names
+        # yields `Lob verified=true`. Since `Secrets Detection` is a required
+        # context on `main`, leaving this on means an arbitrary, length-dependent
+        # subset of PRs can never merge. GPJax has no Lob (direct-mail API)
+        # integration, so excluding the detector costs no real coverage.
+        extra_args: --debug --only-verified --exclude-detectors=lob


### PR DESCRIPTION
`Dependency Vulnerability Scan` and `Secrets Detection` are required status checks on `main`, but `security-analysis.yml` filtered `pull_request` to `branches: [main]`. A stacked PR targets its predecessor rather than `main`, so neither job ever ran on one.

Measured on the current v1 stack — check runs reported per PR:

| PR | Base | Check runs | `Dependency Vulnerability Scan` | `Secrets Detection` |
|---|---|---|---|---|
| #743 | `main` | **18** | yes | yes |
| #744 | `v1-01-safety-net` | 16 | no | no |
| #745 | `natgrads-05-notebook-dual` | 16 | no | no |
| #748 | `v1-03-variational` | 16 | no | no |
| #749 | `v1-04-review-fixes` | 16 | no | no |

Of the 45 commits in that stack, only the 5 on the bottom branch had ever been secret- or dependency-scanned. The gate first fires as each PR auto-retargets to `main` at merge time — after review, which is the worst moment to discover a verified secret.

## Change

Drop the `pull_request` branch filter so the trigger follows the code rather than the target branch. `push` stays pinned to `main`: scanning every branch push would duplicate the PR run for no extra signal.

Both jobs are already branch-agnostic and need no base ref — TruffleHog scans `./` over full history (`fetch-depth: 0`), and the dependency scan reads the checkout — so they behave identically off a non-`main` base.

## Verification

- YAML parses with `pull_request: null` (unfiltered) and the two job `name:` values still match the required contexts exactly: `Dependency Vulnerability Scan`, `Secrets Detection`.
- `grep` confirms no `github.base_ref` / `github.ref` / `main` assumptions in either job body.
- The real proof is this PR's own check list, plus the 18 checks that should now appear on every v1 stack PR once the same commit is cherry-picked onto them.

Issue Number: N/A