### PR TITLE
ci(bench): wire bench-check into all-tests poe sequence

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -77,6 +77,6 @@ Prints a regression report with significance markers. No branches touched.
 ## Notes on bench-check
 
 `bench-check` runs `asv check`, which builds an env for the commit
-referenced by `asv.conf.json`'s `branches: ["main"]`. It only succeeds
-once `benchmarks/` and `asv-constraints.txt` have landed on `main`. After
-that, it's safe to add to the `all-tests` poe sequence.
+referenced by `asv.conf.json`'s `branches: ["main"]`. It is wired into
+the `all-tests` poe sequence, so it runs on every `uv run poe all-tests`
+alongside `lint`, `docstrings` and `test`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,7 +256,7 @@ shell = "asv continuous --machine $(hostname -s) -e ${1} ${2}"
 
 # Combined tasks
 [tool.poe.tasks.all-tests]
-sequence = ["lint", "docstrings", "test"]
+sequence = ["lint", "docstrings", "bench-check", "test"]
 help = "Run all checks and tests"
 
 [tool.poe.tasks.all-tests-slow]

--- a/tests/test_poe_tasks.py
+++ b/tests/test_poe_tasks.py
@@ -1,0 +1,45 @@
+# Copyright 2026 The thomaspinder Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from pathlib import Path
+import tomllib
+
+
+def _poe_tasks() -> dict:
+    pyproject = Path(__file__).parents[1] / "pyproject.toml"
+    return tomllib.loads(pyproject.read_text())["tool"]["poe"]["tasks"]
+
+
+def test_bench_check_wired_into_all_tests() -> None:
+    """`bench-check` must run as part of the `all-tests` CI gate (issue #638).
+
+    It was left out of the sequence pending a soak period for `benchmarks/`
+    and `asv-constraints.txt` to land on `main`; that precondition is now
+    satisfied, so `bench-check` belongs between `docstrings` and `test`.
+    """
+    tasks = _poe_tasks()
+
+    assert tasks["all-tests"]["sequence"] == [
+        "lint",
+        "docstrings",
+        "bench-check",
+        "test",
+    ]
+
+
+def test_bench_check_task_defined() -> None:
+    tasks = _poe_tasks()
+
+    assert tasks["bench-check"]["cmd"] == "asv check"


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `uv run poe format` before committing.
- [x] I've added tests for new code.
- [x] I've added docstrings for the new code.

## Description

`bench-check` (`asv check`) existed as a standalone poe task but wasn't wired into `all-tests`, because it originally couldn't be — `benchmarks/` and `asv-constraints.txt` hadn't yet landed. That precondition has been satisfied for months now. Wires `bench-check` into the `all-tests` sequence (`["lint", "docstrings", "bench-check", "test"]`, matching the original benchmarking-infra plan's spec) and updates `benchmarks/README.md`'s now-stale "Notes on bench-check" section.

Addresses #638.

## Test plan

- `uv run pytest tests/test_poe_tasks.py` — 2 passed
- `pyproject.toml`'s `all-tests` sequence verified by inspection to include `bench-check` in the correct position
- (`asv check` itself can't build an env in this sandbox — a pre-existing, unrelated limitation noted in the original issue's own risk section)
- `uv run poe lint` — clean