### PR TITLE
feat(state-space): support quasi-periodic Periodic x Matern product SDEs

### DIFF
--- a/gpjax/state_space/kernels.py
+++ b/gpjax/state_space/kernels.py
@@ -23,9 +23,12 @@ from gpjax.state_space.sde import (
     Matern12SDE,
     Matern32SDE,
     Matern52SDE,
+    ProductSDE,
     SumSDE,
     TruncatedPeriodicSDE,
 )
+
+_STATIONARY_MATERN_KERNELS = (Matern12, Matern32, Matern52)
 
 
 class TruncatedPeriodic(StationaryKernel):
@@ -166,10 +169,37 @@ def _to_sde_periodic(kernel: Periodic) -> LinearSDE:
     )
 
 
+def _find_quasi_periodic_factors(
+    kernels: tuple,
+) -> tuple[TruncatedPeriodic, StationaryKernel] | None:
+    """Return ``(periodic_factor, matern_factor)`` if ``kernels`` is exactly a
+    ``TruncatedPeriodic`` and a stationary Matérn factor, else ``None``.
+    """
+    if len(kernels) != 2:
+        return None
+    periodic_factor, matern_factor = None, None
+    for factor in kernels:
+        if isinstance(factor, TruncatedPeriodic):
+            periodic_factor = factor
+        elif isinstance(factor, _STATIONARY_MATERN_KERNELS):
+            matern_factor = factor
+    if periodic_factor is None or matern_factor is None:
+        return None
+    return periodic_factor, matern_factor
+
+
 @to_sde.register
 def _to_sde_product_kernel(kernel: ProductKernel) -> LinearSDE:
+    quasi_periodic_factors = _find_quasi_periodic_factors(kernel.kernels)
+    if quasi_periodic_factors is not None:
+        periodic_factor, matern_factor = quasi_periodic_factors
+        return ProductSDE(components=(to_sde(periodic_factor), to_sde(matern_factor)))
     raise NotImplementedError(
-        "ProductKernel state-space conversion is not supported in v1: state dimension "
-        "blows up Kronecker-style as the product of component state dimensions, which "
-        "defeats the O(N · d³) advantage of the state-space approach."
+        "ProductKernel state-space conversion is only supported for the "
+        "quasi-periodic TruncatedPeriodic x {Matern12, Matern32, Matern52} case "
+        "(Solin & Sarkka 2014 sec. 3), whose Kronecker state dimension is "
+        "(2K+1)*d. Generic ProductKernel conversion is not supported in v1: state "
+        "dimension blows up Kronecker-style as the product of component state "
+        "dimensions, which defeats the O(N · d³) advantage of the state-space "
+        "approach."
     )

--- a/gpjax/state_space/sde.py
+++ b/gpjax/state_space/sde.py
@@ -374,6 +374,89 @@ class TruncatedPeriodicSDE(LinearSDE):
         return A, L_Q
 
 
