### PR TITLE
fix(kernels): honest field defaults, drop stale init workaround, fix White

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`gpx.kernels.RBF()` was a type error, and `White()` carried a phantom
+  trainable lengthscale**
+  ([#695](https://github.com/JaxGaussianProcesses/GPJax/issues/695)). Pyright
+  synthesises `__init__` signatures from dataclass fields for any kernel that
+  inherits its `__init__` (e.g. `RBF`, `Matern12/32/52`), and those fields had
+  no defaults, so the canonical `RBF()` call was flagged as missing arguments
+  while the nonsensical `RBF(name="xyz")` type-checked cleanly (raising
+  `TypeError` at runtime). Kernel fields now carry real defaults matching
+  their `__init__` defaults, and `name` is a `ClassVar` rather than a
+  dataclass field, so the synthesised and hand-written signatures agree.
+  Separately, `White` hardcoded `lengthscale=1.0` into
+  `StationaryKernel.__init__` even though `White.__call__` never reads it,
+  so every `White` kernel carried a real, trainable `PositiveReal` leaf with
+  zero gradient that showed up in optimiser state and MCMC traces; `White`
+  now has its own minimal `__init__` and no longer carries a lengthscale at
+  all (`White().lengthscale is None`, and it is absent from
+  `jax.tree_util.tree_flatten`). The stale `_compute_base_init` workaround in
+  `kernels/base.py`, whose docstring claimed "equinox modules are frozen
+  after `super().__init__()`" -- no longer true under the pinned Equinox
+  version -- was removed in favour of a plain `super().__init__(...)` call.
+
 - **`Zero` mean function is trainable and drifts away from zero.** Fitting a
   model with the default `Zero()` mean function moved its constant towards the
   data mean (0.0 → 5.09 on a dataset with mean 5), silently changing the

--- a/gpjax/kernels/base.py
+++ b/gpjax/kernels/base.py
@@ -51,7 +51,9 @@ class AbstractKernel(_SummaryMixin, eqx.Module):
     active_dims: tp.Union[list[int], slice] = eqx.field(
         static=True, default_factory=lambda: slice(None)
     )
-    compute_engine: AbstractKernelComputation = eqx.field(static=True)
+    compute_engine: AbstractKernelComputation = eqx.field(
+        static=True, default_factory=DenseKernelComputation
+    )
     n_dims: tp.Union[int, None] = eqx.field(static=True, default=None)
 
     def __init__(
@@ -301,19 +303,6 @@ class ProductKernel(CombinationKernel):
 
     def _reduce(self, values: Float[Array, " K"]) -> ScalarFloat:
         return jnp.prod(values)
-
-
-def _compute_base_init(active_dims, n_dims, compute_engine=DenseKernelComputation()):
-    """Compute validated base kernel init values without setting fields.
-
-    Use this in subclass __init__ methods to compute the base fields before
-    setting them, since equinox modules are frozen after super().__init__().
-    """
-    active_dims = active_dims or slice(None)
-    _check_active_dims(active_dims)
-    _check_n_dims(n_dims)
-    active_dims, n_dims = _check_dims_compat(active_dims, n_dims)
-    return active_dims, n_dims, compute_engine
 
 
 def _check_active_dims(active_dims: tp.Any):

--- a/gpjax/kernels/stationary/base.py
+++ b/gpjax/kernels/stationary/base.py
@@ -15,12 +15,13 @@
 
 
 import beartype.typing as tp
+import equinox as eqx
 import jax.numpy as jnp
 from jaxtyping import Float
 import numpyro.distributions as npd
 from paramax import AbstractUnwrappable
 
-from gpjax.kernels.base import AbstractKernel, _compute_base_init, _val
+from gpjax.kernels.base import AbstractKernel, _val
 from gpjax.kernels.computations import (
     AbstractKernelComputation,
     DenseKernelComputation,
@@ -48,8 +49,12 @@ class StationaryKernel(AbstractKernel):
     for each input dimension.
     """
 
-    lengthscale: AbstractUnwrappable
-    variance: AbstractUnwrappable
+    lengthscale: AbstractUnwrappable = eqx.field(
+        default_factory=lambda: PositiveReal(1.0)
+    )
+    variance: AbstractUnwrappable = eqx.field(
+        default_factory=lambda: NonNegativeReal(1.0)
+    )
 
     def __init__(
         self,
@@ -73,13 +78,13 @@ class StationaryKernel(AbstractKernel):
             compute_engine: The computation engine that the kernel uses to compute the
                 covariance matrix.
         """
-
-        # Compute base fields without calling super().__init__() since
-        # equinox freezes the module when any parent __init__ returns.
-        active_dims, n_dims, compute_engine = _compute_base_init(
-            active_dims, n_dims, compute_engine
+        super().__init__(
+            active_dims=active_dims, n_dims=n_dims, compute_engine=compute_engine
         )
-        n_dims = _validate_lengthscale(lengthscale, n_dims)
+        # active_dims/n_dims are validated by AbstractKernel.__init__ above; a
+        # vector lengthscale may further pin down n_dims (e.g. ARD with
+        # active_dims=slice(None)), so re-derive it from the lengthscale here.
+        self.n_dims = _validate_lengthscale(lengthscale, self.n_dims)
 
         if isinstance(lengthscale, AbstractUnwrappable):
             self.lengthscale = lengthscale
@@ -90,10 +95,6 @@ class StationaryKernel(AbstractKernel):
             self.variance = variance
         else:
             self.variance = NonNegativeReal(variance)
-
-        self.active_dims = active_dims
-        self.n_dims = n_dims
-        self.compute_engine = compute_engine
 
     def _spectral_scale_tril(self) -> Float[Array, "D D"]:
         r"""The scale matrix $\mathrm{diag}(1/\ell)$ of the spectral measure.

--- a/gpjax/kernels/stationary/matern12.py
+++ b/gpjax/kernels/stationary/matern12.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
+from typing import ClassVar
+
 import jax.numpy as jnp
 from jaxtyping import Float
 import numpyro.distributions as npd
@@ -40,7 +42,7 @@ class Matern12(StationaryKernel):
     $$
     """
 
-    name: str = "Matérn12"
+    name: ClassVar[str] = "Matérn12"
 
     def __call__(self, x: Float[Array, " D"], y: Float[Array, " D"]) -> ScalarFloat:
         x = self.slice_input(x) / _val(self.lengthscale)

--- a/gpjax/kernels/stationary/matern32.py
+++ b/gpjax/kernels/stationary/matern32.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
+from typing import ClassVar
+
 import jax.numpy as jnp
 from jaxtyping import Float
 import numpyro.distributions as npd
@@ -37,7 +39,7 @@ class Matern32(StationaryKernel):
     $$
     """
 
-    name: str = "Matérn32"
+    name: ClassVar[str] = "Matérn32"
 
     def __call__(
         self,

--- a/gpjax/kernels/stationary/matern52.py
+++ b/gpjax/kernels/stationary/matern52.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
+from typing import ClassVar
+
 import jax.numpy as jnp
 from jaxtyping import Float
 import numpyro.distributions as npd
@@ -38,7 +40,7 @@ class Matern52(StationaryKernel):
     $$
     """
 
-    name: str = "Matérn52"
+    name: ClassVar[str] = "Matérn52"
 
     def __call__(
         self, x: Float[Array, " D"], y: Float[Array, " D"]

--- a/gpjax/kernels/stationary/periodic.py
+++ b/gpjax/kernels/stationary/periodic.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
+from typing import ClassVar
+
 import beartype.typing as tp
 import jax.numpy as jnp
 from jaxtyping import Float
@@ -46,7 +48,7 @@ class Periodic(StationaryKernel):
     Key reference is MacKay 1998 - "Introduction to Gaussian processes".
     """
 
-    name: str = "Periodic"
+    name: ClassVar[str] = "Periodic"
     period: tp.Any
 
     def __init__(

--- a/gpjax/kernels/stationary/powered_exponential.py
+++ b/gpjax/kernels/stationary/powered_exponential.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
+from typing import ClassVar
+
 import beartype.typing as tp
 import jax.numpy as jnp
 from jaxtyping import Float
@@ -50,7 +52,7 @@ class PoweredExponential(StationaryKernel):
     https://en.wikipedia.org/wiki/Generalized_normal_distribution#Symmetric_version
     """
 
-    name: str = "Powered Exponential"
+    name: ClassVar[str] = "Powered Exponential"
     power: tp.Any
 
     def __init__(

--- a/gpjax/kernels/stationary/rational_quadratic.py
+++ b/gpjax/kernels/stationary/rational_quadratic.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
+from typing import ClassVar
+
 import beartype.typing as tp
 from jaxtyping import Float
 from paramax import AbstractUnwrappable
@@ -48,7 +50,7 @@ class RationalQuadratic(StationaryKernel):
     squared lengthscale.
     """
 
-    name: str = "Rational Quadratic"
+    name: ClassVar[str] = "Rational Quadratic"
     alpha: tp.Any
 
     def __init__(

--- a/gpjax/kernels/stationary/rbf.py
+++ b/gpjax/kernels/stationary/rbf.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
+from typing import ClassVar
+
 import jax.numpy as jnp
 from jaxtyping import Float
 import numpyro.distributions as npd
@@ -36,7 +38,7 @@ class RBF(StationaryKernel):
     $$
     """
 
-    name: str = "RBF"
+    name: ClassVar[str] = "RBF"
 
     def __call__(self, x: Float[Array, " D"], y: Float[Array, " D"]) -> ScalarFloat:
         x = self.slice_input(x) / _val(self.lengthscale)

--- a/gpjax/kernels/stationary/white.py
+++ b/gpjax/kernels/stationary/white.py
@@ -12,16 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from typing import ClassVar
+
 import jax.numpy as jnp
 from jaxtyping import Float
 from paramax import AbstractUnwrappable
 
-from gpjax.kernels.base import _val
+from gpjax.kernels.base import AbstractKernel, _val
 from gpjax.kernels.computations import (
     AbstractKernelComputation,
     ConstantDiagonalKernelComputation,
 )
 from gpjax.kernels.stationary.base import StationaryKernel
+from gpjax.parameters import NonNegativeReal
 from gpjax.typing import (
     Array,
     ScalarFloat,
@@ -37,7 +40,12 @@ class White(StationaryKernel):
     $$
     """
 
-    name: str = "White"
+    name: ClassVar[str] = "White"
+    # White noise has no lengthscale: __call__ never reads it, so it is
+    # overridden to a ClassVar here rather than inherited as a real field,
+    # which would otherwise manufacture a phantom, trainable pytree leaf
+    # (see issue #695).
+    lengthscale: ClassVar[None] = None
 
     def __init__(
         self,
@@ -55,7 +63,18 @@ class White(StationaryKernel):
             compute_engine: The computation engine that the kernel uses to compute the
                 covariance matrix
         """
-        super().__init__(active_dims, 1.0, variance, n_dims, compute_engine)
+        # Bypass StationaryKernel.__init__ (which would set a lengthscale)
+        # and go straight to AbstractKernel.__init__.
+        AbstractKernel.__init__(
+            self,
+            active_dims=active_dims,
+            n_dims=n_dims,
+            compute_engine=compute_engine,
+        )
+        if isinstance(variance, AbstractUnwrappable):
+            self.variance = variance
+        else:
+            self.variance = NonNegativeReal(variance)
 
     def __call__(self, x: Float[Array, " D"], y: Float[Array, " D"]) -> ScalarFloat:
         K = jnp.all(jnp.equal(x, y)) * _val(self.variance)

--- a/tests/test_kernels/test_stationary.py
+++ b/tests/test_kernels/test_stationary.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
+import dataclasses
 from itertools import product
 from typing import Any
 
@@ -130,7 +131,13 @@ def test_init_defaults(kernel: type[StationaryKernel]):
     # Check that the parameters are set correctly
     assert isinstance(k.compute_engine, type(AbstractKernelComputation()))
     assert isinstance(k.variance, NonNegativeReal)
-    assert isinstance(k.lengthscale, PositiveReal)
+
+    # White has no lengthscale: __call__ never reads it, so it is not a
+    # real (trainable) field -- see test_white_kernel_has_no_lengthscale_leaf.
+    if kernel == White:
+        assert k.lengthscale is None
+    else:
+        assert isinstance(k.lengthscale, PositiveReal)
 
 
 @pytest.mark.parametrize("kernel", [k[0] for k in TESTED_KERNELS])
@@ -215,3 +222,35 @@ def test_cross_covariance(test_init: StationaryKernel, n_a: int, n_b: int):
     Kxy = k.cross_covariance(x, y)
     assert isinstance(Kxy, jax.Array)
     assert Kxy.shape == (n_a, n_b)
+
+
+def test_white_kernel_has_no_lengthscale_leaf():
+    """Regression test for issue #695.
+
+    `White.__call__` never reads a lengthscale, so `StationaryKernel`'s
+    lengthscale must not survive as a real (trainable) pytree leaf on
+    `White` -- previously it was hardcoded to 1.0 and silently optimised.
+    """
+    kernel = White()
+    leaves = jax.tree_util.tree_leaves(kernel)
+
+    # Only the (unconstrained) variance leaf should remain.
+    assert len(leaves) == 1
+    assert jnp.allclose(leaves[0], kernel.variance._unconstrained)
+
+
+@pytest.mark.parametrize("kernel", [k[0] for k in TESTED_KERNELS])
+def test_name_is_not_a_constructor_argument(kernel: type[StationaryKernel]):
+    """Regression test for issue #695.
+
+    `name` is a `ClassVar`, not a dataclass field: it must not appear in the
+    pytree, and passing it as a keyword argument must fail at runtime just as
+    it already did before the fix (this pins the *runtime* contract; the
+    corresponding *static* contract -- that a type checker also rejects
+    `kernel(name=...)` -- is exercised via pyright in issue #695's fix).
+    """
+    kernel_name = kernel().name
+    assert isinstance(kernel_name, str)
+    assert "name" not in [f.name for f in dataclasses.fields(kernel)]
+    with pytest.raises(TypeError):
+        kernel(name="renamed")


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `uv run poe format` before committing.
- [x] I've added tests for new code.
- [x] I've added docstrings for the new code.

## Description

Scoped fix per the existing research note at `plans/2026-07-26-issue-695-abstract-final.md` (not a wholesale abstract/final rewrite, which the plan explicitly recommends against since it would break the documented custom-kernel extension pattern):

1. Real Equinox field defaults + `name` as `ClassVar[str]`, so `RBF()` type-checks cleanly under pyright and `RBF(name="xyz")` is correctly flagged as invalid.
2. Dropped the stale `_compute_base_init` workaround (its "equinox modules are frozen after super().__init__()" premise no longer holds).
3. Fixed `White`'s phantom trainable `lengthscale`: it hardcoded `lengthscale=1.0` into the base `__init__` even though `White.__call__` never reads it, so it was a real, trainable `PositiveReal` leaf polluting optimizer/MCMC state. `White` no longer carries a lengthscale leaf at all (verified via pytree leaf count).

Addresses #695.

## Test plan

- `uv run pytest tests/test_kernels/` — 1480 passed
- `uvx pyright` confirms `RBF()` type-checks and `RBF(name="xyz")` is flagged
- `uv run poe lint` — clean