### PR TITLE
feat(variational): pathwise (decoupled) sampling for sparse posteriors

### DIFF
--- a/gpjax/conditioning.py
+++ b/gpjax/conditioning.py
@@ -546,6 +546,98 @@ class SparsePosterior(Posterior):
             jitter=model.prior.jitter,
         )
 
+    def sample_approx(
+        self,
+        num_samples: int,
+        key: KeyArray,
+        num_features: int | None = 100,
+    ) -> FunctionalSample:
+        r"""Draw approximate posterior samples via decoupled (pathwise) sampling.
+
+        The sparse analogue of :meth:`ExactPosterior.sample_approx`: a prior
+        draw built from Fourier features of the kernel, plus a canonical
+        correction that pulls the draw onto a draw of the variational
+        distribution :math:`q(u)` at the inducing inputs (Wilson et al., 2020,
+        section 5.2),
+
+        .. math::
+
+            \hat{f}(\cdot) = \hat{f}_{\text{prior}}(\cdot)
+                + K_{\cdot z} K_{zz}^{-1}
+                \big(u - \hat{f}_{\text{prior}}(z)\big),
+                \qquad u \sim q(u).
+
+        Reuses the cached :math:`K_{zz}` Cholesky factor and variational
+        moments; no extra factorisation is performed. For the whitened
+        parameterisation, the draw of :math:`u` is de-whitened through the
+        same cached factor before entering the correction.
+
+        Args:
+            num_samples: The desired number of samples.
+            key: The random seed used for the sample(s).
+            num_features: The number of Fourier features used to approximate
+                the prior component of each sample.
+
+        Returns:
+            FunctionalSample: A function evaluating the sample draws at any
+                inputs; the same draw is returned for all queries.
+        """
+        if (not isinstance(num_samples, int)) or num_samples <= 0:
+            raise ValueError("num_samples must be a positive integer")
+        model = self.model
+        if model.likelihood.num_outputs > 1:
+            raise ValueError(
+                "sample_approx does not support multi-output likelihoods yet."
+            )
+
+        freq_key, weight_key, inducing_key = jr.split(key, 3)
+        prior = model.prior
+        inducing_inputs = self.inducing_inputs
+        cholesky_kzz = self.cholesky_kzz
+        num_inducing = cholesky_kzz.shape[0]
+
+        fourier_feature_fn = _build_fourier_features_fn(prior, num_features, freq_key)
+        fourier_weights = jr.normal(weight_key, [num_samples, 2 * num_features])
+
+        # A draw of q(u) (or, whitened, of q(v)): mu + sqrt @ eps.
+        standard_normal = jr.normal(inducing_key, [num_inducing, num_samples])
+        site_draws = self.variational_mean + jnp.matmul(
+            self.variational_root, standard_normal
+        )
+        if self.whitened:
+            # u = m(z) + Lz v, so u - m(z) = Lz v -- the mean cancels without
+            # ever being added, matching the de-meaned residual below.
+            centred_inducing_draws = jnp.matmul(cholesky_kzz, site_draws)
+        else:
+            centred_inducing_draws = site_draws - prior.mean_function(inducing_inputs)
+
+        # Kzz^{-1}(u - f_prior(z)), with f_prior(z) = m(z) + phi(z)^T w:
+        # the mean cancels, leaving only the deviation phi(z)^T w to subtract.
+        prior_features_z = fourier_feature_fn(inducing_inputs)
+        perturbed_residual = centred_inducing_draws - jnp.inner(
+            prior_features_z, fourier_weights
+        )
+        canonical_weights = jsp.linalg.cho_solve(
+            (cholesky_kzz, True), perturbed_residual
+        )
+
+        def sample_fn(test_inputs: Float[Array, "n D"]) -> Float[Array, "n B"]:
+            fourier_features = fourier_feature_fn(test_inputs)
+            weight_space_contribution = jnp.inner(fourier_features, fourier_weights)
+            canonical_features = prior.kernel.cross_covariance(
+                test_inputs, inducing_inputs
+            )
+            function_space_contribution = jnp.matmul(
+                canonical_features, canonical_weights
+            )
+            return (
+                prior.mean_function(test_inputs)
+                + weight_space_contribution
+                + function_space_contribution
+            )
+
+        return sample_fn
+
 
 class CollapsedPosterior(Posterior):
     r"""The Titsias (2009) collapsed sparse posterior.

--- a/tests/test_conditioning.py
+++ b/tests/test_conditioning.py
@@ -166,6 +166,32 @@ def _nontrivial_moments(num_inducing: int):
     return mean, root
 
 
+def _pathwise_model() -> ConjugateModel:
+    """A conjugate model whose kernel has a well-defined spectral density.
+
+    The pathwise (Fourier-feature) sampler needs `n_dims` fixed on the
+    kernel; an ARD (array-valued) lengthscale does that implicitly, whereas
+    the scalar lengthscale used by `_conjugate_model` leaves it `None`.
+    """
+    prior = gpx.gps.Prior(
+        mean_function=gpx.mean_functions.Constant(jnp.array(0.3)),
+        kernel=gpx.kernels.RBF(lengthscale=jnp.array([0.3]), variance=jnp.array(0.9)),
+    )
+    return prior * gpx.likelihoods.Gaussian(obs_stddev=jnp.array(0.2))
+
+
+def _pathwise_family(family_cls, variational_mean=None, variational_root=None):
+    mean, root = _nontrivial_moments(_NUM_INDUCING)
+    return family_cls(
+        model=_pathwise_model(),
+        inducing_inputs=_inducing_inputs(),
+        variational_mean=mean if variational_mean is None else variational_mean,
+        variational_root_covariance=root
+        if variational_root is None
+        else variational_root,
+    )
+
+
 def _multi_output_model():
     coregionalization = gpx.parameters.CoregionalizationMatrix(
         num_outputs=2, rank=1, key=jr.key(3)
@@ -637,6 +663,111 @@ def test_sample_approx_still_draws_for_a_single_output_posterior():
 
     assert draws.shape == (_NUM_TEST, 3)
     assert bool(jnp.all(jnp.isfinite(draws)))
+
+
+# ---------------------------------------------------------------------------
+# 3b. sample_approx on SparsePosterior (decoupled / Matheron sampling, #673)
+# ---------------------------------------------------------------------------
+
+_PATHWISE_FAMILIES = [VariationalGaussian, WhitenedVariationalGaussian]
+
+
+@pytest.mark.parametrize("family_cls", _PATHWISE_FAMILIES)
+def test_sparse_sample_approx_matches_the_analytic_predictive(family_cls):
+    """Monte-Carlo mean/covariance of the decoupled sampler must reproduce the
+    sparse posterior's closed-form predictive moments, for both the
+    unwhitened and whitened parameterisations."""
+    posterior = _pathwise_family(family_cls).condition(_regression_data())
+    grid = jnp.linspace(-0.2, 1.2, 8).reshape(-1, 1)
+
+    sample_fn = posterior.sample_approx(6000, jr.key(0), num_features=500)
+    draws = sample_fn(grid)  # [8, 6000]
+
+    empirical_mean = jnp.mean(draws, axis=-1)
+    empirical_cov = jnp.cov(draws)
+
+    exact = posterior(grid, covariance="dense")
+    np.testing.assert_allclose(
+        np.asarray(empirical_mean), np.asarray(exact.mean), atol=0.06
+    )
+
+    exact_cov = np.asarray(exact.covariance())
+    rel_frobenius = np.linalg.norm(
+        np.asarray(empirical_cov) - exact_cov
+    ) / np.linalg.norm(exact_cov)
+    assert rel_frobenius < 0.15
+
+
+@pytest.mark.parametrize("family_cls", _PATHWISE_FAMILIES)
+def test_sparse_sample_approx_is_deterministic_and_finite(family_cls):
+    posterior = _pathwise_family(family_cls).condition(_regression_data())
+    grid = _test_inputs()
+
+    draws_a = posterior.sample_approx(4, jr.key(1), num_features=32)(grid)
+    draws_b = posterior.sample_approx(4, jr.key(1), num_features=32)(grid)
+    draws_c = posterior.sample_approx(4, jr.key(2), num_features=32)(grid)
+
+    np.testing.assert_array_equal(np.asarray(draws_a), np.asarray(draws_b))
+    assert not bool(jnp.allclose(draws_a, draws_c))
+    assert draws_a.shape == (_NUM_TEST, 4)
+    assert bool(jnp.all(jnp.isfinite(draws_a)))
+
+
+def test_sparse_sample_approx_is_jittable():
+    grid = _test_inputs()
+
+    def draw(conditionable, train_data, key):
+        posterior = conditionable.condition(train_data)
+        return posterior.sample_approx(4, key, num_features=32)(grid)
+
+    family, data, key = (
+        _pathwise_family(VariationalGaussian),
+        _regression_data(),
+        jr.key(5),
+    )
+    eager = draw(family, data, key)
+    compiled = jax.jit(draw)(family, data, key)
+
+    np.testing.assert_allclose(
+        np.asarray(compiled), np.asarray(eager), rtol=1e-10, atol=1e-12
+    )
+
+
+def test_sparse_sample_approx_is_differentiable_in_the_variational_mean():
+    """Gradients must flow from the sampled functions back to q(u)'s mean."""
+    grid = _test_inputs()
+    key = jr.key(9)
+    _, root = _nontrivial_moments(_NUM_INDUCING)
+
+    def summed_draws(variational_mean):
+        posterior = _pathwise_family(
+            VariationalGaussian,
+            variational_mean=variational_mean,
+            variational_root=root,
+        ).condition(_regression_data())
+        return jnp.sum(posterior.sample_approx(3, key, num_features=32)(grid))
+
+    mean0, _ = _nontrivial_moments(_NUM_INDUCING)
+    gradient = jax.grad(summed_draws)(mean0)
+
+    assert gradient.shape == mean0.shape
+    assert bool(jnp.all(jnp.isfinite(gradient)))
+    assert bool(jnp.any(gradient != 0.0))
+
+
+def test_sparse_sample_approx_vmaps_over_keys():
+    posterior = _pathwise_family(VariationalGaussian).condition(_regression_data())
+    grid = _test_inputs()
+    keys = jr.split(jr.key(11), 4)
+
+    batched = jax.vmap(lambda k: posterior.sample_approx(3, k, num_features=32)(grid))(
+        keys
+    )
+
+    assert batched.shape == (4, _NUM_TEST, 3)
+    assert bool(jnp.all(jnp.isfinite(batched)))
+    # Independent keys must give independent draws, not a broadcast repeat.
+    assert not bool(jnp.allclose(batched[0], batched[1]))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `uv run poe format` before committing.
- [x] I've added tests for new code.
- [x] I've added docstrings for the new code.

## Description

Pathwise/Matheron `sample_approx` existed only on `Prior`/`ExactPosterior` (the `ConjugateModel` conditioning target) — not on `SparsePosterior`, the conditioning target of `VariationalGaussian`/`WhitenedVariationalGaussian`/`DualVariationalGaussian`/`GraphVariationalGaussian`. ADR-0001 documents this as an open follow-up, not a deliberate exclusion.

Adds `sample_approx` to `SparsePosterior` via the Wilson et al. (2020, §5.2) decoupled sampler: a prior sample via the existing `_build_fourier_features_fn` machinery, plus the u-conditioned canonical correction `Kzz⁻¹(u − Φ_z θ)`, reusing the posterior's already-cached Cholesky factor (no extra factorisation). Caught and fixed a real bug during TDD: the inducing-point draw needs de-meaning (`u − m(z)`) before the correction, mirroring `ExactPosterior`'s cached residual — missing this produced a systematic offset in the Monte Carlo mean check.

Addresses #673.

## Test plan

- `uv run pytest tests/test_conditioning.py tests/test_variational_families.py tests/test_gps.py` — 445 passed
- 7 new tests: Monte Carlo mean/covariance agreement, determinism, jit/grad/vmap-compatibility
- `uv run poe lint` — clean