### PR TITLE
feat(likelihoods): add StudentT likelihood for robust regression

### DIFF
--- a/docs/reference/likelihoods.md
+++ b/docs/reference/likelihoods.md
@@ -19,5 +19,6 @@
    NonGaussian
    Poisson
    SoftplusTransform
+   StudentT
    inv_probit
 ```

--- a/gpjax/likelihoods.py
+++ b/gpjax/likelihoods.py
@@ -35,6 +35,7 @@ from gpjax.integrators import (
 )
 from gpjax.parameters import (
     NonNegativeReal,
+    PositiveReal,
     _val,
 )
 from gpjax.summary import _SummaryMixin
@@ -588,6 +589,90 @@ class Poisson(AbstractLikelihood):
         return self.link_function(dist.mean)
 
 
+class StudentT(AbstractLikelihood):
+    r"""Student's t likelihood object for robust regression.
+
+    Replaces the Gaussian likelihood's light-tailed noise model with a
+    heavy-tailed Student's t distribution, so that outlying observations pull
+    the posterior mean less strongly (Jylanki, Vanhatalo & Vehtari, 2011).
+    Since the Student's t distribution is not conjugate to a Gaussian prior,
+    the expected log likelihood has no closed form and is instead computed by
+    Gauss-Hermite quadrature via `GHQuadratureIntegrator`.
+    """
+
+    degrees_of_freedom: tp.Any
+    scale: tp.Any
+
+    def __init__(
+        self,
+        degrees_of_freedom: tp.Union[ScalarFloat, PositiveReal] = 4.0,
+        scale: tp.Union[ScalarFloat, PositiveReal] = 1.0,
+        integrator: AbstractIntegrator = GHQuadratureIntegrator(num_points=20),
+    ):
+        r"""Initializes the Student's t likelihood.
+
+        Args:
+            degrees_of_freedom (Union[ScalarFloat, PositiveReal]): the degrees
+                of freedom of the Student's t distribution. Lower values give
+                heavier tails and hence more robustness to outliers; as the
+                degrees of freedom grow large the distribution approaches a
+                Gaussian.
+            scale (Union[ScalarFloat, PositiveReal]): the scale of the
+                Student's t observation noise. Note this is not the
+                observation standard deviation: for `degrees_of_freedom > 2`
+                the variance is `scale**2 * degrees_of_freedom /
+                (degrees_of_freedom - 2)`.
+            integrator (AbstractIntegrator): The integrator to be used for computing expected log
+                likelihoods. Must be an instance of `AbstractIntegrator`. Defaults to the
+                `GHQuadratureIntegrator`, as the Student's t expected log likelihood has no
+                closed form.
+        """
+        if not isinstance(degrees_of_freedom, PositiveReal):
+            degrees_of_freedom = PositiveReal(jnp.asarray(degrees_of_freedom))
+        self.degrees_of_freedom = degrees_of_freedom
+
+        if not isinstance(scale, PositiveReal):
+            scale = PositiveReal(jnp.asarray(scale))
+        self.scale = scale
+
+        super().__init__(integrator)
+
+    def link_function(self, f: Float[Array, ...]) -> npd.StudentT:
+        r"""The link function of the Student's t likelihood.
+
+        Args:
+            f (Float[Array, "..."]): Function values.
+
+        Returns:
+            npd.StudentT: The likelihood function.
+        """
+        return npd.StudentT(
+            df=_val(self.degrees_of_freedom),
+            loc=f,
+            scale=_val(self.scale).astype(f.dtype),
+        )
+
+    def predict(
+        self, dist: tp.Union[npd.MultivariateNormal, GaussianDistribution]
+    ) -> npd.StudentT:
+        r"""Evaluate the pointwise predictive distribution.
+
+        Evaluate the pointwise predictive distribution, given a Gaussian
+        process posterior and likelihood parameters. As with `Poisson`, the
+        Student's t distribution is not conjugate to a Gaussian latent, so
+        this evaluates the link function at the posterior mean rather than
+        marginalising the latent uncertainty.
+
+        Args:
+            dist (tp.Union[npd.MultivariateNormal, GaussianDistribution]): The Gaussian
+                process posterior, evaluated at a finite set of test points.
+
+        Returns:
+            npd.StudentT: The pointwise predictive distribution.
+        """
+        return self.link_function(dist.mean)
+
+
 def inv_probit(x: Float[Array, " *N"]) -> Float[Array, " *N"]:
     r"""Compute the inverse probit function.
 
@@ -601,7 +686,7 @@ def inv_probit(x: Float[Array, " *N"]) -> Float[Array, " *N"]:
     return 0.5 * (1.0 + jsp.special.erf(x / jnp.sqrt(2.0))) * (1 - 2 * jitter) + jitter
 
 
-NonGaussian = tp.Union[Poisson, Bernoulli]
+NonGaussian = tp.Union[Poisson, Bernoulli, StudentT]
 
 __all__ = [
     "AbstractHeteroscedasticLikelihood",
@@ -616,5 +701,6 @@ __all__ = [
     "NonGaussian",
     "Poisson",
     "SoftplusTransform",
+    "StudentT",
     "inv_probit",
 ]

--- a/tests/test_gps.py
+++ b/tests/test_gps.py
@@ -42,6 +42,7 @@ from gpjax.likelihoods import (
     Bernoulli,
     Gaussian,
     Poisson,
+    StudentT,
 )
 from gpjax.mean_functions import (
     AbstractMeanFunction,
@@ -342,7 +343,38 @@ def test_nonconjugate_posterior(
 
 
 @pytest.mark.filterwarnings("ignore:A JAX array is being set as static:UserWarning")
-@pytest.mark.parametrize("likelihood", [Bernoulli, Gaussian])
+@pytest.mark.parametrize("num_datapoints", [1, 10])
+@pytest.mark.parametrize("num_test_datapoints", [1, 10, 200])
+def test_nonconjugate_posterior_studentt(
+    num_datapoints: int,
+    num_test_datapoints: int,
+) -> None:
+    # Create a dataset of continuous, real-valued observations (as StudentT,
+    # unlike Bernoulli/Poisson, models a real-valued robust-regression target).
+    key = jr.key(123)
+    x = jr.uniform(key=key, minval=-2.0, maxval=2.0, shape=(num_datapoints, 1))
+    y = jnp.sin(x) + jr.normal(key=key, shape=x.shape) * 0.1
+    D = Dataset(X=x, y=y)
+
+    prior = Prior(mean_function=Zero(), kernel=RBF())
+    likelihood = StudentT()
+
+    posterior = NonConjugateModel(prior=prior, likelihood=likelihood)
+    posterior = posterior.init_latent(num_datapoints)
+    assert isinstance(posterior, NonConjugateModel)
+
+    inputs = jnp.linspace(-3.0, 3.0, num_test_datapoints).reshape(-1, 1)
+    marginal_distribution = posterior(inputs, D)
+
+    assert isinstance(marginal_distribution, GaussianDistribution)
+    mu = marginal_distribution.mean
+    sigma = marginal_distribution.covariance()
+    assert mu.shape == (num_test_datapoints,)
+    assert sigma.shape == (num_test_datapoints, num_test_datapoints)
+
+
+@pytest.mark.filterwarnings("ignore:A JAX array is being set as static:UserWarning")
+@pytest.mark.parametrize("likelihood", [Bernoulli, Gaussian, StudentT])
 @pytest.mark.parametrize("num_datapoints", [1, 10])
 @pytest.mark.parametrize("kernel", [RBF, Matern52])
 @pytest.mark.parametrize("mean_function", [Zero, Constant])
@@ -373,8 +405,9 @@ def test_posterior_construct(
     if isinstance(likelihood, Gaussian):
         assert isinstance(posterior_mul, ConjugateModel)
 
-    # If the likelihood is Bernoulli or Poisson, then the posterior should be non-conjugate.
-    if isinstance(likelihood, (Bernoulli, Poisson)):
+    # If the likelihood is Bernoulli, Poisson, or StudentT, then the posterior
+    # should be non-conjugate.
+    if isinstance(likelihood, (Bernoulli, Poisson, StudentT)):
         assert isinstance(posterior_mul, NonConjugateModel)
 
 

--- a/tests/test_likelihoods.py
+++ b/tests/test_likelihoods.py
@@ -20,6 +20,7 @@ from gpjax.likelihoods import (
     Bernoulli,
     Gaussian,
     Poisson,
+    StudentT,
     inv_probit,
 )
 from jax import config
@@ -104,6 +105,36 @@ def test_poisson_likelihood(n: int):
     # Check predictive mean and variance.
     rate = jnp.exp(latent_mean)
     assert (pred_dist.mean == rate).all()
+
+
+@pytest.mark.parametrize("n", [1, 2, 10])
+@pytest.mark.parametrize("degrees_of_freedom", [2.5, 4.0, 30.0])
+def test_studentt_likelihood(n: int, degrees_of_freedom: float):
+    x = jnp.linspace(-3.0, 3.0).reshape(-1, 1)
+    likelihood = StudentT(degrees_of_freedom=degrees_of_freedom)
+
+    assert isinstance(likelihood.link_function, Callable)
+    assert isinstance(likelihood.link_function(x), npd.StudentT)
+    assert jnp.allclose(likelihood.degrees_of_freedom.unwrap(), degrees_of_freedom)
+    assert jnp.allclose(likelihood.scale.unwrap(), 1.0)
+
+    # Construct latent function distribution.
+    latent_dist, latent_mean, _latent_cov = _compute_latent_dist(n)
+    pred_dist = likelihood(latent_dist)
+    assert isinstance(pred_dist, npd.StudentT)
+
+    # Check predictive mean matches the latent mean, pushed through the link.
+    assert (pred_dist.mean == latent_mean).all()
+
+
+def test_studentt_likelihood_scale():
+    likelihood = StudentT(degrees_of_freedom=3.0, scale=0.5)
+    assert jnp.allclose(likelihood.degrees_of_freedom.unwrap(), 3.0)
+    assert jnp.allclose(likelihood.scale.unwrap(), 0.5)
+
+    f = jnp.zeros((5,))
+    dist = likelihood.link_function(f)
+    assert jnp.allclose(dist.scale, 0.5)
 
 
 class TestMultiOutputGaussian:

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -187,6 +187,49 @@ def test_non_conjugate_mll(n_points, n_dims, key_val):
     _ = loss_grad(params)
 
 
+@pytest.mark.parametrize("n_points", [1, 2, 10])
+@pytest.mark.parametrize("n_dims", [1, 2, 3])
+@pytest.mark.parametrize("key_val", [123, 42])
+def test_non_conjugate_mll_studentt(n_points, n_dims, key_val):
+    key = jr.key(key_val)
+    D = build_data(n_points, n_dims, key, binary=False)
+
+    # Build model
+    p = gpx.gps.Prior(
+        kernel=gpx.kernels.RBF(active_dims=list(range(n_dims))),
+        mean_function=gpx.mean_functions.Constant(),
+    )
+    likelihood = gpx.likelihoods.StudentT()
+    post = (p * likelihood).init_latent(D.n)
+
+    # test simple call
+    res_simple = -non_conjugate_mll(post, D)
+    assert isinstance(res_simple, jax.Array)
+    assert res_simple.shape == ()
+
+    # test call wrapped in loss function
+    params, static = eqx.partition(post, eqx.is_array)
+
+    def loss(params):
+        posterior = paramax.unwrap(eqx.combine(params, static))
+        return -non_conjugate_mll(posterior, D)
+
+    res_wrapped = loss(params)
+    assert jnp.allclose(res_simple, res_wrapped)
+
+    # test loss with jit
+    loss_jit = jax.jit(loss)
+    res_jit = loss_jit(params)
+    assert jnp.allclose(res_simple, res_jit)
+
+    # test loss with grad
+    loss_grad = jax.grad(loss)
+    grads = loss_grad(params)
+    # Gradient should flow to the degrees-of-freedom parameter too.
+    dof_grad = grads.likelihood.degrees_of_freedom._unconstrained
+    assert jnp.isfinite(dof_grad).all()
+
+
 @pytest.mark.parametrize("n_points", [10, 20])
 @pytest.mark.parametrize("n_dims", [1, 2, 3])
 @pytest.mark.parametrize("key_val", [123, 42])


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `uv run poe format` before committing.
- [x] I've added tests for new code.
- [x] I've added docstrings for the new code.

## Description

Adds a heavy-tailed Student's t observation likelihood (Jylänki, Vanhatalo & Vehtari 2011) following the existing `Bernoulli`/`Poisson` pattern: `GHQuadratureIntegrator(20)` for the expected log-likelihood, since the Student's t is not conjugate to a Gaussian latent. `degrees_of_freedom` and `scale` are both `PositiveReal`-wrapped; matches this codebase's "pure conditional" likelihood contract (no `num_datapoints`).

Addresses #671.

## Test plan

- `uv run pytest tests/test_likelihoods.py tests/test_gps.py tests/test_objectives.py` — 355 passed
- `uv run poe lint` — clean