### PR TITLE
feat(objectives): add with_log_prior for MAP-style regularised fitting

### DIFF
--- a/gpjax/objectives.py
+++ b/gpjax/objectives.py
@@ -29,6 +29,93 @@ DVF = TypeVar("DVF", bound=DualVariationalGaussian)
 
 
 Objective = tpe.Callable[[eqx.Module, Dataset], ScalarFloat]
+LogPriorFn = tpe.Callable[[eqx.Module], ScalarFloat]
+
+
+def with_log_prior(objective: Objective, log_prior: LogPriorFn) -> Objective:
+    r"""Regularise an objective with a user-supplied log-prior over the model.
+
+    Adds a scalar log-prior density, evaluated on the model's hyperparameters,
+    to an existing objective. The result is a new :data:`Objective` that can be
+    passed straight to :func:`gpjax.fit`, :func:`gpjax.fit_scipy`, or
+    :func:`gpjax.fit_lbfgs`, giving GPyTorch-style MAP-regularised fitting: the
+    optimiser still climbs the marginal log-likelihood, but is nudged towards
+    prior-consistent hyperparameters rather than whatever the data alone would
+    pick. A common motivating use is discouraging small, overfitting-prone
+    lengthscales or noise variances in high dimensions, by preferring a broad
+    prior that favours larger values.
+
+    This intentionally does not resurrect the pre-v1 ``Parameter(...,
+    prior=...)`` field (removed in #621): attaching a prior to every
+    ``Parameter`` tangled the constrained/unconstrained bijection with an
+    ambiguous "is this prior for gradient-based optimisation or for NumPyro
+    MCMC?" scope, and duplicated the fully Bayesian path. Here the prior is
+    not attached to any ``Parameter`` at all -- it is a plain function the
+    caller writes directly over the model pytree, composed with an objective
+    via ordinary addition. This keeps regularised MLE/MAP fitting completely
+    separate from the fully Bayesian, NumPyro-based path (``numpyro.sample``
+    fed straight into GPJax constructors, see ``gpjax.objectives`` usage in
+    the NumPyro integration example): no new field on ``Parameter``, no
+    change to ``fit``/``fit_scipy``/``fit_lbfgs``, and the existing
+    NumPyro path and plain (unregularised) objectives are untouched.
+
+    Note:
+        ``log_prior`` is evaluated on the *constrained* parameter values --
+        the same values ``objective`` itself receives, since both run after
+        ``paramax.unwrap``. It does not include the change-of-variables
+        Jacobian for the unconstrained space the optimiser actually moves
+        in, so the resulting mode is a useful regularised estimate rather
+        than the literal Bayesian MAP under a formal change of variables.
+        For the strongly regularising priors this feature targets, that
+        distinction rarely matters in practice.
+
+    Example:
+        >>> import gpjax as gpx
+        >>> import jax.numpy as jnp
+        >>> import numpyro.distributions as dist
+        >>> import optax as ox
+        >>>
+        >>> xtrain = jnp.linspace(0, 1, 50).reshape(-1, 1)
+        >>> ytrain = jnp.sin(xtrain)
+        >>> D = gpx.Dataset(X=xtrain, y=ytrain)
+        >>>
+        >>> meanf = gpx.mean_functions.Constant()
+        >>> kernel = gpx.kernels.RBF()
+        >>> likelihood = gpx.likelihoods.Gaussian()
+        >>> posterior = gpx.gps.Prior(mean_function=meanf, kernel=kernel) * likelihood
+        >>>
+        >>> def log_prior(model):
+        ...     lengthscale = model.prior.kernel.lengthscale
+        ...     return dist.LogNormal(jnp.log(5.0), 0.5).log_prob(lengthscale).sum()
+        >>>
+        >>> regularised_mll = gpx.objectives.with_log_prior(
+        ...     gpx.objectives.conjugate_mll, log_prior
+        ... )
+        >>> nmll = lambda p, d: -regularised_mll(p, d)
+        >>> trained_model, history = gpx.fit(
+        ...     model=posterior, objective=nmll, train_data=D,
+        ...     optim=ox.adam(0.01), num_iters=100, verbose=False,
+        ... )
+
+    Args:
+        objective (Objective): The objective to regularise, e.g.
+            ``conjugate_mll`` or ``elbo``. Called as ``objective(model,
+            data)`` with the model's parameters already unwrapped to their
+            constrained space.
+        log_prior (LogPriorFn): A callable that receives the same unwrapped
+            model and returns a scalar log-density. Typically built from
+            ``numpyro.distributions`` log-probabilities evaluated on
+            whichever leaves of the model the caller wants to regularise.
+
+    Returns:
+        Objective: A new objective computing
+        ``objective(model, data) + log_prior(model)``.
+    """
+
+    def _regularised_objective(model: eqx.Module, data: Dataset) -> ScalarFloat:
+        return objective(model, data) + log_prior(model)
+
+    return _regularised_objective
 
 
 def conjugate_mll(model: ConjugateModel, data: Dataset) -> ScalarFloat:
