### PR TITLE
fix(oilmm): default predict/__call__ to diagonal, not dense, covariance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gradient descent in the dual coordinates. The `VariationalParametrisationSuite` ASV
   benchmark gains a `dual` axis value.
 
+### Changed (breaking)
+
+- **`OILMMPosterior.__call__`/`.predict` default to `covariance="diagonal"`**
+  (was `"dense"`) ([#682](https://github.com/JaxGaussianProcesses/GPJax/issues/682)).
+  The dense joint covariance costs `O(m n^2 p^2)` — an `np x np` matrix built
+  from `m` dense `n x n` latent covariances — which forfeits the
+  `O(mn^3 + nmp)` scaling that OILMM exists to provide, and is unaffordable
+  well before the mean/marginal-variance query is. Marginal variances are the
+  common case and are unaffected by the mixing matrix's off-diagonal
+  structure, so the cheap path is now the default; pass
+  `covariance="dense"` explicitly for the joint covariance.
+
 ### Removed
 
 - **`NaturalVariationalGaussian` and `ExpectationVariationalGaussian`.** These were

--- a/gpjax/models/oilmm.py
+++ b/gpjax/models/oilmm.py
@@ -413,7 +413,7 @@ class OILMMPosterior(Posterior):
         self,
         test_inputs: Float[Array, "N D"],
         *,
-        covariance: tp.Literal["dense", "diagonal"] = "dense",
+        covariance: tp.Literal["dense", "diagonal"] = "diagonal",
     ) -> GaussianDistribution:
         r"""Evaluate the conditioned OILMM at the given test inputs.
 
@@ -427,6 +427,13 @@ class OILMMPosterior(Posterior):
         processes return :math:`(N, N)`. ``covariance="diagonal"`` returns the
         :math:`NP` marginal variances, and asks the same of each latent
         process, so the dense latent covariances are never formed.
+
+        The default is ``"diagonal"``: forming the joint covariance costs
+        :math:`O(m n^2 p^2)` (an :math:`np \times np` matrix from :math:`m`
+        :math:`n \times n` latent covariances), which forfeits the
+        :math:`O(mn^3 + nmp)` scaling OILMM exists for. Marginal variances are
+        the common query and stay on the cheap path; pass
+        ``covariance="dense"`` to opt into the joint covariance explicitly.
 
         Args:
             test_inputs: Input locations of shape ``(N, D)``.
@@ -495,10 +502,12 @@ class OILMMPosterior(Posterior):
         test_inputs: Float[Array, "N D"],
         train_data: Dataset | None = None,
         *,
-        covariance: tp.Literal["dense", "diagonal"] = "dense",
+        covariance: tp.Literal["dense", "diagonal"] = "diagonal",
         return_full_cov: bool | None = None,
     ) -> GaussianDistribution:
         r"""Sugar for calling the posterior: ``predict(t) == self(t)``.
+
+        Defaults to ``covariance="diagonal"``: see :meth:`__call__` for why.
 
         Args:
             test_inputs: Input locations of shape ``(N, D)``.

--- a/tests/test_models_oilmm.py
+++ b/tests/test_models_oilmm.py
@@ -325,7 +325,7 @@ class TestOILMMPosterior:
         posterior = model.condition(gpx.Dataset(X=X, y=y))
 
         X_test = jnp.linspace(0.2, 0.8, 5).reshape(-1, 1)
-        pred = posterior.predict(X_test)
+        pred = posterior.predict(X_test, covariance="dense")
 
         expected_shape = (5 * P, 5 * P)
         assert pred.covariance().shape == expected_shape
@@ -350,7 +350,7 @@ class TestOILMMPosterior:
         posterior = model.condition(gpx.Dataset(X=X, y=y))
 
         X_test = jnp.linspace(0.1, 0.9, 8).reshape(-1, 1)
-        pred = posterior.predict(X_test)
+        pred = posterior.predict(X_test, covariance="dense")
         cov = pred.covariance()
 
         # Check PSD via eigenvalues
@@ -482,7 +482,7 @@ class TestOILMMIntegration:
         # 4. Predict at test points (train data stored internally)
         N_test = 10
         X_test = jnp.linspace(0.1, 0.9, N_test).reshape(-1, 1)
-        pred = posterior.predict(X_test)
+        pred = posterior.predict(X_test, covariance="dense")
 
         # 5. Verify prediction properties
         assert pred.mean.shape == (N_test * P,)
@@ -1037,6 +1037,49 @@ def test_oilmm_predict_diagonal_returns_diagonal_operator():
     pred_full = posterior.predict(X_test, covariance="dense")
     assert jnp.allclose(
         jnp.diag(pred_full.covariance()), jnp.diag(pred_diag.covariance()), atol=1e-6
+    )
+
+
+def test_oilmm_predict_default_covariance_is_diagonal():
+    """The default covariance must be "diagonal", not "dense" (issue #682): the
+    dense joint covariance is O(m n^2 p^2) and forfeits OILMM's O(mn^3 + nmp)
+    scaling, so the cheap marginal-variance path must be the default rather
+    than an opt-in."""
+    import gpjax as gpx
+    from gpjax.models.oilmm import OILMMModel
+    import lineax as lx
+
+    key = jax.random.PRNGKey(17)
+    model = OILMMModel(
+        num_outputs=3,
+        num_latent_gps=2,
+        kernel=gpx.kernels.RBF(),
+        key=key,
+    )
+
+    N, P = 8, 3
+    X = jnp.linspace(0.0, 1.0, N).reshape(-1, 1)
+    y = jr.normal(key, (N, P))
+    dataset = gpx.Dataset(X=X, y=y)
+    posterior = model.condition(dataset)
+
+    X_test = jnp.linspace(0.1, 0.9, 5).reshape(-1, 1)
+
+    # Neither __call__ nor predict() takes a covariance kwarg here.
+    pred_call = posterior(X_test)
+    pred_predict = posterior.predict(X_test)
+
+    for pred in (pred_call, pred_predict):
+        assert isinstance(pred.scale, lx.DiagonalLinearOperator), (
+            f"Expected default covariance to be diagonal, got "
+            f"{type(pred.scale).__name__}"
+        )
+
+    # And it must agree with the explicit diagonal call.
+    pred_explicit_diag = posterior.predict(X_test, covariance="diagonal")
+    assert jnp.allclose(pred_predict.mean, pred_explicit_diag.mean, atol=1e-10)
+    assert jnp.allclose(
+        pred_predict.covariance(), pred_explicit_diag.covariance(), atol=1e-10
     )
 
 


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `uv run poe format` before committing.
- [x] I've added tests for new code.
- [x] I've added docstrings for the new code.

## Description

`OILMMPosterior.__call__`/`.predict` defaulted `covariance="dense"`, building a `[P,P,N,N]` einsum and a dense `[NP,NP]` covariance by default — O(m n² p²) work that forfeits the O(mn³+nmp) scaling OILMM exists for (Bruinsma et al. 2020 §3). Training already used the fast path; only prediction densified by default.

Flips the default to `covariance="diagonal"` so the common marginal-variance query stays cheap; the dense joint covariance remains available via explicit opt-in. This is a **breaking default-behaviour change** — a CHANGELOG entry is included. `docs/examples/oilmm.py`/`multioutput.py` already pass `covariance=` explicitly everywhere, so no doc changes were needed.

Addresses #682.

## Test plan

- `uv run pytest tests/test_models_oilmm.py tests/test_models_oilmm_performance.py` — 47 passed
- `uv run poe lint` — clean