### PR TITLE
refactor(kernels): merge _newton_girard and _newton_girard_matrices

### DIFF
--- a/gpjax/kernels/additive/oak.py
+++ b/gpjax/kernels/additive/oak.py
@@ -58,9 +58,9 @@ def _constrained_se_kernel(
 
 
 def _newton_girard(
-    z: Float[Array, " D"],
+    z: Float[Array, " D *trailing"],
     max_order: int,
-) -> Float[Array, " D_tilde_plus_1"]:
+) -> Float[Array, " D_tilde_plus_1 *trailing"]:
     """Compute elementary symmetric polynomials via Newton-Girard recursion.
 
     Given values z_1, ..., z_D, computes e_0, e_1, ..., e_{max_order} where:
@@ -71,33 +71,44 @@ def _newton_girard(
 
     and s_k = sum(z_i^k) are power sums.
 
+    Each z_i may itself be an array of arbitrary trailing shape (e.g. a
+    scalar per dimension for OAK's kernel evaluation, or an (N, N) matrix
+    per dimension for Sobol index computation): all arithmetic broadcasts
+    element-wise over the trailing dimensions, so the same recursion serves
+    both call sites.
+
     Uses jax.lax.fori_loop for JAX compatibility (no Python for loops).
 
     Args:
-        z: Array of D values (one per dimension).
+        z: Array of shape (D, *trailing) -- one value per dimension, each
+            value itself an array of arbitrary (possibly empty) trailing
+            shape.
         max_order: Maximum order of elementary symmetric polynomial to compute.
 
     Returns:
-        Array of shape (max_order + 1,) containing e_0 through e_{max_order}.
+        Array of shape (max_order + 1, *trailing) containing e_0 through
+        e_{max_order}.
     """
-    # Power sums: s[k] = sum_{d=1}^D z_d^{k+1}  (vectorised over k)
-    exponents = jnp.arange(1, max_order + 1)[:, None]
-    power_sums = jnp.sum(z[None, :] ** exponents, axis=1)
+    trailing_ndim = z.ndim - 1
+
+    # Power sums: s[k, ...] = sum_{d=1}^D z_d[...]^{k+1}  (vectorised over k)
+    exponents = jnp.arange(1, max_order + 1).reshape((-1,) + (1,) * z.ndim)
+    power_sums = jnp.sum(z[None] ** exponents, axis=1)
 
     # Precompute sign-alternating power sums: (-1)^{k-1} * s_k
     signs = (-1.0) ** jnp.arange(max_order)  # [+1, -1, +1, -1, ...]
-    signed_power_sums = signs * power_sums
+    signed_power_sums = signs.reshape((-1,) + (1,) * trailing_ndim) * power_sums
 
-    elem_sym = jnp.zeros(max_order + 1)
+    elem_sym = jnp.zeros((max_order + 1, *z.shape[1:]))
     elem_sym = elem_sym.at[0].set(1.0)
 
     def _recursion_step(order, elem_sym):
         # e_order = (1/order) * sum_{k=1}^{order} (-1)^{k-1} * e[order-k] * s[k-1]
         k_indices = jnp.arange(max_order)
         lookback_indices = (order - 1 - k_indices).clip(0)
-        mask = k_indices < order
+        mask = (k_indices < order).reshape((-1,) + (1,) * trailing_ndim)
         previous_values = jnp.where(mask, elem_sym[lookback_indices], 0.0)
-        value = jnp.dot(previous_values, signed_power_sums) / order
+        value = jnp.sum(previous_values * signed_power_sums, axis=0) / order
         return elem_sym.at[order].set(value)
 
     elem_sym = lax.fori_loop(1, max_order + 1, _recursion_step, elem_sym)

--- a/gpjax/kernels/additive/sobol.py
+++ b/gpjax/kernels/additive/sobol.py
@@ -13,10 +13,10 @@ from __future__ import annotations
 import typing as tp
 
 import jax
-from jax import lax
 import jax.numpy as jnp
 from jaxtyping import Float
 
+from gpjax.kernels.additive.oak import _newton_girard
 from gpjax.kernels.base import _val
 from gpjax.typing import Array
 
