### PR TITLE
Fix bug when unwrapping paramax parameters

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -357,7 +357,7 @@ function, and freezing parameters is expressed by wrapping them in
 # Before (0.13.x)
 opt_model, history = gpx.fit(
     model=posterior,
-    objective=gpx.objectives.conjugate_mll,
+    objective=lambda p, d: -gpx.objectives.conjugate_mll(p, d),
     train_data=D,
     optim=ox.adam(1e-2),
     params_bijection=gpx.parameters.DEFAULT_BIJECTION,
@@ -378,7 +378,7 @@ posterior = eqx.tree_at(
 
 opt_model, history = gpx.fit(
     model=posterior,
-    objective=gpx.objectives.conjugate_mll,
+    objective=lambda p, d: -gpx.objectives.conjugate_mll(p, d),
     train_data=D,
     optim=ox.adam(1e-2),
 )

--- a/gpjax/integrators.py
+++ b/gpjax/integrators.py
@@ -4,8 +4,8 @@ import beartype.typing as tp
 import jax.numpy as jnp
 from jaxtyping import Float
 import numpy as np
-from paramax import AbstractUnwrappable
 
+from gpjax.parameters import _val
 from gpjax.typing import Array
 
 L = tp.TypeVar(
@@ -149,11 +149,7 @@ class AnalyticalGaussianIntegrator(AbstractIntegrator):
         Returns:
             Float[Array, 'N']: The expected log likelihood.
         """
-        obs_stddev = (
-            likelihood.obs_stddev.unwrap()
-            if isinstance(likelihood.obs_stddev, AbstractUnwrappable)
-            else likelihood.obs_stddev
-        ).squeeze()
+        obs_stddev = _val(likelihood.obs_stddev).squeeze()
         sq_error = jnp.square(y - mean)
         log2pi = jnp.log(2.0 * jnp.pi)
         val = jnp.sum(

--- a/gpjax/kernels/stationary/base.py
+++ b/gpjax/kernels/stationary/base.py
@@ -165,7 +165,7 @@ def _check_lengthscale_dims_compat(
     """
 
     if isinstance(lengthscale, AbstractUnwrappable):
-        return _check_lengthscale_dims_compat(lengthscale.unwrap(), n_dims)
+        return _check_lengthscale_dims_compat(_val(lengthscale), n_dims)
 
     lengthscale = jnp.asarray(lengthscale)
     ls_shape = jnp.shape(lengthscale)
@@ -188,7 +188,7 @@ def _check_lengthscale(lengthscale: tp.Any):
     """Check that the lengthscale is a valid value."""
 
     if isinstance(lengthscale, AbstractUnwrappable):
-        _check_lengthscale(lengthscale.unwrap())
+        _check_lengthscale(_val(lengthscale))
         return
 
     if not isinstance(lengthscale, (int, float, jnp.ndarray, list, tuple)):

--- a/gpjax/parameters.py
+++ b/gpjax/parameters.py
@@ -7,6 +7,7 @@ import jax.numpy as jnp
 import jax.random as jr
 from numpyro.distributions import biject_to, constraints
 from numpyro.distributions.transforms import SoftplusLowerCholeskyTransform
+import paramax
 from paramax import AbstractUnwrappable
 
 # numpyro's biject_to is a ConstraintRegistry that maps constraints to
@@ -56,7 +57,7 @@ _dtype_preserving_lower_cholesky = _DtypePreservingSoftplusLowerCholeskyTransfor
 
 def _val(x):
     """Unwrap a paramax parameter or return the value directly."""
-    return x.unwrap() if isinstance(x, AbstractUnwrappable) else x
+    return paramax.unwrap(x) if isinstance(x, AbstractUnwrappable) else x
 
 
 class PositiveReal(AbstractUnwrappable):
@@ -164,12 +165,8 @@ class CoregionalizationMatrix(eqx.Module):
 
     @property
     def B(self) -> jnp.ndarray:
-        w = self.W.unwrap() if isinstance(self.W, AbstractUnwrappable) else self.W
-        k = (
-            self.kappa.unwrap()
-            if isinstance(self.kappa, AbstractUnwrappable)
-            else self.kappa
-        )
+        w = _val(self.W)
+        k = _val(self.kappa)
         return w @ w.T + jnp.diag(k)
 
 

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -86,6 +86,16 @@ class LinearModel(eqx.Module):
         return _val(self.weight) * x + self.bias
 
 
+# The mll and the elbo are both maximised, whereas fit functions minimise,
+# so optimisation is always driven by the negated quantity.
+def _negative_conjugate_mll(model, data):
+    return -conjugate_mll(model, data)
+
+
+def _negative_elbo(model, data):
+    return -elbo(model, data)
+
+
 def test_fit_simple() -> None:
     # Create dataset:
     X = jnp.linspace(0.0, 10.0, 100).reshape(-1, 1)
@@ -206,7 +216,7 @@ def test_fit_gp_regression(n_data: int, verbose: bool) -> None:
     # Train!
     trained_model, history = fit(
         model=posterior,
-        objective=conjugate_mll,
+        objective=_negative_conjugate_mll,
         train_data=D,
         optim=ox.adam(0.1),
         num_iters=15,
@@ -220,8 +230,8 @@ def test_fit_gp_regression(n_data: int, verbose: bool) -> None:
     # Ensure we return a history of the correct length
     assert len(history) == 15
 
-    # Ensure we reduce the loss
-    assert conjugate_mll(trained_model, D) < conjugate_mll(posterior, D)
+    # Ensure we improve the marginal log-likelihood
+    assert conjugate_mll(trained_model, D) > conjugate_mll(posterior, D)
 
 
 @pytest.mark.parametrize("n_data", [20])
@@ -242,7 +252,7 @@ def test_fit_lbfgs_gp_regression(n_data: int) -> None:
     # Train with BFGS!
     trained_model_bfgs, _final_loss = fit_lbfgs(
         model=posterior,
-        objective=conjugate_mll,
+        objective=_negative_conjugate_mll,
         train_data=D,
         max_iters=40,
     )
@@ -250,8 +260,68 @@ def test_fit_lbfgs_gp_regression(n_data: int) -> None:
     # Ensure the trained model is a Gaussian process posterior
     assert isinstance(trained_model_bfgs, ConjugateModel)
 
-    # Ensure we reduce the loss
-    assert conjugate_mll(trained_model_bfgs, D) < conjugate_mll(posterior, D)
+    # Ensure we improve the marginal log-likelihood
+    assert conjugate_mll(trained_model_bfgs, D) > conjugate_mll(posterior, D)
+
+
+@pytest.mark.parametrize(
+    "run_fit",
+    [
+        lambda model, objective, data: fit(
+            model=model,
+            objective=objective,
+            train_data=data,
+            optim=ox.adam(0.1),
+            num_iters=20,
+            key=jr.key(123),
+        )[0],
+        lambda model, objective, data: fit_scipy(
+            model=model, objective=objective, train_data=data, max_iters=20
+        )[0],
+        lambda model, objective, data: fit_lbfgs(
+            model=model, objective=objective, train_data=data, max_iters=20
+        )[0],
+    ],
+    ids=["fit", "fit_scipy", "fit_lbfgs"],
+)
+def test_fitters_hold_frozen_parameter_constant(run_fit) -> None:
+    """Every fitter honours paramax.non_trainable.
+
+    Each optimiser reaches the parameters differently -- an Optax update rule, an
+    Optax while_loop, and a raveled vector handed to SciPy -- so the guarantee is
+    worth asserting for each. Note that it is a property of the *optimiser* as
+    much as of the wrapper: ox.adamw would still shrink the frozen parameter,
+    because decoupled weight decay applies regardless of the gradient.
+    """
+    # Create dataset:
+    key = jr.key(123)
+    x = jnp.sort(jr.uniform(key=key, minval=-2.0, maxval=2.0, shape=(20, 1)), axis=0)
+    y = jnp.sin(x) + jr.normal(key=key, shape=x.shape) * 0.1
+    D = Dataset(X=x, y=y)
+
+    # Define GP model, freezing the observation noise:
+    prior = Prior(kernel=RBF(), mean_function=Constant())
+    likelihood = eqx.tree_at(
+        lambda lik: lik.obs_stddev, Gaussian(), replace_fn=paramax.non_trainable
+    )
+    posterior = prior * likelihood
+
+    # Train!
+    trained_model = run_fit(posterior, _negative_conjugate_mll, D)
+
+    before = paramax.unwrap(posterior)
+    after = paramax.unwrap(trained_model)
+
+    # Ensure the frozen noise is held exactly
+    assert after.likelihood.obs_stddev == before.likelihood.obs_stddev
+
+    # Ensure the remaining hyperparameters are still optimised
+    assert not jnp.allclose(
+        after.prior.kernel.lengthscale, before.prior.kernel.lengthscale
+    )
+
+    # Ensure we improve the marginal log-likelihood
+    assert conjugate_mll(trained_model, D) > conjugate_mll(posterior, D)
 
 
 def test_fit_scipy_error_raises() -> None:
@@ -317,7 +387,7 @@ def test_fit_batch(num_iters: int, batch_size: int, n_data: int, verbose: bool) 
     # Train!
     trained_model, history = fit(
         model=q,
-        objective=elbo,
+        objective=_negative_elbo,
         train_data=D,
         optim=ox.adam(0.1),
         num_iters=num_iters,
@@ -332,8 +402,8 @@ def test_fit_batch(num_iters: int, batch_size: int, n_data: int, verbose: bool) 
     # Ensure we return a history of the correct length
     assert len(history) == num_iters
 
-    # Ensure we reduce the loss
-    assert elbo(trained_model, D) < elbo(q, D)
+    # Ensure we improve the elbo
+    assert elbo(trained_model, D) > elbo(q, D)
 
 
 def _svgp_setup(n_data: int, n_inducing: int = 5, jitter: float = 1e-8):
@@ -352,10 +422,6 @@ def _svgp_setup(n_data: int, n_inducing: int = 5, jitter: float = 1e-8):
     z = jnp.linspace(-2.0, 2.0, n_inducing).reshape(-1, 1)
     q = VariationalGaussian(model=posterior, inducing_inputs=z)
     return q, D
-
-
-def _negative_elbo(model, data):
-    return -elbo(model, data)
 
 
 def _conjugate_optimal_q(q, data):
@@ -535,6 +601,43 @@ def test_fit_natgrads_rejects_unsupported_family() -> None:
             num_iters=2,
             verbose=False,
         )
+
+
+def test_fit_natgrads_holds_frozen_hyperparameter_constant() -> None:
+    q, D = _svgp_setup(n_data=20)
+    frozen = eqx.tree_at(
+        lambda tree: tree.model.likelihood.obs_stddev,
+        q,
+        replace_fn=paramax.non_trainable,
+    )
+
+    trained_model, history = fit_natgrads(
+        model=frozen,
+        objective=_negative_elbo,
+        train_data=D,
+        optim=ox.adam(0.1),
+        natgrad_lr=0.5,
+        num_iters=15,
+        verbose=False,
+        key=jr.key(123),
+    )
+
+    before = paramax.unwrap(frozen)
+    after = paramax.unwrap(trained_model)
+
+    # Ensure the frozen noise is held exactly
+    assert after.model.likelihood.obs_stddev == before.model.likelihood.obs_stddev
+
+    # Ensure the remaining hyperparameters are still optimised by the Optax half
+    assert not jnp.allclose(
+        after.model.prior.kernel.lengthscale, before.model.prior.kernel.lengthscale
+    )
+
+    # Ensure the variational coordinates are still optimised by the natgrad half
+    assert not jnp.allclose(after.variational_mean, before.variational_mean)
+
+    # Ensure we reduce the loss
+    assert history[-1] < history[0]
 
 
 def test_fit_natgrads_rejects_frozen_coordinates(monkeypatch) -> None:
@@ -858,7 +961,7 @@ def test_fit_freeze_kernel_variance() -> None:
 
     trained_posterior, _ = fit(
         model=frozen_posterior,
-        objective=gpx.objectives.conjugate_mll,
+        objective=_negative_conjugate_mll,
         train_data=D,
         optim=ox.sgd(0.01),
         num_iters=10,
@@ -871,8 +974,9 @@ def test_fit_freeze_kernel_variance() -> None:
     # Assert variance has not changed
     assert jnp.allclose(unwrapped.prior.kernel.variance, initial_variance)
 
-    # Assert lengthscale has changed
+    # Assert lengthscale has changed, and in the direction that improves the mll
     assert not jnp.allclose(unwrapped.prior.kernel.lengthscale, 1.0)
+    assert conjugate_mll(trained_posterior, D) > conjugate_mll(frozen_posterior, D)
 
 
 def test_fit_zero_mean_function_is_frozen_by_default() -> None:
@@ -895,7 +999,7 @@ def test_fit_zero_mean_function_is_frozen_by_default() -> None:
 
     trained_posterior, _ = fit(
         model=posterior,
-        objective=lambda model, data: -gpx.objectives.conjugate_mll(model, data),
+        objective=_negative_conjugate_mll,
         train_data=D,
         optim=ox.adam(0.1),
         num_iters=50,
@@ -928,7 +1032,7 @@ def test_fit_constant_mean_function_with_parameter() -> None:
     # Train (should train the mean function Parameter)
     trained_posterior, _ = fit(
         model=posterior,
-        objective=gpx.objectives.conjugate_mll,
+        objective=_negative_conjugate_mll,
         train_data=D,
         optim=ox.adam(0.01),
         num_iters=20,
@@ -973,7 +1077,7 @@ def test_fit_constant_mean_function_frozen_with_non_trainable() -> None:
     # Train (constant should NOT change because it is frozen)
     trained_posterior, _ = fit(
         model=frozen_posterior,
-        objective=gpx.objectives.conjugate_mll,
+        objective=_negative_conjugate_mll,
         train_data=D,
         optim=ox.sgd(0.1),
         num_iters=50,
@@ -1018,7 +1122,7 @@ def test_fit_freeze_by_non_trainable() -> None:
 
     trained_posterior, _ = fit(
         model=frozen_posterior,
-        objective=gpx.objectives.conjugate_mll,
+        objective=_negative_conjugate_mll,
         train_data=D,
         optim=ox.sgd(0.01),
         num_iters=10,
@@ -1031,6 +1135,9 @@ def test_fit_freeze_by_non_trainable() -> None:
     # Assert that frozen parameters have not changed
     assert jnp.allclose(unwrapped.prior.kernel.variance, initial_variance)
     assert jnp.allclose(unwrapped.likelihood.obs_stddev, initial_obs_stddev)
+
+    # The trainable lengthscale must have moved so as to improve the mll
+    assert conjugate_mll(trained_posterior, D) > conjugate_mll(frozen_posterior, D)
 
     # Assert lengthscale has changed
     assert not jnp.allclose(unwrapped.prior.kernel.lengthscale, initial_lengthscale)

--- a/tests/test_gps.py
+++ b/tests/test_gps.py
@@ -23,6 +23,7 @@ except ImportError:
 
 from collections.abc import Callable
 
+import equinox as eqx
 from gpjax.dataset import Dataset
 from gpjax.distributions import GaussianDistribution
 from gpjax.gps import (
@@ -54,6 +55,7 @@ import jax.numpy as jnp
 import jax.random as jr
 import lineax as lx
 from numpyro.distributions import Distribution as NumpyroDistribution
+import paramax
 import pytest
 
 # Enable Float64 for more stable matrix inversions.
@@ -693,6 +695,29 @@ def test_predict_diagonal_jit_smoke():
     for cov_type in ("dense", "diagonal"):
         fn = jax.jit(lambda t, c=cov_type: prior(t, covariance=c).mean)
         _ = fn(xtest)
+
+
+def test_frozen_parameter_predicts_without_explicit_unwrap():
+    """A model with a frozen parameter is usable on the direct-call path.
+
+    Freezing inserts stop_gradient, which is the identity in the forward pass,
+    so predictions must match the unfrozen model exactly without the caller
+    invoking paramax.unwrap.
+    """
+    X = jnp.linspace(0.0, 1.0, 20).reshape(-1, 1)
+    D = Dataset(X=X, y=jnp.sin(X))
+    xtest = jnp.linspace(0.0, 1.0, 5).reshape(-1, 1)
+
+    prior = Prior(mean_function=Zero(), kernel=RBF())
+    likelihood = Gaussian()
+    frozen_likelihood = eqx.tree_at(
+        lambda lik: lik.obs_stddev, likelihood, replace_fn=paramax.non_trainable
+    )
+
+    reference = (prior * likelihood)(xtest, D).mean
+    frozen = (prior * frozen_likelihood)(xtest, D).mean
+
+    assert jnp.array_equal(reference, frozen)
 
 
 if __name__ == "__main__":

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -86,6 +86,24 @@ def test_paramax_unwrap_on_module():
     assert jnp.allclose(unwrapped.b, jnp.array(-1.0))
 
 
+def test_val_unwraps_nested_wrappers():
+    """_val must resolve wrappers nested *inside* a parameter, not just the outer node.
+
+    paramax.non_trainable wraps array leaves, so freezing a parameter yields e.g.
+    PositiveReal(_unconstrained=NonTrainable(...)). A single .unwrap() call would
+    feed the NonTrainable object straight into the softplus bijection of the
+    PositiveReal.
+    """
+    from gpjax.parameters import (
+        PositiveReal,
+        _val,
+    )
+
+    p = paramax.non_trainable(PositiveReal(jnp.array(2.0)))
+    assert isinstance(p._unconstrained, paramax.NonTrainable)
+    assert jnp.equal(_val(p), jnp.array(2.0))
+
+
 def test_lower_triangular_positive_diagonal():
     """LowerTriangular enforces positive diagonal via softplus."""
     from gpjax.parameters import LowerTriangular


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `uv run poe format` before committing.
- [x] I've added tests for new code.
- [N/a] I've added docstrings for the new code.

## Description

Fixes https://github.com/thomaspinder/GPJax/issues/766. Additionally:

- Updates some of the `fit` tests to optimise the *negative* marginal log likelihood (since fit *minimises* and we want to *maximise* the marginal log lieklihood).
- Updated `migration.md` which was incorrectly showing `fit` being called with `conjugate_mll` as the objective - it should be negated.
- Updated a few sites to use `_val` which were not previously calling it, and instead copying the (buggy) logic.