@@ -509,6 +596,7 @@ def heteroscedastic_elbo(variational_family: HVF, data: Dataset) -> ScalarFloat:
 
 
 __all__ = [
+    "LogPriorFn",
     "Objective",
     "collapsed_elbo",
     "conjugate_loocv",
@@ -520,4 +608,5 @@ __all__ = [
     "log_posterior_density",
     "non_conjugate_mll",
     "variational_expectation",
+    "with_log_prior",
 ]

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -15,6 +15,7 @@ from gpjax.objectives import (
     dual_elbo,
     elbo,
     non_conjugate_mll,
+    with_log_prior,
 )
 from gpjax.parameters import (
     PositiveReal,
@@ -28,6 +29,7 @@ import jax.random as jr
 import jax.scipy as jsp
 import jax.tree_util as jtu
 import numpy as np
+import numpyro.distributions as dist
 import paramax
 import pytest
 
@@ -840,3 +842,99 @@ def test_pinned_elbo_is_a_lower_bound_on_the_evidence(family: str):
     """
     q, data = _pinned_uncollapsed_family(family, binary=False)
     assert elbo(q, data) <= conjugate_mll(q.model, data)
+def test_with_log_prior_matches_base_objective_when_prior_is_zero():
+    """A zero log-prior must leave both the value and the gradient of the
+    wrapped objective unchanged, i.e. `with_log_prior` does not disturb plain
+    `conjugate_mll` behaviour when no meaningful prior is supplied."""
+    key = jr.key(7)
+    D = build_data(20, 1, key, binary=False)
+
+    p = gpx.gps.Prior(
+        kernel=gpx.kernels.RBF(), mean_function=gpx.mean_functions.Constant()
+    )
+    likelihood = gpx.likelihoods.Gaussian()
+    posterior = p * likelihood
+
+    zero_log_prior = lambda model: jnp.array(0.0)
+    regularised_mll = with_log_prior(conjugate_mll, zero_log_prior)
+
+    base_value = conjugate_mll(posterior, D)
+    regularised_value = regularised_mll(posterior, D)
+    assert jnp.allclose(base_value, regularised_value)
+
+    params, static = eqx.partition(posterior, eqx.is_array)
+
+    def base_loss(params):
+        model = paramax.unwrap(eqx.combine(params, static))
+        return -conjugate_mll(model, D)
+
+    def regularised_loss(params):
+        model = paramax.unwrap(eqx.combine(params, static))
+        return -regularised_mll(model, D)
+
+    base_grad = jax.grad(base_loss)(params)
+    regularised_grad = jax.grad(regularised_loss)(params)
+    for base_leaf, regularised_leaf in zip(
+        jax.tree_util.tree_leaves(base_grad),
+        jax.tree_util.tree_leaves(regularised_grad),
+        strict=True,
+    ):
+        assert jnp.allclose(base_leaf, regularised_leaf)
+
+
+def test_with_log_prior_map_regularised_fit_prefers_prior_consistent_lengthscale():
+    """MAP-style regularisation: a strong prior favouring large lengthscales
+    should pull a gradient-descent fit away from the overfitting-prone tiny
+    lengthscale an unregularised MLE fit converges to, towards the prior
+    mean, on the same data. This is the acceptance scenario for issue #515."""
+    key = jr.key(1)
+    n_points = 60
+    X = jnp.linspace(0.0, 1.0, n_points).reshape(-1, 1)
+    y = jnp.sin(2.0 * jnp.pi * 8.0 * X) + jr.normal(key, X.shape) * 0.05
+    D = Dataset(X=X, y=y)
+
+    def build_posterior():
+        kernel = gpx.kernels.RBF(lengthscale=jnp.array(0.3), variance=jnp.array(1.0))
+        meanf = gpx.mean_functions.Constant()
+        likelihood = gpx.likelihoods.Gaussian(obs_stddev=jnp.array(0.05))
+        posterior = gpx.gps.Prior(mean_function=meanf, kernel=kernel) * likelihood
+        # Freeze the noise so the kernel lengthscale alone must explain the
+        # high-frequency signal -- this isolates the lengthscale/overfitting
+        # trade-off the prior is meant to regularise.
+        return eqx.tree_at(
+            lambda m: m.likelihood.obs_stddev,
+            posterior,
+            replace_fn=paramax.non_trainable,
+        )
+
+    unregularised_nmll = lambda p, d: -conjugate_mll(p, d)
+    unregularised_model, _ = gpx.fit_scipy(
+        model=build_posterior(),
+        objective=unregularised_nmll,
+        train_data=D,
+        verbose=False,
+    )
+    unregularised_lengthscale = paramax.unwrap(
+        unregularised_model
+    ).prior.kernel.lengthscale
+
+    prior_mean = 3.0
+
+    def log_prior(model):
+        lengthscale = model.prior.kernel.lengthscale
+        return dist.LogNormal(jnp.log(prior_mean), 0.15).log_prob(lengthscale).sum()
+
+    regularised_nmll = lambda p, d: -with_log_prior(conjugate_mll, log_prior)(p, d)
+    regularised_model, _ = gpx.fit_scipy(
+        model=build_posterior(),
+        objective=regularised_nmll,
+        train_data=D,
+        verbose=False,
+    )
+    regularised_lengthscale = paramax.unwrap(regularised_model).prior.kernel.lengthscale
+
+    # Unregularised MLE overfits the high-frequency signal with a tiny lengthscale.
+    assert unregularised_lengthscale < 0.05
+    # The prior-regularised fit converges near the prior mean instead.
+    assert jnp.abs(regularised_lengthscale - prior_mean) < 1.0
+    assert regularised_lengthscale > unregularised_lengthscale

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -842,6 +842,8 @@ def test_pinned_elbo_is_a_lower_bound_on_the_evidence(family: str):
     """
     q, data = _pinned_uncollapsed_family(family, binary=False)
     assert elbo(q, data) <= conjugate_mll(q.model, data)
+
+
 def test_with_log_prior_matches_base_objective_when_prior_is_zero():
     """A zero log-prior must leave both the value and the gradient of the
     wrapped objective unchanged, i.e. `with_log_prior` does not disturb plain


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `uv run poe format` before committing.
- [x] I've added tests for new code.
- [x] I've added docstrings for the new code.

## Description

Feature request: regularise a gradient-descent MLE fit with hyperparameter priors (GPyTorch-style MAP regularisation), e.g. to discourage overfitting-prone tiny lengthscales in high dimensions.

Deliberately does **not** resurrect the pre-v1 `Parameter(..., prior=...)` field (removed in #621 — see `plans/remove-default-priors.md` for why: it tangled the constrained/unconstrained bijection with an ambiguous "gradient-based or NumPyro MCMC?" scope, and duplicated the fully-Bayesian path). Instead adds `with_log_prior`, a pure objective-to-objective combinator: `with_log_prior(objective, log_prior)` returns a new objective computing `objective(model, data) + log_prior(model)`, composable with `fit`/`fit_scipy`/`fit_lbfgs` unchanged. Keeps regularised MLE/MAP fitting completely separate from the existing NumPyro-based fully-Bayesian path.

Addresses #515.

## Test plan

- `uv run pytest tests/test_objectives.py` — 131 passed
- New tests: zero-prior value/gradient equivalence to the base objective, and an end-to-end acceptance scenario (a strong prior pulls a fit away from an overfitting-prone lengthscale towards the prior mean)
- `uv run xdoctest gpjax/objectives.py` — 8 passed
- `uv run poe lint` — clean