@@ -120,42 +120,6 @@ def _sobol_integral_matrix(
     return jnp.where(inactive, jnp.zeros((num_points, num_points)), result)
 
 
-def _newton_girard_matrices(
-    matrices: Float[Array, "D N N"],
-    max_order: int,
-) -> Float[Array, "D_tilde_plus_1 N N"]:
-    """Element-wise Newton-Girard on a stack of (D, N, N) matrices.
-
-    Computes the elementary symmetric polynomials E_0, ..., E_{max_order}
-    where E_d[i,j] = sum over all size-d subsets u of prod_{k in u} M_k[i,j].
-
-    This is the matrix-level analogue of _newton_girard in oak.py, using
-    lax.fori_loop for JAX compatibility.
-    """
-    _, num_points, _ = matrices.shape
-
-    # Power sums: S[k, i, j] = sum_{d=0}^{D-1} matrices[d, i, j]^{k+1}
-    exponents = jnp.arange(1, max_order + 1)[:, None, None, None]
-    power_sums = jnp.sum(matrices[None, :, :, :] ** exponents, axis=1)
-
-    signs = (-1.0) ** jnp.arange(max_order)
-    signed_power_sums = signs[:, None, None] * power_sums
-
-    elem_sym = jnp.zeros((max_order + 1, num_points, num_points))
-    elem_sym = elem_sym.at[0].set(jnp.ones((num_points, num_points)))
-
-    def _recursion_step(order, elem_sym):
-        k_indices = jnp.arange(max_order)
-        lookback_indices = (order - 1 - k_indices).clip(0)
-        mask = (k_indices < order)[:, None, None]
-        previous_values = jnp.where(mask, elem_sym[lookback_indices], 0.0)
-        value = jnp.sum(previous_values * signed_power_sums, axis=0) / order
-        return elem_sym.at[order].set(value)
-
-    elem_sym = lax.fori_loop(1, max_order + 1, _recursion_step, elem_sym)
-    return elem_sym
-
-
 def sobol_indices(
     kernel: OrthogonalAdditiveKernel,
     x_train: Float[Array, "N D"],
@@ -200,7 +164,7 @@ def sobol_indices(
 
     # Matrix-level Newton-Girard: E_d[i,j] = sum over size-d subsets
     # of element-wise products of integral matrices
-    elem_sym = _newton_girard_matrices(integral_matrices, max_order)
+    elem_sym = _newton_girard(integral_matrices, max_order)
 
     # Sobol index for order d: V_d = sigma^2_d * alpha^T E_d alpha
     # Skip E[0] (the offset term); use E[1:] for orders 1..max_order

--- a/tests/test_oak.py
+++ b/tests/test_oak.py
@@ -112,6 +112,34 @@ class TestNewtonGirard:
         assert jnp.allclose(e[1], 10.0)
         assert jnp.allclose(e[2], 35.0)
 
+    def test_matrix_valued_broadcasts_elementwise(self):
+        """A (D, N, N) input applies the recursion element-wise per matrix.
+
+        This is the shape used by Sobol index computation: one (N, N)
+        integral matrix per dimension, in place of one scalar per dimension.
+        The merged `_newton_girard` must reduce to the same per-element
+        scalar recursion, so each (i, j) slice should match calling
+        `_newton_girard` directly on the scalars z[:, i, j].
+        """
+        key = jr.PRNGKey(0)
+        matrices = jr.normal(key, shape=(4, 3, 3))  # (D=4, N=3, N=3)
+        max_order = 3
+
+        e_matrix = _newton_girard(matrices, max_order=max_order)
+        assert e_matrix.shape == (max_order + 1, 3, 3)
+
+        for i in range(3):
+            for j in range(3):
+                e_scalar = _newton_girard(matrices[:, i, j], max_order=max_order)
+                assert jnp.allclose(e_matrix[:, i, j], e_scalar, atol=1e-10)
+
+    def test_scalar_trailing_shape_unaffected(self):
+        """Zero trailing dims (the OAK call site) still returns a 1D array."""
+        z = jnp.array([2.0, 3.0, 5.0])
+        e = _newton_girard(z, max_order=2)
+        assert e.ndim == 1
+        assert e.shape == (3,)
+
 
 class TestOrthogonalAdditiveKernelInit:
     """Tests for OAK construction."""


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `uv run poe format` before committing.
- [x] I've added tests for new code.
- [x] I've added docstrings for the new code.

## Description

`_newton_girard` (oak.py) and `_newton_girard_matrices` (sobol.py) implemented the identical power-sum/sign/mask/`fori_loop` recursion, differing only by trailing broadcast dims of size 1 — sobol's own docstring already called it "the matrix-level analogue of `_newton_girard` in oak.py". Merges into one broadcast-generic implementation called from both sites. Pure refactor, no behaviour change.

Addresses #683.

## Test plan

- `uv run pytest tests/test_oak.py` — 41 passed
- `uv run poe lint` — clean