+class ProductSDE(LinearSDE):
+    """Kronecker state-space representation of TruncatedPeriodic × stationary-Matérn.
+
+    For independent processes ``f_p ~ GP(0, k_p)`` (periodic) and
+    ``f_m ~ GP(0, k_m)`` (Matérn), the product process
+    ``f(t) = f_p(t) f_m(t)`` has covariance ``k_p(τ) k_m(τ)`` and an exact
+    finite-dimensional state-space realisation on the Kronecker-product state
+    ``x(t) = x_p(t) ⊗ x_m(t)`` (Solin & Särkkä 2014 §3):
+
+        F = F_p ⊗ I_m + I_p ⊗ F_m
+        L = S_p ⊗ L_m     (the periodic factor's own diffusion L_p is zero)
+        Qc = I_p ⊗ Qc_m
+        H = H_p ⊗ H_m
+        P_∞ = P_∞,p ⊗ P_∞,m   (sqrt: S = S_p ⊗ S_m)
+
+    where ``S_p``, ``S_m`` are the factors' ``stationary_state_cov_sqrt``.
+    This relies on ``TruncatedPeriodicSDE`` having zero own diffusion (its
+    transition is an exact rotation per harmonic, so its own discrete
+    process noise is exactly zero — see ``test_truncated_periodic_L_Q_is_zero``);
+    ``components`` must therefore be ``(periodic_factor, matern_factor)`` in
+    that order. This ordering is enforced by ``to_sde``'s ``ProductKernel``
+    dispatch, the only production caller.
+
+    The state dimension is the *product* of the two factor state
+    dimensions, so this is only used where both factors have small state
+    dimension — e.g. ``TruncatedPeriodic`` × Matérn, whose state dimension
+    is ``(2K + 1) · d`` (Solin & Särkkä 2014 §3.2) — not for arbitrary
+    products, which is why ``to_sde`` gates which kernel pairs reach here.
+
+    ``discretise`` avoids ever forming or eigendecomposing the full
+    ``state_dim × state_dim`` stationary covariance. Two exact identities
+    let it reuse each factor's own closed-form ``discretise`` instead:
+    ``A(Δt) = expm(F Δt) = A_p(Δt) ⊗ A_m(Δt)``, since ``F_p ⊗ I_m`` and
+    ``I_p ⊗ F_m`` commute; and, because the periodic factor is lossless
+    (``A_p(t) P_∞,p A_p(t)ᵀ = P_∞,p`` for all ``t``), the discrete process
+    noise factorises as ``Q(Δt) = P_∞,p ⊗ Q_m(Δt)`` with square root
+    ``L_Q(Δt) = S_p ⊗ L_Q,m(Δt)``. A generic eigendecomposition-based square
+    root of ``P_∞ − A P_∞ Aᵀ`` (as used by the Matérn SDEs) is deliberately
+    avoided here: the periodic factor's per-harmonic eigenvalues repeat in
+    pairs (cos/sin components share variance), which makes the combined
+    stationary covariance's spectrum degenerate and ``jnp.linalg.eigh``'s
+    reverse-mode gradient singular there.
+    """
+
+    components: tuple[LinearSDE, LinearSDE]
+
+    def __init__(self, components: tuple[LinearSDE, LinearSDE]):
+        periodic_factor, matern_factor = components
+        self.components = (periodic_factor, matern_factor)
+
+        eye_periodic = jnp.eye(periodic_factor.state_dim)
+        eye_matern = jnp.eye(matern_factor.state_dim)
+        stationary_cov_sqrt_periodic = periodic_factor.stationary_state_cov_sqrt
+        stationary_cov_sqrt_matern = matern_factor.stationary_state_cov_sqrt
+
+        F = jnp.kron(periodic_factor.drift_matrix, eye_matern) + jnp.kron(
+            eye_periodic, matern_factor.drift_matrix
+        )
+        L = jnp.kron(stationary_cov_sqrt_periodic, matern_factor.diffusion_matrix)
+        Qc = jnp.kron(eye_periodic, matern_factor.process_noise_spectral_density)
+        H = jnp.kron(
+            periodic_factor.observation_matrix, matern_factor.observation_matrix
+        )
+        L_inf = jnp.kron(stationary_cov_sqrt_periodic, stationary_cov_sqrt_matern)
+
+        super().__init__(
+            drift_matrix=F,
+            diffusion_matrix=L,
+            process_noise_spectral_density=Qc,
+            observation_matrix=H,
+            stationary_state_cov_sqrt=L_inf,
+            state_dim=periodic_factor.state_dim * matern_factor.state_dim,
+        )
+
+    def discretise(self, time_step):
+        periodic_factor, matern_factor = self.components
+        A_periodic, _ = periodic_factor.discretise(time_step)
+        A_matern, L_Q_matern = matern_factor.discretise(time_step)
+        A = jnp.kron(A_periodic, A_matern)
+        L_Q = jnp.kron(periodic_factor.stationary_state_cov_sqrt, L_Q_matern)
+        return A, L_Q
+
+
 class SumSDE(LinearSDE):
     """Block-diagonal sum of LinearSDE components.
 

--- a/tests/test_state_space/test_kernels.py
+++ b/tests/test_state_space/test_kernels.py
@@ -6,6 +6,7 @@ from gpjax.state_space.sde import (
     Matern12SDE,
     Matern32SDE,
     Matern52SDE,
+    ProductSDE,
     SumSDE,
     TruncatedPeriodicSDE,
 )
@@ -143,3 +144,96 @@ def test_to_sde_rejects_product_kernel_with_kronecker_blowup_message():
     )
     with pytest.raises(NotImplementedError, match=r"Kronecker|product|state space"):
         to_sde(kernel)
+
+
+@pytest.mark.parametrize(
+    "kernel_factory,error_match",
+    [
+        (
+            # Three-factor product: genuinely unsupported even though a
+            # TruncatedPeriodic x Matern32 pair is embedded within it.
+            lambda: gpx.kernels.Matern32(lengthscale=1.0, variance=1.0)
+            * TruncatedPeriodic(lengthscale=0.5, variance=1.0, period=1.0)
+            * gpx.kernels.Matern12(lengthscale=1.0, variance=1.0),
+            r"Kronecker|product|state space",
+        ),
+        (
+            # Two periodics, no Matern factor.
+            lambda: TruncatedPeriodic(lengthscale=0.5, variance=1.0, period=1.0)
+            * TruncatedPeriodic(lengthscale=0.3, variance=1.0, period=2.0),
+            r"Kronecker|product|state space",
+        ),
+        (
+            # Non-truncated Periodic x Matern: the periodic factor itself has
+            # no finite-dimensional state-space representation.
+            lambda: gpx.kernels.Periodic(lengthscale=1.0, variance=1.0)
+            * gpx.kernels.Matern32(lengthscale=1.0, variance=1.0),
+            r"Kronecker|product|state space",
+        ),
+    ],
+)
+def test_to_sde_rejects_genuinely_unsupported_product_kernels(
+    kernel_factory, error_match
+):
+    kernel = kernel_factory()
+    with pytest.raises(NotImplementedError, match=error_match):
+        to_sde(kernel)
+
+
+@pytest.mark.parametrize(
+    "matern_cls,matern_sde_cls,matern_state_dim",
+    [
+        (gpx.kernels.Matern12, Matern12SDE, 1),
+        (gpx.kernels.Matern32, Matern32SDE, 2),
+        (gpx.kernels.Matern52, Matern52SDE, 3),
+    ],
+)
+@pytest.mark.parametrize("truncation_order", [1, 4])
+def test_to_sde_periodic_times_matern_returns_product_sde_with_expected_state_dim(
+    matern_cls, matern_sde_cls, matern_state_dim, truncation_order
+):
+    periodic_kernel = TruncatedPeriodic(
+        lengthscale=0.5, variance=1.3, period=1.5, truncation_order=truncation_order
+    )
+    matern_kernel = matern_cls(lengthscale=2.0, variance=0.7)
+
+    for kernel in (periodic_kernel * matern_kernel, matern_kernel * periodic_kernel):
+        sde = to_sde(kernel)
+        assert isinstance(sde, ProductSDE)
+        periodic_state_dim = 1 + 2 * truncation_order
+        assert sde.state_dim == periodic_state_dim * matern_state_dim
+        factor_types = {type(component) for component in sde.components}
+        assert factor_types == {TruncatedPeriodicSDE, matern_sde_cls}
+
+
+def test_to_sde_periodic_times_matern_kernel_value_matches_dense_product():
+    lengthscale_periodic, variance_periodic, period, K = 0.5, 1.3, 1.5, 5
+    lengthscale_matern, variance_matern = 2.0, 0.7
+
+    periodic_kernel = TruncatedPeriodic(
+        lengthscale=lengthscale_periodic,
+        variance=variance_periodic,
+        period=period,
+        truncation_order=K,
+    )
+    matern_kernel = gpx.kernels.Matern32(
+        lengthscale=lengthscale_matern, variance=variance_matern
+    )
+    product_kernel = periodic_kernel * matern_kernel
+    sde = to_sde(product_kernel)
+
+    for tau in (0.0, 0.1, 0.37, 1.0, 2.5):
+        H = np.asarray(sde.observation_matrix)
+        A, _ = sde.discretise(jnp.asarray(tau))
+        P_inf = np.asarray(
+            sde.stationary_state_cov_sqrt @ sde.stationary_state_cov_sqrt.T
+        )
+        # k(τ) = H A(τ) P_∞ Hᵀ for a stationary LTI state-space GP.
+        sde_kernel_value = (H @ np.asarray(A) @ P_inf @ H.T)[0, 0]
+
+        dense_kernel_value = product_kernel(jnp.array([tau]), jnp.array([0.0]))
+        expected = periodic_kernel(jnp.array([tau]), jnp.array([0.0])) * matern_kernel(
+            jnp.array([tau]), jnp.array([0.0])
+        )
+        np.testing.assert_allclose(dense_kernel_value, expected, atol=1e-10)
+        np.testing.assert_allclose(sde_kernel_value, expected, atol=1e-8)

--- a/tests/test_state_space/test_prediction.py
+++ b/tests/test_state_space/test_prediction.py
@@ -3,8 +3,10 @@
 import gpjax as gpx
 from gpjax.distributions import GaussianDistribution
 from gpjax.state_space.gps import StateSpacePrior
+from gpjax.state_space.kernels import TruncatedPeriodic
 from gpjax.state_space.prediction import _merge_grids
 import jax.numpy as jnp
+import jax.random as jr
 import lineax as lx
 import numpy as np
 import pytest
@@ -141,6 +143,79 @@ def test_state_space_posterior_predict_smoothed_matches_dense_gp(kernel_class, j
 
     np.testing.assert_allclose(ss_means, dense_means, atol=1e-5, rtol=1e-6)
     np.testing.assert_allclose(ss_variances, dense_variances, atol=1e-5, rtol=1e-6)
+
+
+def _build_quasi_periodic_dataset(
+    kernel, n=25, obs_stddev=0.2, minval=0.0, maxval=10.0, seed=0
+):
+    """Sample a small 1-D dataset from a dense quasi-periodic kernel."""
+    key = jr.key(seed)
+    key_x, key_eps = jr.split(key)
+    X = jnp.sort(jr.uniform(key_x, shape=(n,), minval=minval, maxval=maxval))
+    K = kernel.gram(X.reshape(-1, 1)).as_matrix()
+    L = jnp.linalg.cholesky(K + 1e-9 * jnp.eye(n))
+    y = L @ jr.normal(key_eps, shape=(n,)) + obs_stddev * jr.normal(
+        jr.fold_in(key_eps, 1), shape=(n,)
+    )
+    return X, y
+
+
+@pytest.mark.parametrize(
+    "matern_class",
+    [gpx.kernels.Matern12, gpx.kernels.Matern32, gpx.kernels.Matern52],
+)
+def test_state_space_posterior_predict_smoothed_matches_dense_gp_for_quasi_periodic_product(
+    matern_class,
+):
+    """The TruncatedPeriodic x Matern product SDE must match a dense-kernel GP."""
+    periodic_lengthscale, periodic_variance, period, truncation_order = (
+        0.6,
+        1.0,
+        2.0,
+        6,
+    )
+    matern_lengthscale, matern_variance = 3.0, 0.7
+    obs_stddev = 0.15
+    n_train = 30
+    n_test = 12
+
+    product_kernel = TruncatedPeriodic(
+        lengthscale=periodic_lengthscale,
+        variance=periodic_variance,
+        period=period,
+        truncation_order=truncation_order,
+    ) * matern_class(lengthscale=matern_lengthscale, variance=matern_variance)
+
+    X_train, y_train = _build_quasi_periodic_dataset(
+        product_kernel, n=n_train, obs_stddev=obs_stddev
+    )
+    Xtest = jnp.linspace(-0.5, 10.5, n_test).reshape(-1, 1)
+
+    ss_prior = StateSpacePrior(
+        mean_function=gpx.mean_functions.Zero(),
+        kernel=product_kernel,
+    )
+    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n_train, obs_stddev=obs_stddev)
+    ss_posterior = ss_prior * likelihood
+    train_data = gpx.Dataset(X=X_train.reshape(-1, 1), y=y_train.reshape(-1, 1))
+
+    ss_dist = ss_posterior.predict(Xtest, train_data)
+    ss_means = np.asarray(ss_dist.mean)
+    ss_variances = np.asarray(ss_dist.variance)
+
+    dense_prior = gpx.gps.Prior(
+        mean_function=gpx.mean_functions.Zero(),
+        kernel=product_kernel,
+    )
+    dense_posterior = dense_prior * likelihood
+    dense_dist = dense_posterior.predict(
+        Xtest, train_data, return_covariance_type="diagonal"
+    )
+    dense_means = np.asarray(dense_dist.mean)
+    dense_variances = np.asarray(dense_dist.variance)
+
+    np.testing.assert_allclose(ss_means, dense_means, atol=1e-4, rtol=1e-5)
+    np.testing.assert_allclose(ss_variances, dense_variances, atol=1e-4, rtol=1e-5)
 
 
 def test_state_space_posterior_predict_smoothed_returns_diagonal_distribution():

--- a/tests/test_state_space/test_prediction.py
+++ b/tests/test_state_space/test_prediction.py
@@ -195,7 +195,7 @@ def test_state_space_posterior_predict_smoothed_matches_dense_gp_for_quasi_perio
         mean_function=gpx.mean_functions.Zero(),
         kernel=product_kernel,
     )
-    likelihood = gpx.likelihoods.Gaussian(num_datapoints=n_train, obs_stddev=obs_stddev)
+    likelihood = gpx.likelihoods.Gaussian(obs_stddev=obs_stddev)
     ss_posterior = ss_prior * likelihood
     train_data = gpx.Dataset(X=X_train.reshape(-1, 1), y=y_train.reshape(-1, 1))
 
@@ -208,9 +208,7 @@ def test_state_space_posterior_predict_smoothed_matches_dense_gp_for_quasi_perio
         kernel=product_kernel,
     )
     dense_posterior = dense_prior * likelihood
-    dense_dist = dense_posterior.predict(
-        Xtest, train_data, return_covariance_type="diagonal"
-    )
+    dense_dist = dense_posterior.predict(Xtest, train_data, covariance="diagonal")
     dense_means = np.asarray(dense_dist.mean)
     dense_variances = np.asarray(dense_dist.variance)
 

--- a/tests/test_state_space/test_sde.py
+++ b/tests/test_state_space/test_sde.py
@@ -9,6 +9,7 @@ from gpjax.state_space.sde import (
     Matern12SDE,
     Matern32SDE,
     Matern52SDE,
+    ProductSDE,
     SumSDE,
     TruncatedPeriodicSDE,
 )
@@ -429,3 +430,157 @@ def test_continuous_lyapunov_stationarity(sde_name):
         + diffusion @ spectral_density @ diffusion.T
     )
     assert jnp.allclose(residual, 0.0, atol=1e-9)
+
+
+# --- ProductSDE (quasi-periodic TruncatedPeriodic x Matern) -----------------
+
+
+@pytest.mark.parametrize(
+    "matern_cls,matern_state_dim",
+    [(Matern12SDE, 1), (Matern32SDE, 2), (Matern52SDE, 3)],
+)
+@pytest.mark.parametrize("truncation_order", [1, 3])
+def test_product_sde_state_dim_is_product_of_component_state_dims(
+    matern_cls, matern_state_dim, truncation_order
+):
+    periodic = TruncatedPeriodicSDE(
+        lengthscale=0.6, variance=1.1, period=1.5, truncation_order=truncation_order
+    )
+    matern = matern_cls(lengthscale=1.2, variance=0.8)
+    product = ProductSDE(components=(periodic, matern))
+    expected_state_dim = (1 + 2 * truncation_order) * matern_state_dim
+    assert product.state_dim == expected_state_dim
+    assert product.drift_matrix.shape == (expected_state_dim, expected_state_dim)
+    assert product.observation_matrix.shape == (1, expected_state_dim)
+
+
+@pytest.mark.parametrize("matern_cls", [Matern12SDE, Matern32SDE, Matern52SDE])
+def test_product_sde_lyapunov_identity(matern_cls):
+    """F P∞ + P∞ Fᵀ + L Qc Lᵀ = 0 must hold for the Kronecker-composed product."""
+    periodic = TruncatedPeriodicSDE(
+        lengthscale=0.6, variance=1.1, period=1.5, truncation_order=3
+    )
+    matern = matern_cls(lengthscale=1.2, variance=0.8)
+    product = ProductSDE(components=(periodic, matern))
+
+    drift = np.asarray(product.drift_matrix)
+    diffusion = np.asarray(product.diffusion_matrix)
+    spectral_density = np.asarray(product.process_noise_spectral_density)
+    stationary_cov = np.asarray(
+        product.stationary_state_cov_sqrt @ product.stationary_state_cov_sqrt.T
+    )
+
+    residual = (
+        drift @ stationary_cov
+        + stationary_cov @ drift.T
+        + diffusion @ spectral_density @ diffusion.T
+    )
+    np.testing.assert_allclose(residual, 0.0, atol=1e-9)
+
+
+@pytest.mark.parametrize("matern_cls", [Matern12SDE, Matern32SDE, Matern52SDE])
+def test_product_sde_A_equals_kron_of_component_transitions(matern_cls):
+    periodic = TruncatedPeriodicSDE(
+        lengthscale=0.6, variance=1.1, period=1.5, truncation_order=2
+    )
+    matern = matern_cls(lengthscale=1.2, variance=0.8)
+    product = ProductSDE(components=(periodic, matern))
+
+    dt = jnp.asarray(0.37)
+    A_product, _ = product.discretise(dt)
+    A_periodic, _ = periodic.discretise(dt)
+    A_matern, _ = matern.discretise(dt)
+    expected = jnp.kron(A_periodic, A_matern)
+    np.testing.assert_allclose(np.asarray(A_product), np.asarray(expected), atol=1e-10)
+
+
+@pytest.mark.parametrize("matern_cls", [Matern12SDE, Matern32SDE, Matern52SDE])
+def test_product_sde_A_matches_matrix_exponential_of_kronecker_sum_drift(matern_cls):
+    """A(Δt) = expm(FΔt) must hold at the product level too, not just per-factor."""
+    periodic = TruncatedPeriodicSDE(
+        lengthscale=0.6, variance=1.1, period=1.5, truncation_order=2
+    )
+    matern = matern_cls(lengthscale=1.2, variance=0.8)
+    product = ProductSDE(components=(periodic, matern))
+
+    dt = 0.29
+    A_product, _ = product.discretise(jnp.asarray(dt))
+    expected = scipy.linalg.expm(np.asarray(product.drift_matrix) * dt)
+    np.testing.assert_allclose(np.asarray(A_product), expected, atol=1e-8, rtol=1e-7)
+
+
+@pytest.mark.parametrize("matern_cls", [Matern12SDE, Matern32SDE, Matern52SDE])
+def test_product_sde_Q_equals_stationary_identity(matern_cls):
+    periodic = TruncatedPeriodicSDE(
+        lengthscale=0.6, variance=1.1, period=1.5, truncation_order=2
+    )
+    matern = matern_cls(lengthscale=1.2, variance=0.8)
+    product = ProductSDE(components=(periodic, matern))
+
+    dt = jnp.asarray(0.8)
+    A, L_Q = product.discretise(dt)
+    Q = np.asarray(L_Q @ L_Q.T)
+    P_inf = np.asarray(
+        product.stationary_state_cov_sqrt @ product.stationary_state_cov_sqrt.T
+    )
+    expected = P_inf - np.asarray(A) @ P_inf @ np.asarray(A).T
+    np.testing.assert_allclose(Q, expected, atol=1e-8, rtol=1e-7)
+
+
+def test_product_sde_zero_dt_returns_identity_and_zero_noise():
+    periodic = TruncatedPeriodicSDE(
+        lengthscale=0.6, variance=1.1, period=1.5, truncation_order=2
+    )
+    matern = Matern32SDE(lengthscale=1.2, variance=0.8)
+    product = ProductSDE(components=(periodic, matern))
+
+    A, L_Q = product.discretise(jnp.asarray(0.0))
+    np.testing.assert_allclose(np.asarray(A), np.eye(product.state_dim), atol=1e-12)
+    np.testing.assert_allclose(
+        np.asarray(L_Q), np.zeros((product.state_dim, product.state_dim)), atol=1e-12
+    )
+
+
+def test_product_sde_observation_matrix_is_kron_of_components():
+    periodic = TruncatedPeriodicSDE(
+        lengthscale=0.6, variance=1.1, period=1.5, truncation_order=2
+    )
+    matern = Matern32SDE(lengthscale=1.2, variance=0.8)
+    product = ProductSDE(components=(periodic, matern))
+    expected = jnp.kron(periodic.observation_matrix, matern.observation_matrix)
+    np.testing.assert_allclose(
+        np.asarray(product.observation_matrix), np.asarray(expected), atol=1e-14
+    )
+
+
+def test_product_sde_is_jittable_and_vmap_compatible():
+    periodic = TruncatedPeriodicSDE(
+        lengthscale=0.6, variance=1.1, period=1.5, truncation_order=2
+    )
+    matern = Matern32SDE(lengthscale=1.2, variance=0.8)
+    product = ProductSDE(components=(periodic, matern))
+    state_dim = product.state_dim
+
+    discretise_jitted = eqx.filter_jit(product.discretise)
+    A, L_Q = discretise_jitted(jnp.asarray(0.5))
+    assert A.shape == (state_dim, state_dim)
+    assert L_Q.shape == (state_dim, state_dim)
+
+    dts = jnp.array([0.1, 0.5, 1.0])
+    A_batched, L_Q_batched = jax.vmap(product.discretise)(dts)
+    assert A_batched.shape == (3, state_dim, state_dim)
+    assert L_Q_batched.shape == (3, state_dim, state_dim)
+
+
+def test_product_sde_gradient_through_matern_lengthscale():
+    def loss(lengthscale):
+        periodic = TruncatedPeriodicSDE(
+            lengthscale=0.6, variance=1.1, period=1.5, truncation_order=2
+        )
+        matern = Matern32SDE(lengthscale=lengthscale, variance=0.8)
+        product = ProductSDE(components=(periodic, matern))
+        A, L_Q = product.discretise(jnp.asarray(0.5))
+        return jnp.sum(A) + jnp.sum(L_Q @ L_Q.T)
+
+    grad_value = jax.grad(loss)(jnp.asarray(1.2))
+    assert jnp.isfinite(grad_value)


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `uv run poe format` before committing.
- [x] I've added tests for new code.
- [x] I've added docstrings for the new code.

## Description

The state-space SDE registry rejected all `ProductKernel`s outright, citing Kronecker state-dimension blowup — blocking the canonical quasi-periodic kernel `TruncatedPeriodic × Matérn` (Solin & Särkkä 2014 §3), whose state dimension is only `(2K+1)·d`, much smaller than the general worst case. The module's own Mauna Loa example substitutes a sum as a documented workaround.

Adds a product-SDE construction specifically for the Periodic × stationary-Matérn case via the Kronecker of the two factor state-space models; keeps the explicit rejection for genuinely unsupported product combinations.

Addresses #669.

## Test plan

- `uv run pytest tests/test_state_space/` — 319 passed, 1 skipped (pre-existing, unrelated)
- New tests cover the product-SDE construction and its equivalence to a dense-kernel GP with the same product kernel
- `uv run poe lint` — clean