### PR TITLE
fix(kernels): make gram() delegate to _gram, fixing RFF double-compute

### DIFF
--- a/gpjax/kernels/computations/base.py
+++ b/gpjax/kernels/computations/base.py
@@ -64,7 +64,7 @@ class AbstractKernelComputation:
         Returns:
             The Gram covariance of the kernel function as a linear operator.
         """
-        Kxx = self.cross_covariance(kernel, x, x)
+        Kxx = self._gram(kernel, x)
         return lx.TaggedLinearOperator(
             lx.MatrixLinearOperator(Kxx), lx.positive_semidefinite_tag
         )

--- a/tests/test_kernels/test_computation.py
+++ b/tests/test_kernels/test_computation.py
@@ -2,9 +2,15 @@ from gpjax.kernels.computations import (
     ConstantDiagonalKernelComputation,
     DiagonalKernelComputation,
 )
-from gpjax.kernels.stationary import RBF
+from gpjax.kernels.stationary import (
+    RBF,
+    Matern12,
+    Matern32,
+    Matern52,
+)
 import jax.numpy as jnp
 import lineax as lx
+import pytest
 
 
 def test_dense_computation():
@@ -44,6 +50,21 @@ def test_diagonal_computation():
 
     # All the off diagonal entries should be zero
     assert jnp.allclose(diagonal_matrix - jnp.diag(diag_entries), 0.0)
+
+
+@pytest.mark.parametrize("kernel_type", [RBF, Matern12, Matern32, Matern52])
+def test_gram_matches_cross_covariance_on_self(kernel_type):
+    """AbstractKernelComputation.gram delegates to _gram, which for the base
+    class computes cross_covariance(kernel, x, x). This must remain
+    numerically identical to calling cross_covariance directly.
+    """
+    kernel = kernel_type()
+    x = jnp.linspace(-3.0, 3.0, 5).reshape(-1, 1)
+
+    gram_matrix = kernel.gram(x).as_matrix()
+    cross_covariance_matrix = kernel.cross_covariance(x, x)
+
+    assert jnp.allclose(gram_matrix, cross_covariance_matrix)
 
 
 def test_constant_diagonal_computation():

--- a/tests/test_kernels/test_computations.py
+++ b/tests/test_kernels/test_computations.py
@@ -93,6 +93,42 @@ class TestBasisFunctionComputation:
         cc = rff_kernel.compute_engine.cross_covariance(rff_kernel, x, x)
         assert jnp.allclose(gram, cc, atol=1e-5)
 
+    def test_gram_computes_features_exactly_once(self, rff_kernel, monkeypatch):
+        """gram(x) should compute the feature matrix a single time.
+
+        `cross_covariance(x, x)` legitimately computes the feature matrix
+        twice (once per argument), but `gram` has its own single-pass
+        `_gram` override precisely to avoid that redundant work. If `gram`
+        ever regresses to routing through `cross_covariance`, this test
+        catches it.
+        """
+        x = jr.normal(jr.key(1), (8, 2))
+        engine = rff_kernel.compute_engine
+        original_compute_features = engine.compute_features
+        call_count = 0
+
+        def counting_compute_features(kernel, x):
+            nonlocal call_count
+            call_count += 1
+            return original_compute_features(kernel, x)
+
+        monkeypatch.setattr(engine, "compute_features", counting_compute_features)
+
+        rff_kernel.gram(x)
+
+        assert call_count == 1
+
+    def test_gram_matches_manual_feature_computation(self, rff_kernel):
+        """gram(x) should equal scaling * features @ features.T exactly."""
+        x = jr.normal(jr.key(1), (8, 2))
+        engine = rff_kernel.compute_engine
+        features = engine.compute_features(rff_kernel, x)
+        expected = engine.scaling(rff_kernel) * jnp.matmul(features, features.T)
+
+        gram = rff_kernel.gram(x).as_matrix()
+
+        assert jnp.allclose(gram, expected)
+
     def test_diagonal(self, rff_kernel):
         """Diagonal should return a linear operator."""
         x = jr.normal(jr.key(1), (8, 2))


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `uv run poe format` before committing.
- [x] I've added tests for new code.
- [x] I've added docstrings for the new code.

## Description

`AbstractKernelComputation._gram` had zero callers — `gram()` called `cross_covariance(kernel, x, x)` directly instead, making `BasisFunctionComputation._gram`'s genuine single-pass RFF override dead code. Because `gram()` bypassed it, every RFF `.gram(x)` call recomputed the feature matrix twice (once via each of `cross_covariance`'s two internal calls).

Makes `gram()` delegate to `self._gram(kernel, x)` (base `_gram` = `cross_covariance(kernel, x, x)`, so every other kernel's behaviour is unchanged) so RFF's single-pass override is actually used.

Addresses #679.

## Test plan

- `uv run pytest tests/test_kernels/` — 1483 passed
- New test asserts RFF's `.gram(x)` computes its feature matrix exactly once
- `uv run poe lint` — clean