### PR TITLE
Simplify bijection logic by solely using val() to tranform parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`gpjax.parameters.val`.** Promoted from the private `_val` helper to documented
+  public API, and now the single accessor for a parameter's constrained value:
+  `val(kernel.lengthscale)` applies the constraining bijection, while plain arrays and
+  floats pass through unchanged, so it needs no `isinstance` guard and is safe to
+  apply anywhere. It resolves nested wrappers innermost-first, so a parameter frozen
+  with `paramax.non_trainable` is read exactly like any other. This is the rule to
+  follow when writing a kernel, mean function, likelihood or objective — see the
+  "How does the parameter system work?" section of the Sharp Bits guide
+  (`docs/sharp_bits.md`).
+
 - **Dense joint predictive covariance for state-space GPs.**
   `StateSpacePrior.predict`, `StateSpaceConjugateModel.predict`, and
   `StateSpacePosterior.__call__` (`gpjax.state_space`) now accept
@@ -76,6 +86,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed (breaking)
 
+- **Models are no longer unwrapped before objectives, losses and predictions run.**
+  `fit`, `fit_scipy`, `fit_lbfgs` and `fit_natgrads` no longer call
+  `paramax.unwrap(model)` inside their loss functions, and the `gpjax.state_space`
+  objectives and prediction entry points no longer unwrap on the way in. A model is
+  now *always* in its wrapped form — the model you build, and the model a fitter
+  hands back — and the constraining bijection is applied at the point of use by
+  `gpjax.parameters.val`. Previously the same function could receive either form
+  depending on how it was reached, which made "is this model wrapped?" an
+  undocumented precondition on every user-facing extension point: an objective called
+  directly received a wrapped model, while the identical function called through
+  `fit` received an unwrapped one.
+
+  Ordinary use is unaffected. `gpx.fit(...)` with built-in kernels, and calls such as
+  `conjugate_mll(posterior, D)` or `posterior(X, train_data=D)`, behave exactly as
+  before — `val` is idempotent, so GPJax's own functions still accept a model in
+  either form. What changes is code *inside* the call path: a third-party kernel,
+  mean function, likelihood or objective that reads a parameter directly
+  (`model.prior.kernel.lengthscale` rather than
+  `val(model.prior.kernel.lengthscale)`) now raises `TypeError: unsupported operand
+  type(s) ... 'PositiveReal'` when reached through a fitter. Such code was already
+  inconsistent rather than correct: because GPJax's own kernels have always resolved
+  parameters at the point of use, a bare read failed on a direct `kernel.gram(x)`
+  call before this change too, and worked only when something upstream happened to
+  unwrap first. The fix is to wrap each parameter read in `val`, which returns the
+  constrained value of a parameter and returns plain arrays and floats unchanged.
+  `paramax.unwrap` is untouched and still resolves a whole model tree.
+
+  Gradients are unchanged. The bijection sits on the differentiated path either way,
+  so the chain rule accounts for it identically whether it is applied once or at each
+  of several use sites, and parameters frozen with `paramax.non_trainable` still
+  receive exactly zero gradient — `val` resolves nested wrappers innermost-first, so
+  `lax.stop_gradient` lands on every path back to the underlying array rather than on
+  one. Under `jit` there is no runtime cost: the bijection is loop-invariant under
+  `vmap` and repeated reads of the same parameter are common-subexpression-eliminated,
+  so it is computed once per loss evaluation however many call sites read it.
+
 - **`OILMMPosterior.__call__`/`.predict` default to `covariance="diagonal"`**
   (was `"dense"`) ([#682](https://github.com/JaxGaussianProcesses/GPJax/issues/682)).
   The dense joint covariance costs `O(m n^2 p^2)` — an `np x np` matrix built
@@ -139,7 +185,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unchanged and remains trainable.
 
   `Zero().constant` is now a `NonTrainable` wrapper rather than a bare array.
-  Read it with `paramax.unwrap(mean_function).constant` (or `_val`) if you were
+  Read it with `paramax.unwrap(mean_function).constant` (or `val`) if you were
   accessing it directly; evaluating the mean function is unaffected.
 
 ## [0.18.0] — 2026-07-26

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,15 @@ Parameters are `paramax.AbstractUnwrappable` subclasses. Each class stores its v
 | `SigmoidBounded` | Sigmoid scaled to `[low, high]` | `_unconstrained` via `logit` |
 | `LowerTriangular` | Fill-triangular | `_flat` vector |
 
-Access the constrained value with `param.unwrap()`. To unwrap an entire model tree, use `paramax.unwrap(model)` which recursively resolves all `AbstractUnwrappable` leaves. To freeze parameters, wrap them with `paramax.non_trainable(param)`.
+**Models are always held in wrapped form.** Wrapping happens once, at construction; nothing unwraps a model tree, including `fit`, which returns a wrapped model. The rule is:
+
+> Call `val(param)` (from `gpjax.parameters`) wherever a parameter meets arithmetic. Pass models around untouched everywhere else.
+
+`val` is idempotent and recursive: it returns the constrained value of a parameter (resolving nested wrappers such as `paramax.non_trainable`) and returns plain arrays or floats unchanged, so it never needs an `isinstance` guard. When writing a new kernel, mean function, likelihood, or objective, every parameter read needs a `val()`.
+
+Forgetting `val()` is not silent — a parameter is a pytree node, not an array, so arithmetic raises `TypeError: unsupported operand type(s) ... 'PositiveReal'` immediately. The one quiet exception is `jax.tree_util.tree_map` over a model, which reaches the *unconstrained* leaf; that is what makes optimisation work, but it means tree-mapping arithmetic over a model is not the same as scaling its parameters.
+
+Do not add `paramax.unwrap(model)` to a loss, objective, or prediction function — that is the pre-consolidation pattern, and it reintroduces an undocumented "must be unwrapped first" precondition on user-facing extension points. `paramax.unwrap` remains correct for generic tree introspection (see `gpjax/summary.py`). To freeze parameters, wrap them with `paramax.non_trainable(param)`.
 
 ### Kernel system (`gpjax/kernels/`)
 
@@ -85,7 +93,7 @@ Optimise by negating: `nmll = lambda p, d: -conjugate_mll(p, d)`
 
 ### Fitting (`gpjax/fit.py`)
 
-Four optimisers: `fit()` (Optax gradient descent with scan), `fit_scipy()` (SciPy L-BFGS-B), `fit_lbfgs()` (Optax L-BFGS with `while_loop`), `fit_natgrads()` (natural-gradient steps on a variational family, alternated with Optax steps on the hyperparameters). All handle the constrained/unconstrained bijection automatically: `paramax.unwrap(model)` is called inside the loss function, and `eqx.partition`/`eqx.combine` with `eqx.is_array` manage trainable vs static parts.
+Four optimisers: `fit()` (Optax gradient descent with scan), `fit_scipy()` (SciPy L-BFGS-B), `fit_lbfgs()` (Optax L-BFGS with `while_loop`), `fit_natgrads()` (natural-gradient steps on a variational family, alternated with Optax steps on the hyperparameters). All handle the constrained/unconstrained bijection automatically, without converting the model: `eqx.partition`/`eqx.combine` with `eqx.is_array` manage trainable vs static parts, gradients are taken with respect to the internal unconstrained arrays, and the objective receives — and the optimiser returns — a wrapped model. The bijection is applied only at the `val()` call sites inside kernels, mean functions, and likelihoods.
 
 ### Variational inference (`gpjax/variational_families.py`)
 

--- a/docs/examples/backend.py
+++ b/docs/examples/backend.py
@@ -39,6 +39,7 @@ from gpjax.mean_functions import (
 from gpjax.parameters import (
     PositiveReal,
     Real,
+    val,
 )
 from gpjax.typing import (
     Array,
@@ -61,7 +62,6 @@ try:
 except ImportError:  # notebook downloaded and run outside the docs build
     def glue(*args, **kwargs):
         """No-op stand-in: gluing only matters when Sphinx renders this page."""
-import paramax
 from paramax import AbstractUnwrappable
 
 config.update("jax_enable_x64", True)
@@ -119,12 +119,11 @@ print(meanf)
 #
 # With a parameter instantiated, you likely wish to transform the parameter's value from
 # its constrained support onto the entire real line. In GPJax, parameters store their
-# values internally in unconstrained space. When you need the constrained value, you
-# simply call `unwrap()` on the parameter, or use `paramax.unwrap()` on an entire model
-# to resolve all parameters at once.
+# values internally in unconstrained space. When you need the constrained value, call
+# [`val`](#gpjax.parameters.val) on the parameter.
 
 # %%
-print("Constrained value:", constant_param.unwrap())
+print("Constrained value:", val(constant_param))
 print("Unconstrained (internal) value:", constant_param._unconstrained)
 glue("backend-inv-softplus-one", f"{constant_param._unconstrained:.2f}", display=False)
 
@@ -132,13 +131,19 @@ glue("backend-inv-softplus-one", f"{constant_param._unconstrained:.2f}", display
 # We see here that the Softplus bijector is applied by the `PositiveReal` parameter type.
 # Internally, the value 1.0 is stored as its inverse-softplus
 # (~{glue:text}`backend-inv-softplus-one`), and calling
-# `unwrap()` applies softplus to recover the original constrained value.
+# `val` applies softplus to recover the original constrained value.
+#
+# `val` is the single rule you need to remember: **models are always held in their
+# wrapped form** — the model you build, and the model `fit` hands back — and `val` is
+# what you call at the point where a parameter meets arithmetic. It is safe to apply to
+# anything, returning plain arrays and floats untouched, so there is never a need to
+# check whether a value is wrapped first.
 #
 # For a value closer to 0, the transformation is more pronounced.
 
 # %%
 close_to_zero_param = PositiveReal(value=1e-6)
-print("Constrained value:", close_to_zero_param.unwrap())
+print("Constrained value:", val(close_to_zero_param))
 print("Unconstrained (internal) value:", close_to_zero_param._unconstrained)
 
 # %% [markdown]
@@ -195,12 +200,23 @@ print(params)
 # %% [markdown]
 # The `params` object behaves just like a PyTree and, consequently, we may use JAX's
 # `tree_map` function to alter the values. The updated params can then be recombined
-# with the static structure using `eqx.combine`. In the below, we simply increment each
-# parameter's value by 1.
+# with the static structure using `eqx.combine`. In the below, we increment each leaf
+# by 1.
 
 # %%
 updated_params = jtu.tree_map(lambda x: x + 1, params)
 print(updated_params)
+
+# %% [markdown]
+# Note what `eqx.partition` handed us: the array leaves are the parameters'
+# **unconstrained** internals (`lengthscale._unconstrained` rather than `lengthscale`),
+# so `tree_map` operates in unconstrained space. Adding 1 to the leaf of a
+# unit lengthscale gives a constrained value of ~1.74, not 2.0, because the increment
+# lands before the softplus. This is exactly the behaviour optimisation depends on —
+# gradient steps are taken in the unconstrained space — but it does mean tree-mapping
+# arithmetic over a model is not a way to *set* parameter values. To do that, construct
+# a new parameter and swap it in with
+# [`eqx.tree_at`](inv:equinox#equinox.tree_at).
 
 # %% [markdown]
 # Let us now use Equinox's `combine` function to reconstruct the posterior distribution
@@ -211,12 +227,16 @@ updated_posterior = eqx.combine(updated_params, static)
 print(updated_posterior)
 
 # %% [markdown]
-# To resolve all constrained parameter values at once (applying each parameter's
-# bijection), we can use `paramax.unwrap` on the entire model.
+# To read a constrained parameter value out of the model, reach for `val` at the point
+# of use. Note that there is no separate step converting the model into some other
+# form: `posterior` is the same wrapped object throughout, whether you are inspecting
+# it, evaluating an objective on it, or passing it to `fit`. For a view of every
+# parameter at once, use `gpx.summarise` as above.
 
 # %%
-unwrapped_posterior = paramax.unwrap(posterior)
-print(unwrapped_posterior)
+print("lengthscale:", val(posterior.prior.kernel.lengthscale))
+print("kernel variance:", val(posterior.prior.kernel.variance))
+print("obs stddev:", val(posterior.likelihood.obs_stddev))
 
 # %% [markdown]
 # ### Fine-Scale Control
@@ -280,13 +300,7 @@ class LinearMeanFunction(AbstractMeanFunction):
             self.slope = Real(jnp.array(slope))
 
     def __call__(self, x: Num[Array, "N D"]) -> Float[Array, "N O"]:
-        # Use a helper that works whether the parameter is still wrapped
-        # (an AbstractUnwrappable) or has already been unwrapped to a plain
-        # array by paramax.unwrap().
-        def _val(p):
-            return p.unwrap() if isinstance(p, AbstractUnwrappable) else p
-
-        return _val(self.intercept) + jnp.dot(x, _val(self.slope))
+        return val(self.intercept) + jnp.dot(x, val(self.slope))
 
 
 # %% [markdown]
@@ -296,7 +310,13 @@ class LinearMeanFunction(AbstractMeanFunction):
 # used in any `partition` or `combine` call. Further, we have registered the intercept
 # and slope parameters as [`Real`](#gpjax.parameters.Real) parameter types. This registers
 # their value in the PyTree and means that they will be part of any operation applied to
-# the model e.g., unwrapping and differentiation.
+# the model e.g., differentiation.
+#
+# Note the `val` calls in `__call__`: this is the one thing you must remember when
+# writing your own kernels, mean functions and likelihoods. Every parameter read needs
+# a `val`, because the module receives the model in its wrapped form. Forgetting is not
+# a silent bug — a parameter is a PyTree node rather than an array, so the arithmetic
+# raises `TypeError` immediately.
 #
 # To check our implementation worked, let's now plot the value of our mean function for
 # a linearly spaced set of inputs ({numref}`fig-backend-linear-mean-function`).
@@ -324,13 +344,15 @@ posterior = likelihood * prior
 # %% [markdown]
 # We'll compute derivatives of the conjugate marginal log-likelihood
 # ([`conjugate_mll`](#gpjax.objectives.conjugate_mll)). With Equinox and
-# Paramax, this is straightforward: `paramax.unwrap` resolves all constrained parameters
-# inside the loss function, and `eqx.filter_value_and_grad` computes gradients with
-# respect to the array leaves of the model.
+# Paramax, this is straightforward: the loss takes the model exactly as it is, and
+# `eqx.filter_value_and_grad` computes gradients with respect to the array leaves —
+# which, as we saw above, are the parameters' unconstrained internals. The bijections
+# are applied by the `val` calls inside the kernel, mean function and likelihood, so
+# they sit on the differentiated path and are accounted for by the chain rule
+# automatically.
 
 # %%
 def loss_fn(model, data: gpx.Dataset) -> ScalarFloat:
-    model = paramax.unwrap(model)
     return -gpx.objectives.conjugate_mll(model, data)
 
 

--- a/docs/examples/classification.py
+++ b/docs/examples/classification.py
@@ -29,6 +29,7 @@
 import equinox as eqx
 from utils import use_mpl_style
 from gpjax.linalg import add_jitter, cholesky_factor
+from gpjax.parameters import val
 import jax
 
 # Enable Float64 for more stable matrix inversions.
@@ -45,7 +46,6 @@ import lineax as lx
 import matplotlib.pyplot as plt
 import numpyro.distributions as npd
 import optax as ox
-import paramax
 
 config.update("jax_enable_x64", True)
 
@@ -240,7 +240,7 @@ jitter = 1e-6
 Kxx = opt_posterior.prior.kernel.gram(x).as_matrix()
 Kxx = add_jitter(Kxx, jitter)
 Lx = jnp.linalg.cholesky(Kxx)
-f_hat = Lx @ opt_posterior.latent.unwrap()
+f_hat = Lx @ val(opt_posterior.latent)
 
 # Negative Hessian,  H = -∇²p_tilde(y|f):
 params, static = eqx.partition(opt_posterior, eqx.is_array)
@@ -248,7 +248,6 @@ params, static = eqx.partition(opt_posterior, eqx.is_array)
 
 def loss(params, D):
     model = eqx.combine(params, static)
-    model = paramax.unwrap(model)
     return -gpx.objectives.log_posterior_density(model, D)
 
 

--- a/docs/examples/constructing_new_kernels.py
+++ b/docs/examples/constructing_new_kernels.py
@@ -27,7 +27,7 @@
 # %%
 # Enable Float64 for more stable matrix inversions.
 from utils import use_mpl_style
-from gpjax.kernels.base import _val
+from gpjax.kernels.base import val
 from gpjax.kernels.computations import DenseKernelComputation
 from gpjax.parameters import PositiveReal
 from jax import config
@@ -245,7 +245,7 @@ class Polar(gpx.kernels.AbstractKernel):
     ) -> Float[Array, "1"]:
         c = self.period / 2.0
         t = angular_distance(x, y, c)
-        tau = 4.0 + _val(self.tau)
+        tau = 4.0 + val(self.tau)
         K = (1 + tau * t / c) * jnp.clip(1 - t / c, 0, jnp.inf) ** tau
         return K.squeeze()
 

--- a/docs/examples/dual_svgp.py
+++ b/docs/examples/dual_svgp.py
@@ -101,7 +101,7 @@ with install_import_hook("gpjax", "beartype.beartype"):
         partition_variational,
     )
     from gpjax.objectives import dual_elbo, elbo
-    from gpjax.parameters import Real
+    from gpjax.parameters import Real, val
     from gpjax.variational_families import (
         DualVariationalGaussian,
         VariationalGaussian,
@@ -446,14 +446,14 @@ def exact_sites(lengthscale, inducing_inputs, dataset):
     variational, _ = natural_gradient_step(
         variational, hyper, dataset, negative_dual_elbo, 1.0
     )
-    fitted = paramax.unwrap(eqx.combine(variational, hyper))
-    return (fitted.dual_vector, fitted.dual_matrix), fitted.moments()
+    fitted = eqx.combine(variational, hyper)
+    return (val(fitted.dual_vector), val(fitted.dual_matrix)), fitted.moments()
 
 
 # %%
 # The Titsias optimum in closed form, against the same jittered K_zz the family uses.
 initial_dual = site_family(regression_lengthscale, regression_inducing)
-regression_prior = paramax.unwrap(initial_dual).model.prior
+regression_prior = initial_dual.model.prior
 regression_kernel = regression_prior.kernel
 regression_mean_function = regression_prior.mean_function
 
@@ -495,14 +495,14 @@ dual_variational, dual_hyper = partition_variational(initial_dual)
 stepped_variational, loss_before = natural_gradient_step(
     dual_variational, dual_hyper, regression_data, negative_dual_elbo, 1.0
 )
-stepped_dual = paramax.unwrap(eqx.combine(stepped_variational, dual_hyper))
+stepped_dual = eqx.combine(stepped_variational, dual_hyper)
 stepped_mean, stepped_covariance = stepped_dual.moments()
 
 # A second step must be a no-op.
 twice_stepped_variational, _ = natural_gradient_step(
     stepped_variational, dual_hyper, regression_data, negative_dual_elbo, 1.0
 )
-twice_stepped_dual = paramax.unwrap(eqx.combine(twice_stepped_variational, dual_hyper))
+twice_stepped_dual = eqx.combine(twice_stepped_variational, dual_hyper)
 twice_stepped_mean, twice_stepped_covariance = twice_stepped_dual.moments()
 
 stepped_bound = dual_elbo(stepped_dual, regression_data)
@@ -606,7 +606,7 @@ logit_model = (
 logit_dual = DualVariationalGaussian(
     model=logit_model, inducing_inputs=logit_inducing
 )
-logit_gram = paramax.unwrap(logit_model).prior.kernel.gram(
+logit_gram = logit_model.prior.kernel.gram(
     logit_inducing
 ).as_matrix() + logit_jitter * jnp.eye(num_logit_inducing)
 logit_moments = VariationalGaussian(
@@ -617,8 +617,7 @@ logit_moments = VariationalGaussian(
 )
 
 shared_bound = float(
-    dual_elbo(paramax.unwrap(logit_dual), logit_data)
-    - elbo(paramax.unwrap(logit_moments), logit_data)
+    dual_elbo(logit_dual, logit_data) - elbo(logit_moments, logit_data)
 )
 print(f"cond(K_zz)                          : {jnp.linalg.cond(logit_gram):.3e}")
 print(f"dual_elbo - elbo at the shared init : {shared_bound:.3e}")
@@ -627,11 +626,10 @@ print(f"dual_elbo - elbo at the shared init : {shared_bound:.3e}")
 # %%
 def implied_moments(family):
     """Return $(m, S)$ for either parameterisation."""
-    unwrapped = paramax.unwrap(family)
-    if isinstance(unwrapped, DualVariationalGaussian):
-        return unwrapped.moments()
-    root = unwrapped.variational_root_covariance
-    return unwrapped.variational_mean, root @ root.T
+    if isinstance(family, DualVariationalGaussian):
+        return family.moments()
+    root = val(family.variational_root_covariance)
+    return val(family.variational_mean), root @ root.T
 
 
 print("rate    max |(m, S) gap| over six full-batch steps")
@@ -741,7 +739,7 @@ banana_model = (
     * gpx.likelihoods.Bernoulli()
 )
 
-banana_gram = paramax.unwrap(banana_model).prior.kernel.gram(
+banana_gram = banana_model.prior.kernel.gram(
     banana_inducing
 ).as_matrix() + banana_jitter * jnp.eye(num_banana_inducing)
 banana_prior_root = jnp.linalg.cholesky(banana_gram)
@@ -807,7 +805,7 @@ def six_matched_steps(beta_floor):
     for _ in range(6):
         # Measured before the step, at the q both branches currently share.
         marginal_mean, curvature = price_curvature(
-            paramax.unwrap(eqx.combine(site_partition, site_hyper)), banana_train
+            eqx.combine(site_partition, site_hyper), banana_train
         )
         site_partition, _ = natural_gradient_step(
             site_partition,
@@ -1101,7 +1099,7 @@ def kernel_gradient(variational, hyper, objective, dataset):
     """Gradient of `objective` with respect to the unconstrained kernel parameters."""
 
     def loss(hyper):
-        return objective(paramax.unwrap(eqx.combine(variational, hyper)), dataset)
+        return objective(eqx.combine(variational, hyper), dataset)
 
     gradient = eqx.filter_grad(loss)(hyper)
     leaves = jtu.tree_leaves(gradient.model.prior.kernel)
@@ -1157,16 +1155,10 @@ def bound_slice(inducing_inputs, dataset, sites, moments, offsets):
     for offset in offsets:
         lengthscale = regression_lengthscale * jnp.exp(offset)
         dual_values.append(
-            dual_elbo(
-                paramax.unwrap(site_family(lengthscale, inducing_inputs, sites)),
-                dataset,
-            )
+            dual_elbo(site_family(lengthscale, inducing_inputs, sites), dataset)
         )
         moment_values.append(
-            elbo(
-                paramax.unwrap(moment_family(lengthscale, inducing_inputs, moments)),
-                dataset,
-            )
+            elbo(moment_family(lengthscale, inducing_inputs, moments), dataset)
         )
     return jnp.array(dual_values), jnp.array(moment_values)
 
@@ -1273,9 +1265,7 @@ dense_data = gpx.Dataset(X=dense_inputs, y=dense_outputs)
 dense_sites, dense_moments = exact_sites(
     regression_lengthscale, dense_inputs, dense_data
 )
-dense_prior = paramax.unwrap(
-    site_family(regression_lengthscale, dense_inputs)
-).model.prior
+dense_prior = site_family(regression_lengthscale, dense_inputs).model.prior
 dense_gram = dense_prior.kernel.gram(
     dense_inputs
 ).as_matrix() + regression_jitter * jnp.eye(dense_count)
@@ -1374,7 +1364,7 @@ def vem_joint_model(lengthscale):
     )
 
 
-vem_gram = paramax.unwrap(vem_joint_model(initial_lengthscale)).prior.kernel.gram(
+vem_gram = vem_joint_model(initial_lengthscale).prior.kernel.gram(
     banana_inducing
 ).as_matrix() + banana_jitter * jnp.eye(num_banana_inducing)
 
@@ -1412,9 +1402,7 @@ def run_vem(model, objective):
     @eqx.filter_jit
     def maximisation_step(variational, hyper, opt_state):
         def hyper_loss(hyper):
-            return objective(
-                paramax.unwrap(eqx.combine(variational, hyper)), banana_train
-            )
+            return objective(eqx.combine(variational, hyper), banana_train)
 
         def body(carry, _):
             hyper, opt_state = carry
@@ -1433,8 +1421,8 @@ def run_vem(model, objective):
     for _ in range(vem_rounds):
         variational = expectation_step(variational, hyper)
         hyper, opt_state, loss = maximisation_step(variational, hyper, opt_state)
-        combined = paramax.unwrap(eqx.combine(variational, hyper))
-        lengthscales.append(float(combined.model.prior.kernel.lengthscale))
+        combined = eqx.combine(variational, hyper)
+        lengthscales.append(float(val(combined.model.prior.kernel.lengthscale)))
         bounds.append(float(loss))
     return eqx.combine(variational, hyper), jnp.array(lengthscales), jnp.array(bounds)
 
@@ -1469,8 +1457,7 @@ axes[1].set(
 
 def test_metrics(model):
     """Held-out accuracy and negative log predictive density."""
-    unwrapped = paramax.unwrap(model)
-    probability = unwrapped.model.likelihood(unwrapped(test_inputs_2d)).mean
+    probability = model.model.likelihood(model(test_inputs_2d)).mean
     labels = test_labels.ravel()
     log_density = jnp.mean(
         labels * jnp.log(probability) + (1.0 - labels) * jnp.log1p(-probability)

--- a/docs/examples/natgrads.py
+++ b/docs/examples/natgrads.py
@@ -87,7 +87,7 @@ with install_import_hook("gpjax", "beartype.beartype"):
         natural_gradient_step,
         partition_variational,
     )
-    from gpjax.parameters import LowerTriangular, Real
+    from gpjax.parameters import LowerTriangular, Real, val
 
 key = jr.key(123)
 
@@ -243,7 +243,7 @@ def loss_at_moments(variational_mean, variational_root_covariance):
         check_family,
         (Real(variational_mean), LowerTriangular(variational_root_covariance)),
     )
-    return negative_elbo(paramax.unwrap(trial), check_data)
+    return negative_elbo(trial, check_data)
 
 
 def loss_of_natural(flat):
@@ -384,9 +384,8 @@ initial_family = gpx.variational_families.WhitenedVariationalGaussian(
 # $$\mathbf{S}_w^\star = \boldsymbol{\Lambda}_w^{-1}, \qquad \mathbf{m}_w^\star = \boldsymbol{\Lambda}_w^{-1}\mathbf{b}_w .$$
 
 # %%
-unwrapped_initial = paramax.unwrap(initial_family)
-kernel = unwrapped_initial.model.prior.kernel
-mean_function = unwrapped_initial.model.prior.mean_function
+kernel = initial_family.model.prior.kernel
+mean_function = initial_family.model.prior.mean_function
 
 Kzz = kernel.gram(regression_inducing).as_matrix()
 Kzz = Kzz + initial_family.model.prior.jitter * jnp.eye(num_inducing)
@@ -412,9 +411,7 @@ optimal_family = eqx.tree_at(
     initial_family,
     (Real(optimal_mean), LowerTriangular(jnp.linalg.cholesky(optimal_covariance))),
 )
-reference_elbo = float(
-    gpx.objectives.elbo(paramax.unwrap(optimal_family), regression_data)
-)
+reference_elbo = float(gpx.objectives.elbo(optimal_family, regression_data))
 print(f"ELBO at the closed-form optimum: {reference_elbo:.6f}")
 
 # %%
@@ -430,12 +427,11 @@ stepped_partition, loss_before = natural_gradient_step(
 )
 stepped_family = eqx.combine(stepped_partition, hyper_partition)
 
-unwrapped_stepped = paramax.unwrap(stepped_family)
-stepped_mean = unwrapped_stepped.variational_mean
-stepped_root = unwrapped_stepped.variational_root_covariance
+stepped_mean = val(stepped_family.variational_mean)
+stepped_root = val(stepped_family.variational_root_covariance)
 stepped_covariance = stepped_root @ stepped_root.T
 
-stepped_elbo = float(gpx.objectives.elbo(unwrapped_stepped, regression_data))
+stepped_elbo = float(gpx.objectives.elbo(stepped_family, regression_data))
 
 # A second step from the same place must be a fixed point.
 twice_stepped_partition, _ = natural_gradient_step(
@@ -446,9 +442,9 @@ twice_stepped_partition, _ = natural_gradient_step(
     1.0,
     map_jitter=0.0,
 )
-twice_stepped_mean = paramax.unwrap(
-    eqx.combine(twice_stepped_partition, hyper_partition)
-).variational_mean
+twice_stepped_mean = val(
+    eqx.combine(twice_stepped_partition, hyper_partition).variational_mean
+)
 
 print(f"ELBO before the step           : {-loss_before:12.6f}")
 print(f"ELBO after one gamma=1 step    : {stepped_elbo:12.6f}")
@@ -483,15 +479,15 @@ print(
 # inducing-point approximation.
 
 # %%
-exact_posterior = paramax.unwrap(regression_model).condition(regression_data)
+exact_posterior = regression_model.condition(regression_data)
 exact_predictive = exact_posterior(test_inputs)
 exact_mean = exact_predictive.mean
 exact_stddev = jnp.sqrt(exact_predictive.variance)
 
 fig, axes = plt.subplots(ncols=2, figsize=(10, 3.0), sharey=True)
 for ax, family, title in [
-    (axes[0], unwrapped_initial, "Initialisation"),
-    (axes[1], unwrapped_stepped, "After one $\\gamma=1$ natural-gradient step"),
+    (axes[0], initial_family, "Initialisation"),
+    (axes[1], stepped_family, "After one $\\gamma=1$ natural-gradient step"),
 ]:
     predictive = family(test_inputs)
     predictive_mean = predictive.mean
@@ -528,7 +524,7 @@ axes[0].set_ylabel(r"$f(x)$")
 
 print(
     "max |sparse mean - exact mean| : "
-    f"{jnp.max(jnp.abs(unwrapped_stepped(test_inputs).mean - exact_mean)):.3e}"
+    f"{jnp.max(jnp.abs(stepped_family(test_inputs).mean - exact_mean)):.3e}"
 )
 
 # %% [markdown]
@@ -902,10 +898,9 @@ grid_points = jnp.stack([grid_x.ravel(), grid_y.ravel()], axis=1)
 
 def predictive_probability(model, inputs, num_chunks=8):
     """Bernoulli success probability, evaluated in chunks to bound memory."""
-    unwrapped = paramax.unwrap(model)
-    likelihood = unwrapped.model.likelihood
+    likelihood = model.model.likelihood
     return jnp.concatenate(
-        [likelihood(unwrapped(chunk)).mean for chunk in jnp.split(inputs, num_chunks)]
+        [likelihood(model(chunk)).mean for chunk in jnp.split(inputs, num_chunks)]
     )
 
 
@@ -945,7 +940,7 @@ for ax, model, name, seconds in [
             edgecolors="white",
             linewidths=0.3,
         )
-    inducing = paramax.unwrap(model).inducing_inputs
+    inducing = val(model.inducing_inputs)
     ax.scatter(inducing[:, 0], inducing[:, 1], marker="+", s=25, color="black")
 
     probability_test = predictive_probability(model, test_inputs_2d, num_chunks=1)
@@ -1036,8 +1031,8 @@ overconfident_family = gpx.variational_families.VariationalGaussian(
     variational_mean=jnp.zeros((num_banana_inducing, 1)),
     variational_root_covariance=0.1 * jnp.eye(num_banana_inducing),
 )
-overconfident_mean = overconfident_family.variational_mean.unwrap()
-overconfident_root = overconfident_family.variational_root_covariance.unwrap()
+overconfident_mean = val(overconfident_family.variational_mean)
+overconfident_root = val(overconfident_family.variational_root_covariance)
 
 
 def banana_loss_of_expectation(expectation):
@@ -1047,7 +1042,7 @@ def banana_loss_of_expectation(expectation):
         overconfident_family,
         (Real(variational_mean), LowerTriangular(variational_root)),
     )
-    return negative_elbo(paramax.unwrap(trial), banana_train)
+    return negative_elbo(trial, banana_train)
 
 
 cone_gradient = jax.grad(banana_loss_of_expectation)(
@@ -1098,9 +1093,9 @@ for max_backoff in [0, 3, 5, 7, 10]:
         max_backoff=max_backoff,
     )
     smallest_trial = 100.0 * 0.5**max_backoff
-    root = eqx.combine(
-        stepped, overconfident_hyper
-    ).variational_root_covariance.unwrap()
+    root = val(
+        eqx.combine(stepped, overconfident_hyper).variational_root_covariance
+    )
     outcome = "finite" if bool(jnp.all(jnp.isfinite(root))) else "NaN"
     print(
         f"  max_backoff = {max_backoff:2d}  smallest trial gamma = "

--- a/docs/examples/poisson.py
+++ b/docs/examples/poisson.py
@@ -47,7 +47,6 @@ from jaxtyping import install_import_hook
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import pandas as pd
-import paramax
 
 with install_import_hook("gpjax", "beartype.beartype"):
     import gpjax as gpx
@@ -197,7 +196,6 @@ params, static = eqx.partition(posterior, eqx.is_array)
 
 def logprob_fn(params):
     model = eqx.combine(params, static)
-    model = paramax.unwrap(model)
     return gpx.objectives.log_posterior_density(model, D)
 
 
@@ -274,7 +272,6 @@ key, predictive_key = jr.split(key)
 for i in range(0, num_samples, thin_factor):
     sample_params = jtu.tree_map(lambda samples, i=i: samples[i], states.position)
     model = eqx.combine(sample_params, static)
-    model = paramax.unwrap(model)
     latent_dist = model.predict(xtest, train_data=D)
     predictive_key, f_key, y_key = jr.split(predictive_key, 3)
     f_star = latent_dist.sample(key=f_key, sample_shape=(num_latent_draws,))

--- a/docs/reference/parameters.md
+++ b/docs/reference/parameters.md
@@ -13,4 +13,5 @@
    PositiveReal
    Real
    SigmoidBounded
+   val
 ```

--- a/docs/sharp_bits.md
+++ b/docs/sharp_bits.md
@@ -98,16 +98,100 @@ parameters during optimisation. Each constrained parameter — [`PositiveReal`](
 Equinox-compatible pytree node whose `unwrap()` method applies the constraining
 bijection (e.g. softplus for positivity, sigmoid for bounded parameters).
 
-During optimisation, [`fit`](#gpjax.fit.fit) calls
-[`paramax.unwrap`](inv:paramax#paramax.wrappers.unwrap) inside the loss function.
-This recursively resolves every `AbstractUnwrappable` leaf in the model tree, mapping
-internal unconstrained values to their constrained counterparts. Gradients are computed
-in the unconstrained space, and updates are applied directly to the unconstrained
-arrays — no explicit forward/inverse transform step is needed.
+Gradients are computed in the unconstrained space, and updates are applied directly to
+the internal unconstrained arrays — no explicit forward/inverse transform step is
+needed, and [`fit`](#gpjax.fit.fit) never has to convert your model into a different
+form to optimise it.
+
+### When do I need to call `val()`?
+
+Models are **always** in their wrapped form. A model you build is wrapped, and a model
+returned by `fit` is still wrapped — nothing in GPJax converts it to a plain-array
+model, and you never need to do so yourself. The single rule is:
+
+> Call [`val`](#gpjax.parameters.val) when you want a parameter's **numeric value**.
+> Everywhere else, pass the model around untouched.
+
+```python
+import jax
+import jax.numpy as jnp
+import optax as ox
+import gpjax as gpx
+from gpjax.parameters import val
+
+X = jnp.linspace(0, 1, 20).reshape(-1, 1)
+D = gpx.Dataset(X=X, y=jnp.sin(3 * X))
+prior = gpx.gps.Prior(
+    mean_function=gpx.mean_functions.Constant(), kernel=gpx.kernels.RBF()
+)
+posterior, history = gpx.fit(
+    model=prior * gpx.likelihoods.Gaussian(),
+    objective=lambda p, d: -gpx.objectives.conjugate_mll(p, d),
+    train_data=D,
+    optim=ox.adam(0.01),
+    num_iters=50,
+    verbose=False,
+)
+
+# Reading a parameter's value: needs val().
+lengthscale = val(posterior.prior.kernel.lengthscale)
+print(f"learnt lengthscale: {lengthscale:.3f}")
+
+# Passing the model anywhere: no val(), no unwrapping.
+mll = gpx.objectives.conjugate_mll(posterior, D)
+predictive = posterior(X, train_data=D)
+```
+
+The same rule applies when you write your own kernel. Reach for `val` at the point
+where a parameter meets the arithmetic:
+
+```python
+from gpjax.kernels.stationary.base import StationaryKernel
+from gpjax.kernels.stationary.utils import squared_distance
+
+class MyKernel(StationaryKernel):
+    def __call__(self, x, y):
+        x = self.slice_input(x) / val(self.lengthscale)
+        y = self.slice_input(y) / val(self.lengthscale)
+        return val(self.variance) * jnp.exp(-0.5 * squared_distance(x, y))
+
+MyKernel(lengthscale=jnp.array(0.5))(jnp.array([0.1]), jnp.array([0.4]))
+```
+
+`val` is safe to apply to anything: given a parameter it returns the constrained value,
+and given a plain array or float it returns it unchanged. So there is no need to check
+first, and no harm in calling it on a value that turns out not to be wrapped.
+
+Forgetting `val` is not a silent bug. A parameter is a pytree node rather than an
+array, so arithmetic on it fails immediately and loudly:
+
+```console
+TypeError: unsupported operand type(s) for /: 'ArrayImpl' and 'PositiveReal'
+```
+
+If you see that error, you have found a missing `val()`.
+
+:::{warning}
+The one place this bites quietly is `jax.tree_util.tree_map` over a model. Mapping a
+function across the tree reaches the *unconstrained* leaf, not the value you see:
+
+```python
+from gpjax.parameters import PositiveReal
+
+doubled = jax.tree.map(lambda v: v * 2, PositiveReal(jnp.array(2.0)))
+val(doubled)  # 3.733..., not 4.0 -- it doubled the pre-softplus value
+```
+
+This is exactly what makes optimisation work — `fit` moves those unconstrained leaves
+on purpose — but it means tree-mapping arithmetic over a model is not the same as
+scaling its parameters. Use `val` and rebuild the parameter if that is what you meant.
+:::
 
 To freeze parameters so they are not updated during optimisation, wrap them with
 [`paramax.non_trainable`](inv:paramax#paramax.wrappers.non_trainable). This excludes the
-wrapped subtree from gradient updates while keeping its value available at evaluation time.
+wrapped subtree from gradient updates while keeping its value available at evaluation
+time — and since `val` resolves nested wrappers too, frozen parameters are read exactly
+like any other.
 
 ## Positive-definiteness
 

--- a/gpjax/conditioning.py
+++ b/gpjax/conditioning.py
@@ -46,7 +46,7 @@ from gpjax.dataset import Dataset
 from gpjax.distributions import GaussianDistribution
 from gpjax.kernels import RFF
 from gpjax.linalg.utils import stabilised_cholesky
-from gpjax.parameters import _val
+from gpjax.parameters import val
 from gpjax.typing import (
     Array,
     FunctionalSample,
@@ -321,7 +321,7 @@ class ExactPosterior(Posterior):
         fourier_weights = jr.normal(weight_key, [num_samples, 2 * num_features])
 
         x = self.train_data.X
-        obs_var = _val(self.likelihood.obs_stddev) ** 2
+        obs_var = val(self.likelihood.obs_stddev) ** 2
         observation_noise = jnp.sqrt(obs_var) * jr.normal(
             noise_key, [self.train_data.n, num_samples]
         )
@@ -380,7 +380,7 @@ class LatentPosterior(Posterior):
         self.cholesky_factor = stabilised_cholesky(
             prior.kernel.gram(train_data.X).as_matrix(), prior.jitter
         )
-        self.latent = _val(latent)
+        self.latent = val(latent)
 
     def __call__(
         self,
@@ -670,7 +670,7 @@ class CollapsedPosterior(Posterior):
         model = family.model
         kernel = model.prior.kernel
         mean_function = model.prior.mean_function
-        obs_stddev = _val(model.likelihood.obs_stddev)
+        obs_stddev = val(model.likelihood.obs_stddev)
         noise_var = obs_stddev**2
 
         inducing_inputs = family._fmt_inducing_inputs()
@@ -900,7 +900,7 @@ def _build_fourier_features_fn(
 
     def eval_fourier_features(test_inputs: Float[Array, "N D"]) -> Float[Array, "N L"]:
         feature_matrix = approximate_kernel.compute_features(x=test_inputs)
-        feature_matrix *= jnp.sqrt(_val(prior.kernel.variance) / num_features)
+        feature_matrix *= jnp.sqrt(val(prior.kernel.variance) / num_features)
         return feature_matrix
 
     return eval_fourier_features

--- a/gpjax/fit.py
+++ b/gpjax/fit.py
@@ -22,7 +22,6 @@ from jax.flatten_util import ravel_pytree
 import jax.numpy as jnp
 import jax.random as jr
 import optax as ox
-import paramax
 from scipy.optimize import minimize
 
 from gpjax.dataset import Dataset
@@ -119,12 +118,7 @@ def fit(
 
     model = _prepare_model(model, train_data)
 
-    # Use paramax.unwrap for the constrained -> unconstrained -> constrained cycle.
-    # paramax handles the bijection automatically via AbstractUnwrappable subclasses.
-
-    # Loss definition -- paramax.unwrap resolves all AbstractUnwrappable leaves
     def loss(model: eqx.Module, batch: Dataset) -> ScalarFloat:
-        model = paramax.unwrap(model)
         return objective(model, batch)
 
     # Initialise optimiser state.
@@ -226,7 +220,6 @@ def fit_scipy(
     # Loss definition
     def loss(params) -> ScalarFloat:
         model = eqx.combine(params, static)
-        model = paramax.unwrap(model)
         return objective(model, train_data)
 
     # convert to numpy for interface with scipy
@@ -322,7 +315,6 @@ def fit_lbfgs(
     # Loss definition
     def loss(params) -> ScalarFloat:
         model = eqx.combine(params, static)
-        model = paramax.unwrap(model)
         return objective(model, train_data)
 
     # Initialise optimiser
@@ -552,7 +544,7 @@ def fit_natgrads(
     schedule = natgrad_lr if callable(natgrad_lr) else (lambda _: natgrad_lr)
 
     def hyper_loss(hyper, variational, batch):
-        model = paramax.unwrap(eqx.combine(variational, hyper))
+        model = eqx.combine(variational, hyper)
         return objective(model, batch)
 
     # Optimisation step.

--- a/gpjax/integrators.py
+++ b/gpjax/integrators.py
@@ -5,7 +5,7 @@ import jax.numpy as jnp
 from jaxtyping import Float
 import numpy as np
 
-from gpjax.parameters import _val
+from gpjax.parameters import val
 from gpjax.typing import Array
 
 L = tp.TypeVar(
@@ -112,8 +112,8 @@ class GHQuadratureIntegrator(AbstractIntegrator):
         sd = jnp.sqrt(variance)
         X = mean + jnp.sqrt(2.0) * sd * gh_points
         W = gh_weights / jnp.sqrt(jnp.pi)
-        val = jnp.sum(fun(X, y) * W, axis=1)
-        return val
+        expectation = jnp.sum(fun(X, y) * W, axis=1)
+        return expectation
 
 
 class AnalyticalGaussianIntegrator(AbstractIntegrator):
@@ -149,14 +149,14 @@ class AnalyticalGaussianIntegrator(AbstractIntegrator):
         Returns:
             Float[Array, 'N']: The expected log likelihood.
         """
-        obs_stddev = _val(likelihood.obs_stddev).squeeze()
+        obs_stddev = val(likelihood.obs_stddev).squeeze()
         sq_error = jnp.square(y - mean)
         log2pi = jnp.log(2.0 * jnp.pi)
-        val = jnp.sum(
+        expectation = jnp.sum(
             log2pi + jnp.log(obs_stddev**2) + (sq_error + variance) / obs_stddev**2,
             axis=1,
         )
-        return -0.5 * val
+        return -0.5 * expectation
 
 
 __all__ = [

--- a/gpjax/kernels/additive/decompose.py
+++ b/gpjax/kernels/additive/decompose.py
@@ -16,7 +16,7 @@ import jax
 import jax.numpy as jnp
 from jaxtyping import Float
 
-from gpjax.kernels.base import _val
+from gpjax.kernels.base import val
 from gpjax.typing import Array
 
 if tp.TYPE_CHECKING:
@@ -78,7 +78,7 @@ def rank_first_order(
 
     lengthscales = kernel._lengthscales
     variances = kernel._variances
-    order_variances = _val(kernel.order_variances)
+    order_variances = val(kernel.order_variances)
 
     integral_matrices = jax.vmap(_sobol_integral_matrix)(
         x_train.T, lengthscales, variances
@@ -145,7 +145,7 @@ def predict_first_order(
 
     lengthscale_dim = kernel._lengthscales[dim]
     variance_dim = kernel._variances[dim]
-    first_order_variance = _val(kernel.order_variances)[1]
+    first_order_variance = val(kernel.order_variances)[1]
 
     # K_star: (M, N) cross-covariance between grid and training points
     K_star = _build_first_order_cross_covariance(

--- a/gpjax/kernels/additive/oak.py
+++ b/gpjax/kernels/additive/oak.py
@@ -12,7 +12,7 @@ from jax import lax
 import jax.numpy as jnp
 from jaxtyping import Float
 
-from gpjax.kernels.base import AbstractKernel, _val
+from gpjax.kernels.base import AbstractKernel, val
 from gpjax.kernels.computations import DenseKernelComputation
 from gpjax.kernels.computations.base import AbstractKernelComputation
 from gpjax.parameters import NonNegativeReal
@@ -198,7 +198,7 @@ class OrthogonalAdditiveKernel(AbstractKernel):
     @property
     def _lengthscales(self) -> Float[Array, " D"]:
         """Stack base kernel lengthscales into a single array."""
-        return jnp.stack([_val(k.lengthscale).squeeze() for k in self.base_kernels])
+        return jnp.stack([val(k.lengthscale).squeeze() for k in self.base_kernels])
 
     @property
     def _variances(self) -> Float[Array, " D"]:
@@ -209,7 +209,7 @@ class OrthogonalAdditiveKernel(AbstractKernel):
         """
         if self.fix_base_variance:
             return jnp.ones(len(self.base_kernels))
-        return jnp.stack([_val(k.variance).squeeze() for k in self.base_kernels])
+        return jnp.stack([val(k.variance).squeeze() for k in self.base_kernels])
 
     def __call__(
         self,
@@ -237,4 +237,4 @@ class OrthogonalAdditiveKernel(AbstractKernel):
         elem_sym = _newton_girard(per_dim_values, self.max_order)
 
         # Weighted sum: K(x,y) = sum_d sigma^2_d * e_d
-        return jnp.dot(_val(self.order_variances), elem_sym)
+        return jnp.dot(val(self.order_variances), elem_sym)

--- a/gpjax/kernels/additive/sobol.py
+++ b/gpjax/kernels/additive/sobol.py
@@ -17,7 +17,7 @@ import jax.numpy as jnp
 from jaxtyping import Float
 
 from gpjax.kernels.additive.oak import _newton_girard
-from gpjax.kernels.base import _val
+from gpjax.kernels.base import val
 from gpjax.typing import Array
 
 if tp.TYPE_CHECKING:
@@ -148,7 +148,7 @@ def sobol_indices(
     """
     num_points = x_train.shape[0]
     max_order = kernel.max_order
-    order_variances = _val(kernel.order_variances)
+    order_variances = val(kernel.order_variances)
 
     # Solve alpha = (K + sigma_n^2 I)^{-1} y
     gram_matrix = kernel.gram(x_train).as_matrix()

--- a/gpjax/kernels/base.py
+++ b/gpjax/kernels/base.py
@@ -29,7 +29,7 @@ from gpjax.kernels.computations import (
     AbstractKernelComputation,
     DenseKernelComputation,
 )
-from gpjax.parameters import Real, _val
+from gpjax.parameters import Real, val
 from gpjax.summary import _SummaryMixin
 from gpjax.typing import (
     Array,
@@ -243,7 +243,7 @@ class Constant(AbstractKernel):
         Returns:
             ScalarFloat: The evaluated kernel function at the supplied inputs.
         """
-        return _val(self.constant).squeeze()
+        return val(self.constant).squeeze()
 
 
 class CombinationKernel(AbstractKernel):

--- a/gpjax/kernels/computations/basis_functions.py
+++ b/gpjax/kernels/computations/basis_functions.py
@@ -6,7 +6,7 @@ import lineax as lx
 
 import gpjax
 from gpjax.kernels.computations.base import AbstractKernelComputation
-from gpjax.parameters import _val
+from gpjax.parameters import val
 from gpjax.typing import Array
 
 K = tp.TypeVar("K", bound="gpjax.kernels.approximations.RFF")
@@ -70,4 +70,4 @@ class BasisFunctionComputation(AbstractKernelComputation):
         Returns:
             A scalar array representing the scaling factor.
         """
-        return _val(kernel.base_kernel.variance) / kernel.num_basis_fns
+        return val(kernel.base_kernel.variance) / kernel.num_basis_fns

--- a/gpjax/kernels/non_euclidean/graph.py
+++ b/gpjax/kernels/non_euclidean/graph.py
@@ -23,7 +23,7 @@ from jaxtyping import (
 import paramax
 from paramax import AbstractUnwrappable
 
-from gpjax.kernels.base import _val
+from gpjax.kernels.base import val
 from gpjax.kernels.computations import (
     AbstractKernelComputation,
     EigenKernelComputation,
@@ -119,7 +119,7 @@ class GraphKernel(StationaryKernel):
         x_idx = self._prepare_indices(x)
         y_idx = self._prepare_indices(y)
         S = calculate_heat_semigroup(self)
-        eigenvectors = _val(self.eigenvectors)
+        eigenvectors = val(self.eigenvectors)
         Kxx = (jax_gather_nd(eigenvectors, x_idx) * S.squeeze()) @ jnp.transpose(
             jax_gather_nd(eigenvectors, y_idx)
         )  # shape (n,n)

--- a/gpjax/kernels/non_euclidean/utils.py
+++ b/gpjax/kernels/non_euclidean/utils.py
@@ -22,7 +22,7 @@ from jaxtyping import (
     Int,
 )
 
-from gpjax.kernels.base import _val
+from gpjax.kernels.base import val
 from gpjax.typing import Array
 
 if tp.TYPE_CHECKING:
@@ -60,10 +60,10 @@ def calculate_heat_semigroup(kernel: GraphKernel) -> Float[Array, "N M"]:
     Returns:
         S
     """
-    smoothness = _val(kernel.smoothness)
-    lengthscale = _val(kernel.lengthscale)
-    variance = _val(kernel.variance)
-    eigenvalues = _val(kernel.eigenvalues)
+    smoothness = val(kernel.smoothness)
+    lengthscale = val(kernel.lengthscale)
+    variance = val(kernel.variance)
+    eigenvalues = val(kernel.eigenvalues)
     S = jnp.power(
         eigenvalues + 2 * smoothness / lengthscale / lengthscale,
         -smoothness,

--- a/gpjax/kernels/nonstationary/arccosine.py
+++ b/gpjax/kernels/nonstationary/arccosine.py
@@ -19,7 +19,7 @@ import jax.numpy as jnp
 from jaxtyping import Float
 from paramax import AbstractUnwrappable
 
-from gpjax.kernels.base import AbstractKernel, _val
+from gpjax.kernels.base import AbstractKernel, val
 from gpjax.kernels.computations import (
     AbstractKernelComputation,
     DenseKernelComputation,
@@ -108,7 +108,7 @@ class ArcCosine(AbstractKernel):
         K = self._J(theta)
         K *= jnp.sqrt(x_x) ** self.order
         K *= jnp.sqrt(y_y) ** self.order
-        K *= _val(self.variance) / jnp.pi
+        K *= val(self.variance) / jnp.pi
 
         return K.squeeze()
 
@@ -123,7 +123,7 @@ class ArcCosine(AbstractKernel):
         Returns:
             ScalarFloat: The value of the weighted product between the two arguments``.
         """
-        return jnp.inner(_val(self.weight_variance) * x, y) + _val(self.bias_variance)
+        return jnp.inner(val(self.weight_variance) * x, y) + val(self.bias_variance)
 
     def _J(self, theta: ScalarFloat) -> ScalarFloat:
         r"""Evaluate the angular dependency function corresponding to the desired order.

--- a/gpjax/kernels/nonstationary/linear.py
+++ b/gpjax/kernels/nonstationary/linear.py
@@ -18,7 +18,7 @@ import jax.numpy as jnp
 from jaxtyping import Float
 from paramax import AbstractUnwrappable
 
-from gpjax.kernels.base import AbstractKernel, _val
+from gpjax.kernels.base import AbstractKernel, val
 from gpjax.kernels.computations import (
     AbstractKernelComputation,
     DenseKernelComputation,
@@ -73,5 +73,5 @@ class Linear(AbstractKernel):
     ) -> ScalarFloat:
         x = self.slice_input(x)
         y = self.slice_input(y)
-        K = _val(self.variance) * jnp.matmul(x.T, y)
+        K = val(self.variance) * jnp.matmul(x.T, y)
         return K.squeeze()

--- a/gpjax/kernels/nonstationary/polynomial.py
+++ b/gpjax/kernels/nonstationary/polynomial.py
@@ -19,7 +19,7 @@ import jax.numpy as jnp
 from jaxtyping import Float
 from paramax import AbstractUnwrappable
 
-from gpjax.kernels.base import AbstractKernel, _val
+from gpjax.kernels.base import AbstractKernel, val
 from gpjax.kernels.computations import (
     AbstractKernelComputation,
     DenseKernelComputation,
@@ -82,7 +82,5 @@ class Polynomial(AbstractKernel):
     def __call__(self, x: Float[Array, " D"], y: Float[Array, " D"]) -> ScalarFloat:
         x = self.slice_input(x)
         y = self.slice_input(y)
-        K = jnp.power(
-            _val(self.shift) + _val(self.variance) * jnp.dot(x, y), self.degree
-        )
+        K = jnp.power(val(self.shift) + val(self.variance) * jnp.dot(x, y), self.degree)
         return K.squeeze()

--- a/gpjax/kernels/stationary/base.py
+++ b/gpjax/kernels/stationary/base.py
@@ -21,7 +21,7 @@ from jaxtyping import Float
 import numpyro.distributions as npd
 from paramax import AbstractUnwrappable
 
-from gpjax.kernels.base import AbstractKernel, _val
+from gpjax.kernels.base import AbstractKernel, val
 from gpjax.kernels.computations import (
     AbstractKernelComputation,
     DenseKernelComputation,
@@ -110,7 +110,7 @@ class StationaryKernel(AbstractKernel):
                 "in order to construct its spectral measure. Please specify the "
                 "n_dims argument for the kernel."
             )
-        return jnp.diag(jnp.ones(self.n_dims) / _val(self.lengthscale))
+        return jnp.diag(jnp.ones(self.n_dims) / val(self.lengthscale))
 
     @property
     def spectral_density(self) -> npd.MultivariateNormal | npd.MultivariateStudentT:
@@ -165,7 +165,7 @@ def _check_lengthscale_dims_compat(
     """
 
     if isinstance(lengthscale, AbstractUnwrappable):
-        return _check_lengthscale_dims_compat(_val(lengthscale), n_dims)
+        return _check_lengthscale_dims_compat(val(lengthscale), n_dims)
 
     lengthscale = jnp.asarray(lengthscale)
     ls_shape = jnp.shape(lengthscale)
@@ -188,7 +188,7 @@ def _check_lengthscale(lengthscale: tp.Any):
     """Check that the lengthscale is a valid value."""
 
     if isinstance(lengthscale, AbstractUnwrappable):
-        _check_lengthscale(_val(lengthscale))
+        _check_lengthscale(val(lengthscale))
         return
 
     if not isinstance(lengthscale, (int, float, jnp.ndarray, list, tuple)):

--- a/gpjax/kernels/stationary/matern12.py
+++ b/gpjax/kernels/stationary/matern12.py
@@ -19,7 +19,7 @@ import jax.numpy as jnp
 from jaxtyping import Float
 import numpyro.distributions as npd
 
-from gpjax.kernels.base import _val
+from gpjax.kernels.base import val
 from gpjax.kernels.stationary.base import StationaryKernel
 from gpjax.kernels.stationary.utils import (
     build_student_t_distribution,
@@ -45,9 +45,9 @@ class Matern12(StationaryKernel):
     name: ClassVar[str] = "Matérn12"
 
     def __call__(self, x: Float[Array, " D"], y: Float[Array, " D"]) -> ScalarFloat:
-        x = self.slice_input(x) / _val(self.lengthscale)
-        y = self.slice_input(y) / _val(self.lengthscale)
-        K = _val(self.variance) * jnp.exp(-euclidean_distance(x, y))
+        x = self.slice_input(x) / val(self.lengthscale)
+        y = self.slice_input(y) / val(self.lengthscale)
+        K = val(self.variance) * jnp.exp(-euclidean_distance(x, y))
         return K.squeeze()
 
     @property

--- a/gpjax/kernels/stationary/matern32.py
+++ b/gpjax/kernels/stationary/matern32.py
@@ -19,7 +19,7 @@ import jax.numpy as jnp
 from jaxtyping import Float
 import numpyro.distributions as npd
 
-from gpjax.kernels.base import _val
+from gpjax.kernels.base import val
 from gpjax.kernels.stationary.base import StationaryKernel
 from gpjax.kernels.stationary.utils import (
     build_student_t_distribution,
@@ -46,11 +46,11 @@ class Matern32(StationaryKernel):
         x: Float[Array, " D"],
         y: Float[Array, " D"],
     ) -> Float[Array, ""]:
-        x = self.slice_input(x) / _val(self.lengthscale)
-        y = self.slice_input(y) / _val(self.lengthscale)
+        x = self.slice_input(x) / val(self.lengthscale)
+        y = self.slice_input(y) / val(self.lengthscale)
         tau = euclidean_distance(x, y)
         K = (
-            _val(self.variance)
+            val(self.variance)
             * (1.0 + jnp.sqrt(3.0) * tau)
             * jnp.exp(-jnp.sqrt(3.0) * tau)
         )

--- a/gpjax/kernels/stationary/matern52.py
+++ b/gpjax/kernels/stationary/matern52.py
@@ -19,7 +19,7 @@ import jax.numpy as jnp
 from jaxtyping import Float
 import numpyro.distributions as npd
 
-from gpjax.kernels.base import _val
+from gpjax.kernels.base import val
 from gpjax.kernels.stationary.base import StationaryKernel
 from gpjax.kernels.stationary.utils import (
     build_student_t_distribution,
@@ -45,11 +45,11 @@ class Matern52(StationaryKernel):
     def __call__(
         self, x: Float[Array, " D"], y: Float[Array, " D"]
     ) -> Float[Array, ""]:
-        x = self.slice_input(x) / _val(self.lengthscale)
-        y = self.slice_input(y) / _val(self.lengthscale)
+        x = self.slice_input(x) / val(self.lengthscale)
+        y = self.slice_input(y) / val(self.lengthscale)
         tau = euclidean_distance(x, y)
         K = (
-            _val(self.variance)
+            val(self.variance)
             * (1.0 + jnp.sqrt(5.0) * tau + 5.0 / 3.0 * jnp.square(tau))
             * jnp.exp(-jnp.sqrt(5.0) * tau)
         )

--- a/gpjax/kernels/stationary/periodic.py
+++ b/gpjax/kernels/stationary/periodic.py
@@ -20,7 +20,7 @@ import jax.numpy as jnp
 from jaxtyping import Float
 from paramax import AbstractUnwrappable
 
-from gpjax.kernels.base import _val
+from gpjax.kernels.base import val
 from gpjax.kernels.computations import (
     AbstractKernelComputation,
     DenseKernelComputation,
@@ -88,9 +88,9 @@ class Periodic(StationaryKernel):
     ) -> Float[Array, ""]:
         x = self.slice_input(x)
         y = self.slice_input(y)
-        period_val = _val(self.period)
+        period_val = val(self.period)
         sine_squared = (
-            jnp.sin(jnp.pi * (x - y) / period_val) / _val(self.lengthscale)
+            jnp.sin(jnp.pi * (x - y) / period_val) / val(self.lengthscale)
         ) ** 2
-        K = _val(self.variance) * jnp.exp(-0.5 * jnp.sum(sine_squared, axis=0))
+        K = val(self.variance) * jnp.exp(-0.5 * jnp.sum(sine_squared, axis=0))
         return K.squeeze()

--- a/gpjax/kernels/stationary/powered_exponential.py
+++ b/gpjax/kernels/stationary/powered_exponential.py
@@ -20,7 +20,7 @@ import jax.numpy as jnp
 from jaxtyping import Float
 from paramax import AbstractUnwrappable
 
-from gpjax.kernels.base import _val
+from gpjax.kernels.base import val
 from gpjax.kernels.computations import (
     AbstractKernelComputation,
     DenseKernelComputation,
@@ -86,8 +86,8 @@ class PoweredExponential(StationaryKernel):
     def __call__(
         self, x: Float[Array, " D"], y: Float[Array, " D"]
     ) -> Float[Array, ""]:
-        x = self.slice_input(x) / _val(self.lengthscale)
-        y = self.slice_input(y) / _val(self.lengthscale)
-        power_val = _val(self.power)
-        K = _val(self.variance) * jnp.exp(-(euclidean_distance(x, y) ** power_val))
+        x = self.slice_input(x) / val(self.lengthscale)
+        y = self.slice_input(y) / val(self.lengthscale)
+        power_val = val(self.power)
+        K = val(self.variance) * jnp.exp(-(euclidean_distance(x, y) ** power_val))
         return K.squeeze()

--- a/gpjax/kernels/stationary/rational_quadratic.py
+++ b/gpjax/kernels/stationary/rational_quadratic.py
@@ -19,7 +19,7 @@ import beartype.typing as tp
 from jaxtyping import Float
 from paramax import AbstractUnwrappable
 
-from gpjax.kernels.base import _val
+from gpjax.kernels.base import val
 from gpjax.kernels.computations import (
     AbstractKernelComputation,
     DenseKernelComputation,
@@ -82,10 +82,10 @@ class RationalQuadratic(StationaryKernel):
         super().__init__(active_dims, lengthscale, variance, n_dims, compute_engine)
 
     def __call__(self, x: Float[Array, " D"], y: Float[Array, " D"]) -> ScalarFloat:
-        x = self.slice_input(x) / _val(self.lengthscale)
-        y = self.slice_input(y) / _val(self.lengthscale)
-        alpha_val = _val(self.alpha)
-        K = _val(self.variance) * (1 + 0.5 * squared_distance(x, y) / alpha_val) ** (
+        x = self.slice_input(x) / val(self.lengthscale)
+        y = self.slice_input(y) / val(self.lengthscale)
+        alpha_val = val(self.alpha)
+        K = val(self.variance) * (1 + 0.5 * squared_distance(x, y) / alpha_val) ** (
             -alpha_val
         )
         return K.squeeze()

--- a/gpjax/kernels/stationary/rbf.py
+++ b/gpjax/kernels/stationary/rbf.py
@@ -19,7 +19,7 @@ import jax.numpy as jnp
 from jaxtyping import Float
 import numpyro.distributions as npd
 
-from gpjax.kernels.base import _val
+from gpjax.kernels.base import val
 from gpjax.kernels.stationary.base import StationaryKernel
 from gpjax.kernels.stationary.utils import squared_distance
 from gpjax.typing import (
@@ -41,9 +41,9 @@ class RBF(StationaryKernel):
     name: ClassVar[str] = "RBF"
 
     def __call__(self, x: Float[Array, " D"], y: Float[Array, " D"]) -> ScalarFloat:
-        x = self.slice_input(x) / _val(self.lengthscale)
-        y = self.slice_input(y) / _val(self.lengthscale)
-        K = _val(self.variance) * jnp.exp(-0.5 * squared_distance(x, y))
+        x = self.slice_input(x) / val(self.lengthscale)
+        y = self.slice_input(y) / val(self.lengthscale)
+        K = val(self.variance) * jnp.exp(-0.5 * squared_distance(x, y))
         return K.squeeze()
 
     @property

--- a/gpjax/kernels/stationary/white.py
+++ b/gpjax/kernels/stationary/white.py
@@ -18,7 +18,7 @@ import jax.numpy as jnp
 from jaxtyping import Float
 from paramax import AbstractUnwrappable
 
-from gpjax.kernels.base import AbstractKernel, _val
+from gpjax.kernels.base import AbstractKernel, val
 from gpjax.kernels.computations import (
     AbstractKernelComputation,
     ConstantDiagonalKernelComputation,
@@ -77,5 +77,5 @@ class White(StationaryKernel):
             self.variance = NonNegativeReal(variance)
 
     def __call__(self, x: Float[Array, " D"], y: Float[Array, " D"]) -> ScalarFloat:
-        K = jnp.all(jnp.equal(x, y)) * _val(self.variance)
+        K = jnp.all(jnp.equal(x, y)) * val(self.variance)
         return K.squeeze()

--- a/gpjax/likelihoods.py
+++ b/gpjax/likelihoods.py
@@ -36,7 +36,7 @@ from gpjax.integrators import (
 from gpjax.parameters import (
     NonNegativeReal,
     PositiveReal,
-    _val,
+    val,
 )
 from gpjax.summary import _SummaryMixin
 from gpjax.typing import (
@@ -347,7 +347,7 @@ class Gaussian(AbstractLikelihood):
         Returns:
             npd.Normal: The likelihood function.
         """
-        return npd.Normal(loc=f, scale=_val(self.obs_stddev).astype(f.dtype))
+        return npd.Normal(loc=f, scale=val(self.obs_stddev).astype(f.dtype))
 
     def predict(
         self, dist: tp.Union[npd.MultivariateNormal, GaussianDistribution]
@@ -368,7 +368,7 @@ class Gaussian(AbstractLikelihood):
             GaussianDistribution: The predictive distribution with observation
             noise added to the diagonal of the covariance.
         """
-        obs_var = _val(self.obs_stddev) ** 2
+        obs_var = val(self.obs_stddev) ** 2
 
         if isinstance(dist, GaussianDistribution):
             diag = _diagonal_scale(dist.scale)
@@ -385,7 +385,7 @@ class Gaussian(AbstractLikelihood):
 
     def noise_vector(self, n: int) -> Float[Array, " N"]:
         """Per-observation noise variance vector (scalar broadcast for single-output)."""
-        return jnp.full(n, jnp.square(_val(self.obs_stddev)))
+        return jnp.full(n, jnp.square(val(self.obs_stddev)))
 
     def prepare_targets(
         self, y: Float[Array, "N 1"], mx: Float[Array, "N 1"]
@@ -420,7 +420,7 @@ class MultiOutputGaussian(Gaussian):
         Returns sigma_p^2 with each output's variance repeated N times,
         concatenated across outputs: [sigma_1^2...sigma_1^2, sigma_2^2...sigma_2^2, ...].
         """
-        per_output_var = jnp.square(_val(self.obs_stddev))  # [P]
+        per_output_var = jnp.square(val(self.obs_stddev))  # [P]
         return jnp.repeat(per_output_var, n)  # [NP]
 
     def prepare_targets(
@@ -647,9 +647,9 @@ class StudentT(AbstractLikelihood):
             npd.StudentT: The likelihood function.
         """
         return npd.StudentT(
-            df=_val(self.degrees_of_freedom),
+            df=val(self.degrees_of_freedom),
             loc=f,
-            scale=_val(self.scale).astype(f.dtype),
+            scale=val(self.scale).astype(f.dtype),
         )
 
     def predict(

--- a/gpjax/mean_functions.py
+++ b/gpjax/mean_functions.py
@@ -27,7 +27,7 @@ from jaxtyping import (
 import paramax
 from paramax import AbstractUnwrappable
 
-from gpjax.parameters import _val
+from gpjax.parameters import val
 from gpjax.summary import _SummaryMixin
 from gpjax.typing import (
     Array,
@@ -146,7 +146,7 @@ class Constant(AbstractMeanFunction):
         Returns:
             Float[Array, "1"]: The evaluated mean function.
         """
-        return jnp.ones((x.shape[0], 1), dtype=x.dtype) * _val(self.constant)
+        return jnp.ones((x.shape[0], 1), dtype=x.dtype) * val(self.constant)
 
 
 class Zero(Constant):

--- a/gpjax/models/oilmm.py
+++ b/gpjax/models/oilmm.py
@@ -24,7 +24,7 @@ import lineax as lx
 
 from gpjax.conditioning import Posterior
 from gpjax.distributions import GaussianDistribution
-from gpjax.parameters import NonNegativeReal, PositiveReal, Real, _val
+from gpjax.parameters import NonNegativeReal, PositiveReal, Real, val
 from gpjax.typing import ScalarFloat
 
 if tp.TYPE_CHECKING:
@@ -104,18 +104,18 @@ class OrthogonalMixingMatrix(eqx.Module):
         Uses SVD to project U_latent onto the Stiefel manifold (orthonormal columns).
         This ensures U^T U = I_m exactly.
         """
-        U_svd, _, Vt_svd = jnp.linalg.svd(_val(self.U_latent), full_matrices=False)
+        U_svd, _, Vt_svd = jnp.linalg.svd(val(self.U_latent), full_matrices=False)
         return U_svd @ Vt_svd
 
     @property
     def sqrt_S(self) -> Float[Array, " M"]:
         """Square root of S diagonal: S^(1/2)."""
-        return jnp.sqrt(_val(self.S))
+        return jnp.sqrt(val(self.S))
 
     @property
     def inv_sqrt_S(self) -> Float[Array, " M"]:
         """Inverse square root of S diagonal: S^(-1/2)."""
-        return 1.0 / jnp.sqrt(_val(self.S))
+        return 1.0 / jnp.sqrt(val(self.S))
 
     @property
     def H(self) -> Float[Array, "P M"]:
@@ -158,7 +158,7 @@ class OrthogonalMixingMatrix(eqx.Module):
         Returns:
             Array of shape [M] with noise variance for each latent GP.
         """
-        return _val(self.obs_noise_variance) * self.inv_sqrt_S**2 + _val(
+        return val(self.obs_noise_variance) * self.inv_sqrt_S**2 + val(
             self.latent_noise_variance
         )
 
@@ -327,8 +327,8 @@ def _projection_correction(model: OILMMModel, data: Dataset) -> ScalarFloat:
     mix = model.mixing_matrix
 
     U = mix.U  # [P, M]
-    S = _val(mix.S)  # [M]
-    sigma2 = _val(mix.obs_noise_variance)  # scalar
+    S = val(mix.S)  # [M]
+    sigma2 = val(mix.obs_noise_variance)  # scalar
 
     # -(n/2) log|S|, with |S| = prod(S_i).
     term_log_S = -0.5 * num_data * jnp.sum(jnp.log(S))

--- a/gpjax/natural_gradients.py
+++ b/gpjax/natural_gradients.py
@@ -87,7 +87,7 @@ from gpjax.objectives import Objective
 from gpjax.parameters import (
     LowerTriangular,
     Real,
-    _val,
+    val,
 )
 from gpjax.typing import (
     Array,
@@ -639,7 +639,6 @@ def natural_gradient_step(
         >>> jax.config.update("jax_enable_x64", True)
         >>> import jax.numpy as jnp
         >>> import equinox as eqx
-        >>> import paramax
         >>> import gpjax as gpx
         >>> from gpjax.natural_gradients import (
         ...     natural_gradient_step,
@@ -661,7 +660,7 @@ def natural_gradient_step(
         >>> stepped, loss = natural_gradient_step(
         ...     variational, hyper, D, negative_elbo, jnp.asarray(1.0)
         ... )
-        >>> updated = paramax.unwrap(eqx.combine(stepped, hyper))
+        >>> updated = eqx.combine(stepped, hyper)
         >>> bool(loss > -gpx.objectives.elbo(updated, D))
         True
     """
@@ -718,9 +717,8 @@ def _variational_gaussian_step(
     _reject_frozen_coordinates(variational)
 
     family = eqx.combine(variational, hyper)
-    unwrapped = paramax.unwrap(family)
-    initial_mean = _val(unwrapped.variational_mean)
-    initial_root_covariance = _val(unwrapped.variational_root_covariance)
+    initial_mean = val(family.variational_mean)
+    initial_root_covariance = val(family.variational_root_covariance)
 
     # theta_0 comes from L directly, never by round-tripping through eta_0: the
     # detour costs an extra Cholesky and passes through a cancellation site.
@@ -742,7 +740,7 @@ def _variational_gaussian_step(
             family,
             (Real(trial_mean), LowerTriangular(trial_root_covariance)),
         )
-        return objective(paramax.unwrap(trial), data)
+        return objective(trial, data)
 
     loss_value, gradient = jax.value_and_grad(loss_of_expectation)(initial_expectation)
     # H_2 is symmetric, so the gradient must be read in the trace pairing on Sym(M).
@@ -875,7 +873,7 @@ def _dual_variational_gaussian_step(
     del map_jitter, backoff, max_backoff
     _reject_frozen_coordinates(variational)
 
-    family = paramax.unwrap(eqx.combine(variational, hyper))
+    family = eqx.combine(variational, hyper)
 
     # One extra forward pass, taken deliberately: it makes `history[t]` the loss at the
     # pre-update parameters, exactly as in `fit` and in the Salimbeni branch. XLA
@@ -917,8 +915,8 @@ def _dual_variational_gaussian_step(
     target_matrix = _symmetrise(design @ (beta[:, None] * design.T))
 
     rate = natgrad_lr
-    stored_vector = _val(family.dual_vector)
-    stored_matrix = _val(family.dual_matrix)
+    stored_vector = val(family.dual_vector)
+    stored_matrix = val(family.dual_matrix)
 
     # `add_jitter` builds its identity at the default float type, so under
     # `jax_enable_x64` everything downstream of K_zz is float64 even for a float32

--- a/gpjax/objectives.py
+++ b/gpjax/objectives.py
@@ -32,92 +32,6 @@ Objective = tpe.Callable[[eqx.Module, Dataset], ScalarFloat]
 LogPriorFn = tpe.Callable[[eqx.Module], ScalarFloat]
 
 
-def with_log_prior(objective: Objective, log_prior: LogPriorFn) -> Objective:
-    r"""Regularise an objective with a user-supplied log-prior over the model.
-
-    Adds a scalar log-prior density, evaluated on the model's hyperparameters,
-    to an existing objective. The result is a new :data:`Objective` that can be
-    passed straight to :func:`gpjax.fit`, :func:`gpjax.fit_scipy`, or
-    :func:`gpjax.fit_lbfgs`, giving GPyTorch-style MAP-regularised fitting: the
-    optimiser still climbs the marginal log-likelihood, but is nudged towards
-    prior-consistent hyperparameters rather than whatever the data alone would
-    pick. A common motivating use is discouraging small, overfitting-prone
-    lengthscales or noise variances in high dimensions, by preferring a broad
-    prior that favours larger values.
-
-    This intentionally does not resurrect the pre-v1 ``Parameter(...,
-    prior=...)`` field (removed in #621): attaching a prior to every
-    ``Parameter`` tangled the constrained/unconstrained bijection with an
-    ambiguous "is this prior for gradient-based optimisation or for NumPyro
-    MCMC?" scope, and duplicated the fully Bayesian path. Here the prior is
-    not attached to any ``Parameter`` at all -- it is a plain function the
-    caller writes directly over the model pytree, composed with an objective
-    via ordinary addition. This keeps regularised MLE/MAP fitting completely
-    separate from the fully Bayesian, NumPyro-based path (``numpyro.sample``
-    fed straight into GPJax constructors, see ``gpjax.objectives`` usage in
-    the NumPyro integration example): no new field on ``Parameter``, no
-    change to ``fit``/``fit_scipy``/``fit_lbfgs``, and the existing
-    NumPyro path and plain (unregularised) objectives are untouched.
-
-    Note:
-        ``log_prior`` is evaluated on the *constrained* parameter values --
-        the same values ``objective`` itself receives, since both run after
-        ``paramax.unwrap``. It does not include the change-of-variables
-        Jacobian for the unconstrained space the optimiser actually moves
-        in, so the resulting mode is a useful regularised estimate rather
-        than the literal Bayesian MAP under a formal change of variables.
-        For the strongly regularising priors this feature targets, that
-        distinction rarely matters in practice.
-
-    Example:
-        >>> import gpjax as gpx
-        >>> import jax.numpy as jnp
-        >>> import numpyro.distributions as dist
-        >>> import optax as ox
-        >>>
-        >>> xtrain = jnp.linspace(0, 1, 50).reshape(-1, 1)
-        >>> ytrain = jnp.sin(xtrain)
-        >>> D = gpx.Dataset(X=xtrain, y=ytrain)
-        >>>
-        >>> meanf = gpx.mean_functions.Constant()
-        >>> kernel = gpx.kernels.RBF()
-        >>> likelihood = gpx.likelihoods.Gaussian()
-        >>> posterior = gpx.gps.Prior(mean_function=meanf, kernel=kernel) * likelihood
-        >>>
-        >>> def log_prior(model):
-        ...     lengthscale = model.prior.kernel.lengthscale
-        ...     return dist.LogNormal(jnp.log(5.0), 0.5).log_prob(lengthscale).sum()
-        >>>
-        >>> regularised_mll = gpx.objectives.with_log_prior(
-        ...     gpx.objectives.conjugate_mll, log_prior
-        ... )
-        >>> nmll = lambda p, d: -regularised_mll(p, d)
-        >>> trained_model, history = gpx.fit(
-        ...     model=posterior, objective=nmll, train_data=D,
-        ...     optim=ox.adam(0.01), num_iters=100, verbose=False,
-        ... )
-
-    Args:
-        objective (Objective): The objective to regularise, e.g.
-            ``conjugate_mll`` or ``elbo``. Called as ``objective(model,
-            data)`` with the model's parameters already unwrapped to their
-            constrained space.
-        log_prior (LogPriorFn): A callable that receives the same unwrapped
-            model and returns a scalar log-density. Typically built from
-            ``numpyro.distributions`` log-probabilities evaluated on
-            whichever leaves of the model the caller wants to regularise.
-
-    Returns:
-        Objective: A new objective computing
-        ``objective(model, data) + log_prior(model)``.
-    """
-
-    def _regularised_objective(model: eqx.Module, data: Dataset) -> ScalarFloat:
-        return objective(model, data) + log_prior(model)
-
-    return _regularised_objective
-
-
 def conjugate_mll(model: ConjugateModel, data: Dataset) -> ScalarFloat:
     r"""Evaluate the marginal log-likelihood of the Gaussian process.
 
@@ -608,5 +522,4 @@ __all__ = [
     "log_posterior_density",
     "non_conjugate_mll",
     "variational_expectation",
-    "with_log_prior",
 ]

--- a/gpjax/parameters.py
+++ b/gpjax/parameters.py
@@ -55,8 +55,31 @@ class _DtypePreservingSoftplusLowerCholeskyTransform(SoftplusLowerCholeskyTransf
 _dtype_preserving_lower_cholesky = _DtypePreservingSoftplusLowerCholeskyTransform()
 
 
-def _val(x):
-    """Unwrap a paramax parameter or return the value directly."""
+def val(x):
+    """Return a parameter's constrained value.
+
+    Call this wherever a parameter meets arithmetic. Models are always held in
+    their wrapped form -- including the model ``fit`` returns -- so ``val`` is
+    the single point at which the constraining bijection is applied.
+
+    Safe to apply to anything: a parameter is resolved to its constrained value
+    (recursively, so nested wrappers such as ``paramax.non_trainable`` are
+    handled), while a plain array or float is returned unchanged.
+
+    Args:
+        x: A parameter, or any value that does not need unwrapping.
+
+    Returns:
+        The constrained value of ``x`` if it is a parameter, else ``x`` itself.
+
+    Example:
+        >>> import jax.numpy as jnp
+        >>> from gpjax.parameters import PositiveReal, val
+        >>> float(val(PositiveReal(jnp.array(2.0))))
+        2.0
+        >>> float(val(jnp.array(2.0)))
+        2.0
+    """
     return paramax.unwrap(x) if isinstance(x, AbstractUnwrappable) else x
 
 
@@ -165,8 +188,8 @@ class CoregionalizationMatrix(eqx.Module):
 
     @property
     def B(self) -> jnp.ndarray:
-        w = _val(self.W)
-        k = _val(self.kappa)
+        w = val(self.W)
+        k = val(self.kappa)
         return w @ w.T + jnp.diag(k)
 
 
@@ -177,4 +200,5 @@ __all__ = [
     "PositiveReal",
     "Real",
     "SigmoidBounded",
+    "val",
 ]

--- a/gpjax/state_space/_validation.py
+++ b/gpjax/state_space/_validation.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import warnings
 
 import jax.numpy as jnp
-import paramax
+
+from gpjax.parameters import val
 
 
 def _validate_temporal_kernel(kernel) -> None:
@@ -14,7 +15,7 @@ def _validate_temporal_kernel(kernel) -> None:
     State-space GPs require kernels with scalar lengthscale, no active_dims
     selection (or trivial ``slice(None)``), and ``n_dims`` either ``None`` or 1.
     """
-    lengthscale = paramax.unwrap(kernel.lengthscale)
+    lengthscale = val(kernel.lengthscale)
     if jnp.asarray(lengthscale).ndim != 0:
         raise ValueError(
             "State-space kernels require a scalar lengthscale (1-D temporal input). "

--- a/gpjax/state_space/gps.py
+++ b/gpjax/state_space/gps.py
@@ -14,13 +14,13 @@ from jaxtyping import (
     Num,
 )
 import lineax as lx
-import paramax
 
 from gpjax.dataset import Dataset
 from gpjax.distributions import GaussianDistribution
 from gpjax.gps import ConjugateModel, Prior
 from gpjax.likelihoods import Gaussian, MultiOutputGaussian
 from gpjax.linalg.utils import add_jitter
+from gpjax.parameters import val
 from gpjax.state_space.conditioning import StateSpacePosterior
 from gpjax.typing import Array
 
@@ -244,7 +244,7 @@ def _require_scalar_gaussian_likelihood(likelihood) -> None:
             f"State-space inference requires a Gaussian (conjugate) likelihood; "
             f"got {type(likelihood).__name__}."
         )
-    obs_stddev_value = paramax.unwrap(likelihood.obs_stddev)
+    obs_stddev_value = val(likelihood.obs_stddev)
     if jnp.asarray(obs_stddev_value).ndim != 0:
         raise ValueError(
             f"State-space Gaussian likelihood requires a scalar obs_stddev; "

--- a/gpjax/state_space/kernels.py
+++ b/gpjax/state_space/kernels.py
@@ -15,7 +15,7 @@ from gpjax.kernels.stationary.matern12 import Matern12
 from gpjax.kernels.stationary.matern32 import Matern32
 from gpjax.kernels.stationary.matern52 import Matern52
 from gpjax.kernels.stationary.periodic import Periodic
-from gpjax.parameters import PositiveReal
+from gpjax.parameters import PositiveReal, val
 from gpjax.state_space._bessel import _stable_scaled_ive
 from gpjax.state_space._validation import _validate_temporal_kernel
 from gpjax.state_space.sde import (
@@ -83,9 +83,9 @@ class TruncatedPeriodic(StationaryKernel):
     def __call__(self, x, y):
         tau = self.slice_input(x) - self.slice_input(y)
         tau_scalar = jnp.squeeze(tau)
-        lengthscale = paramax.unwrap(self.lengthscale)
-        variance = paramax.unwrap(self.variance)
-        period = paramax.unwrap(self.period)
+        lengthscale = val(self.lengthscale)
+        variance = val(self.variance)
+        period = val(self.period)
         truncation_order = self.truncation_order
 
         bessel_argument = 1.0 / (4.0 * lengthscale**2)
@@ -121,8 +121,8 @@ def to_sde(kernel) -> LinearSDE:
 def _to_sde_matern12(kernel: Matern12) -> Matern12SDE:
     _validate_temporal_kernel(kernel)
     return Matern12SDE(
-        lengthscale=paramax.unwrap(kernel.lengthscale),
-        variance=paramax.unwrap(kernel.variance),
+        lengthscale=val(kernel.lengthscale),
+        variance=val(kernel.variance),
     )
 
 
@@ -130,8 +130,8 @@ def _to_sde_matern12(kernel: Matern12) -> Matern12SDE:
 def _to_sde_matern32(kernel: Matern32) -> Matern32SDE:
     _validate_temporal_kernel(kernel)
     return Matern32SDE(
-        lengthscale=paramax.unwrap(kernel.lengthscale),
-        variance=paramax.unwrap(kernel.variance),
+        lengthscale=val(kernel.lengthscale),
+        variance=val(kernel.variance),
     )
 
 
@@ -139,8 +139,8 @@ def _to_sde_matern32(kernel: Matern32) -> Matern32SDE:
 def _to_sde_matern52(kernel: Matern52) -> Matern52SDE:
     _validate_temporal_kernel(kernel)
     return Matern52SDE(
-        lengthscale=paramax.unwrap(kernel.lengthscale),
-        variance=paramax.unwrap(kernel.variance),
+        lengthscale=val(kernel.lengthscale),
+        variance=val(kernel.variance),
     )
 
 
@@ -148,9 +148,9 @@ def _to_sde_matern52(kernel: Matern52) -> Matern52SDE:
 def _to_sde_truncated_periodic(kernel: TruncatedPeriodic) -> TruncatedPeriodicSDE:
     _validate_temporal_kernel(kernel)
     return TruncatedPeriodicSDE(
-        lengthscale=paramax.unwrap(kernel.lengthscale),
-        variance=paramax.unwrap(kernel.variance),
-        period=paramax.unwrap(kernel.period),
+        lengthscale=val(kernel.lengthscale),
+        variance=val(kernel.variance),
+        period=val(kernel.period),
         truncation_order=kernel.truncation_order,
     )
 

--- a/gpjax/state_space/objectives.py
+++ b/gpjax/state_space/objectives.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import jax.numpy as jnp
-import paramax
 
+from gpjax.parameters import val
 from gpjax.state_space.inference import kalman_filter
 from gpjax.state_space.kernels import to_sde
 
@@ -52,7 +52,6 @@ def state_space_mll(
         >>> bool(jnp.isfinite(mll))
         True
     """
-    posterior = paramax.unwrap(posterior)
     prior = posterior.prior
     likelihood = posterior.likelihood
 
@@ -65,7 +64,7 @@ def state_space_mll(
     centred_targets = targets - mean_at_train
 
     sde = to_sde(prior.kernel)
-    obs_variance = likelihood.obs_stddev**2
+    obs_variance = val(likelihood.obs_stddev) ** 2
     sigma_eff = jnp.sqrt(obs_variance + prior.jitter)
 
     time_steps = jnp.concatenate([jnp.zeros(1), jnp.diff(times)])

--- a/gpjax/state_space/prediction.py
+++ b/gpjax/state_space/prediction.py
@@ -10,10 +10,10 @@ from typing import Literal
 import jax
 import jax.numpy as jnp
 import lineax as lx
-import paramax
 
 from gpjax.distributions import GaussianDistribution
 from gpjax.linalg.utils import add_jitter
+from gpjax.parameters import val
 from gpjax.state_space.inference import _sqrt_filter_forward, rts_smoother
 from gpjax.state_space.kernels import to_sde
 
@@ -242,7 +242,6 @@ def predict_smoothed(
 
     See plans/2026-04-21-state-space-gps-design.md §Stage 4.
     """
-    posterior = paramax.unwrap(posterior)
     prior = posterior.prior
     likelihood = posterior.likelihood
 
@@ -257,7 +256,7 @@ def predict_smoothed(
     centred_targets = train_targets - mean_at_train
 
     sde = to_sde(prior.kernel)
-    obs_variance = likelihood.obs_stddev**2
+    obs_variance = val(likelihood.obs_stddev) ** 2
     sigma_eff = jnp.sqrt(obs_variance + prior.jitter)
 
     if observation_mask is None:
@@ -334,7 +333,6 @@ def predict_filtered(posterior, train_data, test_inputs, *, observation_mask=Non
 
     See plans/2026-04-21-state-space-gps-design.md §Stage 4.
     """
-    posterior = paramax.unwrap(posterior)
     prior = posterior.prior
     likelihood = posterior.likelihood
 
@@ -349,7 +347,7 @@ def predict_filtered(posterior, train_data, test_inputs, *, observation_mask=Non
     centred_targets = train_targets - mean_at_train
 
     sde = to_sde(prior.kernel)
-    obs_variance = likelihood.obs_stddev**2
+    obs_variance = val(likelihood.obs_stddev) ** 2
     sigma_eff = jnp.sqrt(obs_variance + prior.jitter)
 
     if observation_mask is None:

--- a/gpjax/variational_families.py
+++ b/gpjax/variational_families.py
@@ -52,7 +52,7 @@ from gpjax.mean_functions import AbstractMeanFunction
 from gpjax.parameters import (
     LowerTriangular,
     Real,
-    _val,
+    val,
 )
 from gpjax.summary import _SummaryMixin
 from gpjax.typing import (
@@ -208,7 +208,7 @@ class AbstractVariationalGaussian(AbstractVariationalFamily[L]):
     @property
     def num_inducing(self) -> int:
         """The number of inducing inputs."""
-        return _val(self.inducing_inputs).shape[0]
+        return val(self.inducing_inputs).shape[0]
 
     def _fmt_Kzt_Ktt(self, Kzt, Ktt):
         """Adapt the cross- and test-covariances before they enter ``predict``.
@@ -226,7 +226,7 @@ class AbstractVariationalGaussian(AbstractVariationalFamily[L]):
         An identity pass-through except for families whose inducing inputs are node
         indices rather than continuous coordinates.
         """
-        return _val(self.inducing_inputs)
+        return val(self.inducing_inputs)
 
 
 class VariationalGaussian(AbstractVariationalGaussian[L]):
@@ -298,8 +298,8 @@ class VariationalGaussian(AbstractVariationalGaussian[L]):
                 approximation and the GP prior.
         """
         # Unpack variational parameters
-        variational_mean = _val(self.variational_mean)
-        variational_sqrt = _val(self.variational_root_covariance)
+        variational_mean = val(self.variational_mean)
+        variational_sqrt = val(self.variational_root_covariance)
         inducing_inputs = self._fmt_inducing_inputs()
         num_inducing = self.num_inducing
 
@@ -355,8 +355,8 @@ class VariationalGaussian(AbstractVariationalGaussian[L]):
         del train_data
         return SparsePosterior(
             self,
-            _val(self.variational_mean),
-            _val(self.variational_root_covariance),
+            val(self.variational_mean),
+            val(self.variational_root_covariance),
             whitened=False,
         )
 
@@ -414,7 +414,7 @@ class GraphVariationalGaussian(VariationalGaussian[L]):
             variational_mean,
             variational_root_covariance,
         )
-        self.inducing_inputs = _val(self.inducing_inputs).astype(jnp.int64)
+        self.inducing_inputs = val(self.inducing_inputs).astype(jnp.int64)
 
     def _fmt_Kzt_Ktt(self, Kzt, Ktt):
         Ktt = Ktt.as_matrix() if hasattr(Ktt, "as_matrix") else Ktt
@@ -431,7 +431,7 @@ class GraphVariationalGaussian(VariationalGaussian[L]):
     @property
     def num_inducing(self) -> int:
         """The number of inducing inputs."""
-        return _val(self.inducing_inputs).shape[0]
+        return val(self.inducing_inputs).shape[0]
 
 
 class WhitenedVariationalGaussian(VariationalGaussian[L]):
@@ -478,8 +478,8 @@ class WhitenedVariationalGaussian(VariationalGaussian[L]):
                 approximation and the GP prior.
         """
         # Unpack variational parameters
-        mu = _val(self.variational_mean)
-        sqrt = _val(self.variational_root_covariance)
+        mu = val(self.variational_mean)
+        sqrt = val(self.variational_root_covariance)
 
         # mu^T I^{-1} mu, tr[S] = ||sqrt||_F^2 and log|S| = 2 sum log|sqrt_ii|.
         # The absolute value keeps the log-determinant valid for any square root,
@@ -510,8 +510,8 @@ class WhitenedVariationalGaussian(VariationalGaussian[L]):
         del train_data
         return SparsePosterior(
             self,
-            _val(self.variational_mean),
-            _val(self.variational_root_covariance),
+            val(self.variational_mean),
+            val(self.variational_root_covariance),
             whitened=True,
         )
 
@@ -652,7 +652,7 @@ class DualVariationalGaussian(AbstractVariationalGaussian[L]):
         """
         Kzz, Lk = self._gram_and_root()
 
-        dual_matrix = _val(self.dual_matrix)
+        dual_matrix = val(self.dual_matrix)
         inner = _symmetrise(Lk.T @ dual_matrix @ Lk) + jnp.eye(
             self.num_inducing, dtype=Kzz.dtype
         )
@@ -680,7 +680,7 @@ class DualVariationalGaussian(AbstractVariationalGaussian[L]):
                 of $q(u)$.
         """
         Kzz, _, Lr = self._working_matrices()
-        dual_vector = _val(self.dual_vector)
+        dual_vector = val(self.dual_vector)
         inducing_mean = self.model.prior.mean_function(self._fmt_inducing_inputs())
 
         covariance = _symmetrise(Kzz @ jsp.linalg.cho_solve((Lr, True), Kzz))
@@ -730,7 +730,7 @@ class DualVariationalGaussian(AbstractVariationalGaussian[L]):
                 variance at each input.
         """
         Kzz, Lk, Lr = self._working_matrices()
-        dual_vector = _val(self.dual_vector)
+        dual_vector = val(self.dual_vector)
         kernel = self.model.prior.kernel
         mean_function = self.model.prior.mean_function
         inducing_inputs = self._fmt_inducing_inputs()
@@ -780,7 +780,7 @@ class DualVariationalGaussian(AbstractVariationalGaussian[L]):
                 the GP prior.
         """
         Kzz, Lk, Lr = self._working_matrices()
-        dual_vector = _val(self.dual_vector)
+        dual_vector = val(self.dual_vector)
 
         # tr[R^{-1} Kzz] = tr[Lk^T R^{-1} Lk] = ||Lr^{-1} Lk||_F^2.
         trace = jnp.sum(jnp.square(_tri_solve(Lr, Lk)))

--- a/tests/_dual_helpers.py
+++ b/tests/_dual_helpers.py
@@ -7,7 +7,7 @@ family's implied moments. Written once here so that a change to the site convent
 cannot be applied to one copy and missed by the other two.
 """
 
-from gpjax.parameters import _val
+from gpjax.parameters import val
 from gpjax.variational_families import (
     DualVariationalGaussian,
     VariationalGaussian,
@@ -72,7 +72,7 @@ def matched_variational_gaussian(q_dual: DualVariationalGaussian):
     mean, covariance = q_dual.moments()
     return VariationalGaussian(
         model=q_dual.model,
-        inducing_inputs=_val(q_dual.inducing_inputs),
+        inducing_inputs=val(q_dual.inducing_inputs),
         variational_mean=mean,
         variational_root_covariance=jnp.linalg.cholesky(covariance),
     )

--- a/tests/_reference/conjugate_svgp.py
+++ b/tests/_reference/conjugate_svgp.py
@@ -8,11 +8,10 @@ transpose correction cannot be applied to one transcription and missed by the ot
 """
 
 from gpjax.linalg import add_jitter
-from gpjax.parameters import _val
+from gpjax.parameters import val
 from gpjax.variational_families import WhitenedVariationalGaussian
 import jax.numpy as jnp
 import jax.scipy as jsp
-import paramax
 
 
 def conjugate_optimum(variational_family, data, scale=None):
@@ -41,18 +40,18 @@ def conjugate_optimum(variational_family, data, scale=None):
     tuple
         ``(optimal_mean, optimal_covariance, precision)``.
     """
-    unwrapped = paramax.unwrap(variational_family)
-    inducing_inputs = _val(unwrapped.inducing_inputs)
-    kernel = unwrapped.model.prior.kernel
-    mean_function = unwrapped.model.prior.mean_function
+    inducing_inputs = val(variational_family.inducing_inputs)
+    kernel = variational_family.model.prior.kernel
+    mean_function = variational_family.model.prior.mean_function
 
     gram = add_jitter(
-        kernel.gram(inducing_inputs).as_matrix(), unwrapped.model.prior.jitter
+        kernel.gram(inducing_inputs).as_matrix(),
+        variational_family.model.prior.jitter,
     )
     cross = kernel.cross_covariance(data.X, inducing_inputs)
     inducing_mean = mean_function(inducing_inputs)
     input_mean = mean_function(data.X)
-    noise_variance = _val(unwrapped.model.likelihood.obs_stddev) ** 2
+    noise_variance = val(variational_family.model.likelihood.obs_stddev) ** 2
     if scale is None:
         full_size = data.n_total if data.n_total is not None else data.n
         scale = full_size / data.n

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -50,7 +50,7 @@ from gpjax.objectives import (
 )
 from gpjax.parameters import (
     PositiveReal,
-    _val,
+    val,
 )
 from gpjax.typing import Array
 from gpjax.variational_families import (
@@ -83,7 +83,7 @@ class LinearModel(eqx.Module):
         self.bias = bias
 
     def __call__(self, x):
-        return _val(self.weight) * x + self.bias
+        return val(self.weight) * x + self.bias
 
 
 # The mll and the elbo are both maximised, whereas fit functions minimise,
@@ -309,15 +309,15 @@ def test_fitters_hold_frozen_parameter_constant(run_fit) -> None:
     # Train!
     trained_model = run_fit(posterior, _negative_conjugate_mll, D)
 
-    before = paramax.unwrap(posterior)
-    after = paramax.unwrap(trained_model)
-
     # Ensure the frozen noise is held exactly
-    assert after.likelihood.obs_stddev == before.likelihood.obs_stddev
+    assert val(trained_model.likelihood.obs_stddev) == val(
+        posterior.likelihood.obs_stddev
+    )
 
     # Ensure the remaining hyperparameters are still optimised
     assert not jnp.allclose(
-        after.prior.kernel.lengthscale, before.prior.kernel.lengthscale
+        val(trained_model.prior.kernel.lengthscale),
+        val(posterior.prior.kernel.lengthscale),
     )
 
     # Ensure we improve the marginal log-likelihood
@@ -458,8 +458,8 @@ def test_fit_natgrads_simple() -> None:
 def test_fit_natgrads_gp_regression(n_data: int, verbose: bool) -> None:
     q, D = _svgp_setup(n_data=n_data)
 
-    initial_lengthscale = _val(paramax.unwrap(q).model.prior.kernel.lengthscale)
-    initial_obs_stddev = _val(paramax.unwrap(q).model.likelihood.obs_stddev)
+    initial_lengthscale = val(q.model.prior.kernel.lengthscale)
+    initial_obs_stddev = val(q.model.likelihood.obs_stddev)
 
     trained_model, history = fit_natgrads(
         model=q,
@@ -477,12 +477,11 @@ def test_fit_natgrads_gp_regression(n_data: int, verbose: bool) -> None:
     assert bool(jnp.all(jnp.isfinite(history)))
     assert history[-1] < history[0]
 
-    unwrapped = paramax.unwrap(trained_model)
     assert not jnp.allclose(
-        _val(unwrapped.model.prior.kernel.lengthscale), initial_lengthscale
+        val(trained_model.model.prior.kernel.lengthscale), initial_lengthscale
     )
     assert not jnp.allclose(
-        _val(unwrapped.model.likelihood.obs_stddev), initial_obs_stddev
+        val(trained_model.model.likelihood.obs_stddev), initial_obs_stddev
     )
 
 
@@ -510,9 +509,8 @@ def test_fit_natgrads_batch(
     assert isinstance(trained_model, VariationalGaussian)
     assert history.shape == (num_iters,)
     assert bool(jnp.all(jnp.isfinite(history)))
-    unwrapped = paramax.unwrap(trained_model)
-    assert bool(jnp.all(jnp.isfinite(_val(unwrapped.variational_mean))))
-    assert bool(jnp.all(jnp.isfinite(_val(unwrapped.variational_root_covariance))))
+    assert bool(jnp.all(jnp.isfinite(val(trained_model.variational_mean))))
+    assert bool(jnp.all(jnp.isfinite(val(trained_model.variational_root_covariance))))
 
 
 def test_fit_natgrads_conjugate_single_step_is_exact() -> None:
@@ -530,9 +528,8 @@ def test_fit_natgrads_conjugate_single_step_is_exact() -> None:
         verbose=False,
     )
 
-    unwrapped = paramax.unwrap(trained_model)
-    trained_mean = _val(unwrapped.variational_mean)
-    trained_root = _val(unwrapped.variational_root_covariance)
+    trained_mean = val(trained_model.variational_mean)
+    trained_root = val(trained_model.variational_root_covariance)
     optimal_mean, optimal_covariance = _conjugate_optimal_q(q, D)
 
     np.testing.assert_allclose(
@@ -561,7 +558,7 @@ def test_fit_natgrads_history_matches_fit_convention() -> None:
 
     np.testing.assert_allclose(
         np.float64(history[0]),
-        np.float64(_negative_elbo(paramax.unwrap(q), D)),
+        np.float64(_negative_elbo(q, D)),
         rtol=1e-12,
     )
 
@@ -589,7 +586,7 @@ def test_fit_natgrads_accepts_optax_schedule() -> None:
 def test_fit_natgrads_rejects_unsupported_family() -> None:
     q, D = _svgp_setup(n_data=20)
     collapsed = CollapsedVariationalGaussian(
-        model=q.model, inducing_inputs=_val(q.inducing_inputs)
+        model=q.model, inducing_inputs=val(q.inducing_inputs)
     )
 
     with pytest.raises(NotImplementedError, match="CollapsedVariationalGaussian"):
@@ -622,19 +619,21 @@ def test_fit_natgrads_holds_frozen_hyperparameter_constant() -> None:
         key=jr.key(123),
     )
 
-    before = paramax.unwrap(frozen)
-    after = paramax.unwrap(trained_model)
-
     # Ensure the frozen noise is held exactly
-    assert after.model.likelihood.obs_stddev == before.model.likelihood.obs_stddev
+    assert val(trained_model.model.likelihood.obs_stddev) == val(
+        frozen.model.likelihood.obs_stddev
+    )
 
     # Ensure the remaining hyperparameters are still optimised by the Optax half
     assert not jnp.allclose(
-        after.model.prior.kernel.lengthscale, before.model.prior.kernel.lengthscale
+        val(trained_model.model.prior.kernel.lengthscale),
+        val(frozen.model.prior.kernel.lengthscale),
     )
 
     # Ensure the variational coordinates are still optimised by the natgrad half
-    assert not jnp.allclose(after.variational_mean, before.variational_mean)
+    assert not jnp.allclose(
+        val(trained_model.variational_mean), val(frozen.variational_mean)
+    )
 
     # Ensure we reduce the loss
     assert history[-1] < history[0]
@@ -968,14 +967,11 @@ def test_fit_freeze_kernel_variance() -> None:
         verbose=False,
     )
 
-    # Use paramax.unwrap to fully resolve all wrappers for comparison
-    unwrapped = paramax.unwrap(trained_posterior)
-
     # Assert variance has not changed
-    assert jnp.allclose(unwrapped.prior.kernel.variance, initial_variance)
+    assert jnp.allclose(val(trained_posterior.prior.kernel.variance), initial_variance)
 
     # Assert lengthscale has changed, and in the direction that improves the mll
-    assert not jnp.allclose(unwrapped.prior.kernel.lengthscale, 1.0)
+    assert not jnp.allclose(val(trained_posterior.prior.kernel.lengthscale), 1.0)
     assert conjugate_mll(trained_posterior, D) > conjugate_mll(frozen_posterior, D)
 
 
@@ -1006,8 +1002,7 @@ def test_fit_zero_mean_function_is_frozen_by_default() -> None:
         verbose=False,
     )
 
-    unwrapped = paramax.unwrap(trained_posterior)
-    assert jnp.allclose(unwrapped.prior.mean_function.constant, 0.0)
+    assert jnp.allclose(val(trained_posterior.prior.mean_function.constant), 0.0)
 
 
 def test_fit_constant_mean_function_with_parameter() -> None:
@@ -1085,8 +1080,9 @@ def test_fit_constant_mean_function_frozen_with_non_trainable() -> None:
     )
 
     # Assert mean function constant has NOT changed (frozen with non_trainable)
-    unwrapped = paramax.unwrap(trained_posterior)
-    assert jnp.allclose(unwrapped.prior.mean_function.constant, initial_constant)
+    assert jnp.allclose(
+        val(trained_posterior.prior.mean_function.constant), initial_constant
+    )
 
 
 def test_fit_freeze_by_non_trainable() -> None:
@@ -1129,18 +1125,19 @@ def test_fit_freeze_by_non_trainable() -> None:
         verbose=False,
     )
 
-    # Use paramax.unwrap to fully resolve all wrappers for comparison
-    unwrapped = paramax.unwrap(trained_posterior)
-
     # Assert that frozen parameters have not changed
-    assert jnp.allclose(unwrapped.prior.kernel.variance, initial_variance)
-    assert jnp.allclose(unwrapped.likelihood.obs_stddev, initial_obs_stddev)
+    assert jnp.allclose(val(trained_posterior.prior.kernel.variance), initial_variance)
+    assert jnp.allclose(
+        val(trained_posterior.likelihood.obs_stddev), initial_obs_stddev
+    )
 
     # The trainable lengthscale must have moved so as to improve the mll
     assert conjugate_mll(trained_posterior, D) > conjugate_mll(frozen_posterior, D)
 
     # Assert lengthscale has changed
-    assert not jnp.allclose(unwrapped.prior.kernel.lengthscale, initial_lengthscale)
+    assert not jnp.allclose(
+        val(trained_posterior.prior.kernel.lengthscale), initial_lengthscale
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1151,7 +1148,7 @@ def _dual_svgp_setup(n_data: int, n_inducing: int = 5, jitter: float = 1e-8):
     q, D = _svgp_setup(n_data=n_data, n_inducing=n_inducing, jitter=jitter)
     dual = DualVariationalGaussian(
         model=q.model,
-        inducing_inputs=_val(q.inducing_inputs),
+        inducing_inputs=val(q.inducing_inputs),
     )
     return dual, D
 

--- a/tests/test_heteroscedastic.py
+++ b/tests/test_heteroscedastic.py
@@ -43,7 +43,6 @@ from jax import config
 import jax.numpy as jnp
 import jax.random as jr
 import lineax as lx
-import paramax
 import pytest
 
 config.update("jax_enable_x64", True)
@@ -296,7 +295,7 @@ def test_heteroscedastic_elbo_gradients(dataset, prior, noise_prior):
         params, static = eqx.partition(variational, eqx.is_array)
 
         def loss(p, static=static):
-            model = paramax.unwrap(eqx.combine(p, static))
+            model = eqx.combine(p, static)
             return -heteroscedastic_elbo(model, dataset)
 
         loss_val = loss(params)

--- a/tests/test_integration_equinox.py
+++ b/tests/test_integration_equinox.py
@@ -12,6 +12,7 @@ import pytest
 config.update("jax_enable_x64", True)
 
 import gpjax as gpx
+from gpjax.parameters import val
 
 pytestmark = pytest.mark.filterwarnings(
     "ignore:A JAX array is being set as static:UserWarning"
@@ -50,7 +51,7 @@ def test_full_gp_training_roundtrip():
 def test_parameter_freezing_with_non_trainable():
     """NonTrainable parameters should not change during training."""
     kernel = gpx.kernels.RBF()
-    original_variance = paramax.unwrap(kernel).variance
+    original_variance = val(kernel.variance)
 
     frozen_kernel = eqx.tree_at(
         lambda k: k.variance, kernel, replace_fn=paramax.non_trainable
@@ -75,7 +76,7 @@ def test_parameter_freezing_with_non_trainable():
         verbose=False,
     )
 
-    final_variance = paramax.unwrap(trained.prior.kernel).variance
+    final_variance = val(trained.prior.kernel.variance)
     assert jnp.allclose(final_variance, original_variance)
 
 
@@ -186,7 +187,7 @@ def test_grad_through_model():
     params, static = eqx.partition(posterior, eqx.is_array)
 
     def loss(params):
-        model = paramax.unwrap(eqx.combine(params, static))
+        model = eqx.combine(params, static)
         return -gpx.objectives.conjugate_mll(model, D)
 
     grads = jax.grad(loss)(params)

--- a/tests/test_kernels/test_nonstationary.py
+++ b/tests/test_kernels/test_nonstationary.py
@@ -24,7 +24,7 @@ from gpjax.kernels.nonstationary import (
     Linear,
     Polynomial,
 )
-from gpjax.parameters import NonNegativeReal
+from gpjax.parameters import NonNegativeReal, val
 import jax
 from jax import config
 import jax.numpy as jnp
@@ -194,12 +194,6 @@ def test_arccosine_special_case(order: int):
     assert jnp.max(Kab_approx - Kab_exact) < 1e-4
 
 
-def _val_or_unwrap(v):
-    from paramax import AbstractUnwrappable
-
-    return v.unwrap() if isinstance(v, AbstractUnwrappable) else v
-
-
 def test_arccosine_variances_wrapped_and_trainable():
     """All three ArcCosine variances must be NonNegativeReal so they are
     trainable (not silently frozen) and constrained (cannot go negative)."""
@@ -223,19 +217,17 @@ def test_arccosine_variances_wrapped_and_trainable():
 def test_arccosine_variance_stays_positive_under_optimisation():
     """A gradient step that would push weight_variance negative must instead
     leave the constrained value positive and the Gram finite/PSD."""
-    import paramax
-
     x = jnp.linspace(-1.0, 1.0, 6).reshape(-1, 1)
     kernel = ArcCosine(order=1, n_dims=1, weight_variance=jnp.array(0.05))
     params, static = eqx.partition(kernel, eqx.is_array)
 
     def loss(p):
-        k = paramax.unwrap(eqx.combine(p, static))
+        k = eqx.combine(p, static)
         return jnp.sum(k.gram(x).as_matrix())  # gradient pushes variances down
 
     grads = jax.grad(loss)(params)
     stepped = jax.tree_util.tree_map(lambda leaf, g: leaf - 100.0 * g, params, grads)
-    k_new = paramax.unwrap(eqx.combine(stepped, static))
-    assert _val_or_unwrap(k_new.weight_variance) > 0.0
+    k_new = eqx.combine(stepped, static)
+    assert val(k_new.weight_variance) > 0.0
     gram = k_new.gram(x).as_matrix()
     assert jnp.all(jnp.isfinite(gram))

--- a/tests/test_mean_functions.py
+++ b/tests/test_mean_functions.py
@@ -33,7 +33,7 @@ from gpjax.mean_functions import (
 from gpjax.objectives import conjugate_mll
 from gpjax.parameters import (
     Real,
-    _val,
+    val,
 )
 import jax
 import jax.numpy as jnp
@@ -86,7 +86,7 @@ def test_constant(constant: Float[Array, " Q"]) -> None:
 def test_zero_mean_initialises_at_zero() -> None:
     """Zero mean function should initialise its constant at 0.0."""
     meanf = Zero()
-    assert jnp.allclose(_val(meanf.constant), 0.0)
+    assert jnp.allclose(val(meanf.constant), 0.0)
 
 
 def test_zero_mean_remains_zero() -> None:
@@ -334,7 +334,7 @@ def test_zero_mean_function_constant_is_frozen():
     meanf = Zero()
 
     assert isinstance(meanf.constant, NonTrainable)
-    assert jnp.allclose(_val(meanf.constant), 0.0)
+    assert jnp.allclose(val(meanf.constant), 0.0)
 
     # The wrapper must stop gradients reaching the constant. `eqx.filter` alone
     # does not hide it -- `unwrap` is what applies `stop_gradient`.

--- a/tests/test_models_oilmm.py
+++ b/tests/test_models_oilmm.py
@@ -641,7 +641,6 @@ class TestOILMMMLL:
 
         def loss_fn(params):
             m = eqx.combine(params, static)
-            m = paramax.unwrap(m)
             return -oilmm_mll(m, data)
 
         grads = jax.grad(loss_fn)(params)
@@ -1001,9 +1000,9 @@ def test_create_oilmm_from_data_two_points_finite():
     data = Dataset(X=jnp.array([[0.0], [1.0]]), y=jnp.array([[1.0, 2.0], [3.0, 4.0]]))
     model = create_oilmm_from_data(dataset=data, num_latent_gps=2, key=jr.key(0))
     assert jnp.all(jnp.isfinite(model.mixing_matrix.U))
-    from gpjax.models.oilmm import _val
+    from gpjax.models.oilmm import val
 
-    assert jnp.all(jnp.isfinite(_val(model.mixing_matrix.S)))
+    assert jnp.all(jnp.isfinite(val(model.mixing_matrix.S)))
 
 
 def test_oilmm_predict_diagonal_returns_diagonal_operator():

--- a/tests/test_models_oilmm.py
+++ b/tests/test_models_oilmm.py
@@ -4,7 +4,6 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import jax.random as jr
-import paramax
 import pytest
 
 jax.config.update("jax_enable_x64", True)

--- a/tests/test_natural_gradients.py
+++ b/tests/test_natural_gradients.py
@@ -41,7 +41,7 @@ from gpjax.objectives import (
 from gpjax.parameters import (
     LowerTriangular,
     Real,
-    _val,
+    val,
 )
 from gpjax.variational_families import (
     CollapsedVariationalGaussian,
@@ -143,10 +143,9 @@ def _negative_elbo(family, data):
 
 
 def _moments_of(family):
-    unwrapped = paramax.unwrap(family)
     return (
-        _val(unwrapped.variational_mean),
-        _val(unwrapped.variational_root_covariance),
+        val(family.variational_mean),
+        val(family.variational_root_covariance),
     )
 
 
@@ -161,10 +160,9 @@ def _take_step(family, data, natgrad_lr, objective=_negative_elbo, **kwargs):
 
 def _kernel_matrices(family, inputs):
     """Densify the kernel quantities entering the conjugate closed form."""
-    unwrapped = paramax.unwrap(family)
-    inducing_inputs = _val(unwrapped.inducing_inputs)
-    kernel = unwrapped.model.prior.kernel
-    mean_function = unwrapped.model.prior.mean_function
+    inducing_inputs = val(family.inducing_inputs)
+    kernel = family.model.prior.kernel
+    mean_function = family.model.prior.mean_function
     gram = add_jitter(
         kernel.gram(inducing_inputs).as_matrix(), family.model.prior.jitter
     )
@@ -450,9 +448,7 @@ def test_natgrad_conjugate_one_step_exact(family_cls) -> None:
         atol=1e-10,
     )
 
-    assert float(elbo(paramax.unwrap(stepped), dataset)) >= float(
-        elbo(paramax.unwrap(family), dataset)
-    )
+    assert float(elbo(stepped, dataset)) >= float(elbo(family, dataset))
 
     twice_stepped, _ = _take_step(stepped, dataset, 1.0)
     second_mean, _ = _moments_of(twice_stepped)
@@ -499,8 +495,8 @@ def test_whitened_and_unwhitened_optima_agree() -> None:
     stepped_unwhitened, _ = _take_step(unwhitened, dataset, 1.0)
     stepped_whitened, _ = _take_step(whitened, dataset, 1.0)
     np.testing.assert_allclose(
-        np.float64(elbo(paramax.unwrap(stepped_whitened), dataset)),
-        np.float64(elbo(paramax.unwrap(stepped_unwhitened), dataset)),
+        np.float64(elbo(stepped_whitened, dataset)),
+        np.float64(elbo(stepped_unwhitened, dataset)),
         rtol=1e-10,
     )
 
@@ -549,7 +545,6 @@ def _data_term_covariance_gradient(family, data):
             family,
             (Real(trial_mean), LowerTriangular(trial_root)),
         )
-        trial = paramax.unwrap(trial)
         full_size = data.n_total if data.n_total is not None else data.n
         scale = full_size / data.n
         return jnp.sum(variational_expectation(trial, data)) * scale
@@ -627,10 +622,10 @@ def test_natgrad_monotone_elbo_bernoulli() -> None:
     posterior, dataset, inducing_inputs, _ = _bernoulli_setup()
     family = VariationalGaussian(model=posterior, inducing_inputs=inducing_inputs)
 
-    trace = [float(elbo(paramax.unwrap(family), dataset))]
+    trace = [float(elbo(family, dataset))]
     for _ in range(50):
         family, _ = _take_step(family, dataset, 0.1)
-        trace.append(float(elbo(paramax.unwrap(family), dataset)))
+        trace.append(float(elbo(family, dataset)))
 
     assert bool(jnp.all(jnp.diff(jnp.asarray(trace)) >= -1e-9))
 
@@ -650,7 +645,7 @@ def _expectation_gradient(family, data):
             family,
             (Real(trial_mean), LowerTriangular(trial_root)),
         )
-        return _negative_elbo(paramax.unwrap(trial), data)
+        return _negative_elbo(trial, data)
 
     gradient = jax.grad(loss_of_expectation)(expectation)
     return gradient[0], _symmetrise(gradient[1])
@@ -692,7 +687,7 @@ def test_natgrad_backoff_recovers_from_large_step() -> None:
     assert bool(jnp.all(jnp.isfinite(updated_mean)))
     assert bool(jnp.all(jnp.isfinite(updated_root)))
     assert bool(jnp.isfinite(loss_value))
-    assert bool(jnp.isfinite(elbo(paramax.unwrap(stepped), dataset)))
+    assert bool(jnp.isfinite(elbo(stepped, dataset)))
 
     # Recover the step size actually taken: Theta_2^new = Theta_2 - s * dl/dH_2.
     updated_natural_matrix = natural_from_moments(updated_mean, updated_root)[1]
@@ -778,8 +773,8 @@ def test_natgrad_step_is_jit_and_scan_compatible() -> None:
     compiled, compiled_loss = eqx.filter_jit(step)(variational, jnp.asarray(0.5))
 
     np.testing.assert_allclose(
-        np.float64(_val(compiled.variational_mean)),
-        np.float64(_val(eager.variational_mean)),
+        np.float64(val(compiled.variational_mean)),
+        np.float64(val(eager.variational_mean)),
         atol=1e-12,
     )
     np.testing.assert_allclose(
@@ -857,9 +852,9 @@ def test_natgrad_step_supports_graph_variational_gaussian() -> None:
     )
 
     assert bool(jnp.isfinite(loss_value))
-    assert _val(stepped.inducing_inputs).dtype == jnp.int64
+    assert val(stepped.inducing_inputs).dtype == jnp.int64
     np.testing.assert_array_equal(
-        np.asarray(_val(stepped.inducing_inputs)), np.asarray(inducing_inputs)
+        np.asarray(val(stepped.inducing_inputs)), np.asarray(inducing_inputs)
     )
 
 
@@ -1036,8 +1031,8 @@ def test_whitened_and_unwhitened_traces_agree() -> None:
     for _ in range(6):
         whitened, _ = _take_step(whitened, dataset, 0.3)
         unwhitened, _ = _take_step(unwhitened, dataset, 0.3)
-        whitened_trace.append(float(elbo(paramax.unwrap(whitened), dataset)))
-        unwhitened_trace.append(float(elbo(paramax.unwrap(unwhitened), dataset)))
+        whitened_trace.append(float(elbo(whitened, dataset)))
+        unwhitened_trace.append(float(elbo(unwhitened, dataset)))
 
     np.testing.assert_allclose(
         np.asarray(whitened_trace), np.asarray(unwhitened_trace), atol=1e-9
@@ -1072,7 +1067,7 @@ def _negative_dual_elbo(family, data):
 def _titsias_optimum(family, data):
     r"""Closed-form optimal $(\mathbf m^\star,\mathbf S^\star)$ in the u-space."""
     gram, cross, _, inducing_mean, input_mean = _kernel_matrices(family, data.X)
-    noise_variance = _val(family.model.likelihood.obs_stddev) ** 2
+    noise_variance = val(family.model.likelihood.obs_stddev) ** 2
     working = jnp.linalg.inv(gram + cross.T @ cross / noise_variance)
     residual = data.y - input_mean
     optimal_mean = inducing_mean + gram @ working @ cross.T @ residual / noise_variance
@@ -1095,7 +1090,7 @@ def _uncentred_dual_step(family, data, rate):
     uncentred = alpha + beta * mean
 
     cross = family.model.prior.kernel.cross_covariance(
-        _val(family.inducing_inputs), data.X
+        val(family.inducing_inputs), data.X
     )
     design = jsp.linalg.cho_solve((root_gram, True), cross)
     full_size = data.n_total if data.n_total is not None else data.n
@@ -1107,10 +1102,10 @@ def _uncentred_dual_step(family, data, rate):
         lambda tree: (tree.dual_vector, tree.dual_matrix),
         family,
         (
-            Real((1 - rate) * _val(family.dual_vector) + rate * scale * target_vector),
+            Real((1 - rate) * val(family.dual_vector) + rate * scale * target_vector),
             Real(
                 _symmetrise(
-                    (1 - rate) * _val(family.dual_matrix) + rate * scale * target_matrix
+                    (1 - rate) * val(family.dual_matrix) + rate * scale * target_matrix
                 )
             ),
         ),
@@ -1150,16 +1145,16 @@ def test_dual_natgrad_recovers_exact_sites():
     stepped, _ = _take_step(family, dataset, 1.0, objective=_negative_dual_elbo)
 
     gram, cross, _, _, input_mean = _kernel_matrices(family, dataset.X)
-    noise_variance = _val(posterior.likelihood.obs_stddev) ** 2
+    noise_variance = val(posterior.likelihood.obs_stddev) ** 2
 
     np.testing.assert_allclose(
-        np.asarray(gram @ _val(stepped.dual_matrix) @ gram),
+        np.asarray(gram @ val(stepped.dual_matrix) @ gram),
         np.asarray(cross.T @ cross / noise_variance),
         rtol=1e-10,
         atol=1e-12,
     )
     np.testing.assert_allclose(
-        np.asarray(gram @ _val(stepped.dual_vector)),
+        np.asarray(gram @ val(stepped.dual_vector)),
         np.asarray(cross.T @ (dataset.y - input_mean) / noise_variance),
         rtol=1e-10,
         atol=1e-12,
@@ -1176,13 +1171,13 @@ def test_dual_natgrad_second_step_is_a_fixed_point():
     second, _ = _take_step(first, dataset, 1.0, objective=_negative_dual_elbo)
 
     np.testing.assert_allclose(
-        np.asarray(_val(second.dual_vector)),
-        np.asarray(_val(first.dual_vector)),
+        np.asarray(val(second.dual_vector)),
+        np.asarray(val(first.dual_vector)),
         atol=1e-12,
     )
     np.testing.assert_allclose(
-        np.asarray(_val(second.dual_matrix)),
-        np.asarray(_val(first.dual_matrix)),
+        np.asarray(val(second.dual_matrix)),
+        np.asarray(val(first.dual_matrix)),
         atol=1e-12,
     )
 
@@ -1198,13 +1193,13 @@ def test_dual_natgrad_from_zero_scales_with_rho(rate: float):
     partial, _ = _take_step(family, dataset, rate, objective=_negative_dual_elbo)
 
     np.testing.assert_allclose(
-        np.asarray(_val(partial.dual_vector)),
-        rate * np.asarray(_val(optimal.dual_vector)),
+        np.asarray(val(partial.dual_vector)),
+        rate * np.asarray(val(optimal.dual_vector)),
         atol=1e-12,
     )
     np.testing.assert_allclose(
-        np.asarray(_val(partial.dual_matrix)),
-        rate * np.asarray(_val(optimal.dual_matrix)),
+        np.asarray(val(partial.dual_matrix)),
+        rate * np.asarray(val(optimal.dual_matrix)),
         atol=1e-12,
     )
 
@@ -1257,7 +1252,7 @@ def test_dual_natgrad_preserves_psd():
         indices = jr.choice(batch_key, dataset.n, (8,), replace=False)
         batch = Dataset(X=dataset.X[indices], y=dataset.y[indices], n_total=dataset.n)
         family, _ = _take_step(family, batch, 0.8, objective=_negative_dual_elbo)
-        assert jnp.linalg.eigvalsh(_val(family.dual_matrix)).min() >= -1e-10
+        assert jnp.linalg.eigvalsh(val(family.dual_matrix)).min() >= -1e-10
 
 
 # ---------------------------------------------------------------------------
@@ -1276,7 +1271,7 @@ def test_dual_natgrad_beta_floor_is_trace_safe():
         jnp.asarray(0.8),
         beta_floor=1e-8,
     )
-    assert jnp.all(jnp.isfinite(_val(stepped.dual_matrix)))
+    assert jnp.all(jnp.isfinite(val(stepped.dual_matrix)))
 
     def scan_body(carry, _):
         carry, loss = natural_gradient_step(
@@ -1303,12 +1298,12 @@ def test_dual_natgrad_beta_floor_is_trace_safe():
     unfloored, _ = _take_step(
         concave, dataset, 0.8, objective=_negative_dual_elbo, beta_floor=-jnp.inf
     )
-    assert jnp.linalg.eigvalsh(_val(unfloored.dual_matrix)).min() < -1e-6
+    assert jnp.linalg.eigvalsh(val(unfloored.dual_matrix)).min() < -1e-6
 
     floored, _ = _take_step(
         concave, dataset, 0.8, objective=_negative_dual_elbo, beta_floor=1e-8
     )
-    assert jnp.linalg.eigvalsh(_val(floored.dual_matrix)).min() >= -1e-10
+    assert jnp.linalg.eigvalsh(val(floored.dual_matrix)).min() >= -1e-10
 
 
 # ---------------------------------------------------------------------------
@@ -1351,13 +1346,13 @@ def test_dual_natgrad_minibatch_is_unbiased():
     right, _ = _take_step(family, second_half, 1.0, objective=_negative_dual_elbo)
 
     np.testing.assert_allclose(
-        0.5 * np.asarray(_val(left.dual_vector) + _val(right.dual_vector)),
-        np.asarray(_val(full.dual_vector)),
+        0.5 * np.asarray(val(left.dual_vector) + val(right.dual_vector)),
+        np.asarray(val(full.dual_vector)),
         atol=1e-12,
     )
     np.testing.assert_allclose(
-        0.5 * np.asarray(_val(left.dual_matrix) + _val(right.dual_matrix)),
-        np.asarray(_val(full.dual_matrix)),
+        0.5 * np.asarray(val(left.dual_matrix) + val(right.dual_matrix)),
+        np.asarray(val(full.dual_matrix)),
         atol=1e-12,
     )
 
@@ -1377,13 +1372,13 @@ def test_dual_natgrad_step_is_jit_and_scan_compatible():
         variational, hyper, dataset, _negative_dual_elbo, jnp.asarray(0.5)
     )
     np.testing.assert_allclose(
-        np.asarray(_val(jitted.dual_vector)),
-        np.asarray(_val(eager.dual_vector)),
+        np.asarray(val(jitted.dual_vector)),
+        np.asarray(val(eager.dual_vector)),
         atol=1e-12,
     )
     np.testing.assert_allclose(
-        np.asarray(_val(jitted.dual_matrix)),
-        np.asarray(_val(eager.dual_matrix)),
+        np.asarray(val(jitted.dual_matrix)),
+        np.asarray(val(eager.dual_matrix)),
         atol=1e-12,
     )
     np.testing.assert_allclose(
@@ -1437,8 +1432,8 @@ def test_dual_natgrad_preserves_float32():
     stepped, _ = _take_step(
         family, dataset, jnp.float32(0.5), objective=_negative_dual_elbo
     )
-    assert _val(stepped.dual_vector).dtype == jnp.float32
-    assert _val(stepped.dual_matrix).dtype == jnp.float32
+    assert val(stepped.dual_vector).dtype == jnp.float32
+    assert val(stepped.dual_matrix).dtype == jnp.float32
 
 
 def test_dual_natgrad_step_rejects_non_trainable_coordinates():
@@ -1487,10 +1482,9 @@ def _six_matched_steps(posterior, dataset, inducing_inputs, beta_floor):
     worst_gap = 0.0
     smallest_beta = jnp.inf
     for _ in range(6):
-        unwrapped = paramax.unwrap(dual)
-        mean, variance = unwrapped.marginals(dataset.X)
+        mean, variance = dual.marginals(dataset.X)
         _, beta = _expected_log_likelihood_derivatives(
-            unwrapped.model.likelihood, dataset.y, mean, variance
+            dual.model.likelihood, dataset.y, mean, variance
         )
         smallest_beta = min(smallest_beta, float(jnp.min(beta)))
 

--- a/tests/test_oak.py
+++ b/tests/test_oak.py
@@ -314,7 +314,6 @@ class TestOrthogonalAdditiveKernelProperties:
     def test_gradient_flows(self):
         """Gradients w.r.t. kernel parameters are finite and non-zero."""
         import equinox as eqx
-        import paramax
 
         base_kernels = [RBF(active_dims=[i]) for i in range(3)]
         kernel = OrthogonalAdditiveKernel(base_kernels=base_kernels)
@@ -323,7 +322,7 @@ class TestOrthogonalAdditiveKernelProperties:
         params, static = eqx.partition(kernel, eqx.is_array)
 
         def loss_fn(params):
-            k = paramax.unwrap(eqx.combine(params, static))
+            k = eqx.combine(params, static)
             K = k.gram(x).as_matrix()
             return jnp.sum(K)
 

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -15,11 +15,10 @@ from gpjax.objectives import (
     dual_elbo,
     elbo,
     non_conjugate_mll,
-    with_log_prior,
 )
 from gpjax.parameters import (
     PositiveReal,
-    _val,
+    val,
 )
 from gpjax.variational_families import DualVariationalGaussian
 import jax
@@ -29,8 +28,6 @@ import jax.random as jr
 import jax.scipy as jsp
 import jax.tree_util as jtu
 import numpy as np
-import numpyro.distributions as dist
-import paramax
 import pytest
 
 from tests._dual_helpers import (
@@ -93,7 +90,7 @@ def test_conjugate_mll(n_points: int, n_dims: int, key_val: int):
     params, static = eqx.partition(post, eqx.is_array)
 
     def loss(params):
-        posterior = paramax.unwrap(eqx.combine(params, static))
+        posterior = eqx.combine(params, static)
         return -conjugate_mll(posterior, D)
 
     res_wrapped = loss(params)
@@ -133,7 +130,7 @@ def test_conjugate_loocv(n_points, n_dims, key_val):
     params, static = eqx.partition(post, eqx.is_array)
 
     def loss(params):
-        posterior = paramax.unwrap(eqx.combine(params, static))
+        posterior = eqx.combine(params, static)
         return -conjugate_loocv(posterior, D)
 
     res_wrapped = loss(params)
@@ -173,7 +170,7 @@ def test_non_conjugate_mll(n_points, n_dims, key_val):
     params, static = eqx.partition(post, eqx.is_array)
 
     def loss(params):
-        posterior = paramax.unwrap(eqx.combine(params, static))
+        posterior = eqx.combine(params, static)
         return -non_conjugate_mll(posterior, D)
 
     res_wrapped = loss(params)
@@ -213,7 +210,7 @@ def test_non_conjugate_mll_studentt(n_points, n_dims, key_val):
     params, static = eqx.partition(post, eqx.is_array)
 
     def loss(params):
-        posterior = paramax.unwrap(eqx.combine(params, static))
+        posterior = eqx.combine(params, static)
         return -non_conjugate_mll(posterior, D)
 
     res_wrapped = loss(params)
@@ -292,7 +289,7 @@ def test_elbo(n_points, n_dims, key_val, binary: bool):
     params, static = eqx.partition(q, eqx.is_array)
 
     def loss(params):
-        model = paramax.unwrap(eqx.combine(params, static))
+        model = eqx.combine(params, static)
         return -elbo(model, D)
 
     res_wrapped = loss(params)
@@ -383,7 +380,7 @@ def test_conjugate_loocv_multioutput_matches_brute_force():
     kernel = ICMKernel(base_kernel=RBF(), coregionalization_matrix=coreg)
     prior = Prior(mean_function=Zero(), kernel=kernel)
     lik = MultiOutputGaussian(num_outputs=P)
-    posterior = paramax.unwrap(prior * lik)
+    posterior = prior * lik
 
     # --- Independent brute-force reference on the full [NP, NP] system ---
     mx = posterior.prior.mean_function(X)
@@ -474,7 +471,7 @@ def _kernel_hyper_gradient(objective_fn, family, data):
     params, static = eqx.partition(family, eqx.is_array)
 
     def loss(trainable):
-        return objective_fn(paramax.unwrap(eqx.combine(trainable, static)), data)
+        return objective_fn(eqx.combine(trainable, static), data)
 
     grads = jax.grad(loss)(params)
     leaves = jtu.tree_leaves(grads.model.prior.kernel)
@@ -493,7 +490,7 @@ def test_dual_elbo(binary: bool):
     params, static = eqx.partition(q, eqx.is_array)
 
     def loss(params):
-        model = paramax.unwrap(eqx.combine(params, static))
+        model = eqx.combine(params, static)
         return -dual_elbo(model, data)
 
     np.testing.assert_allclose(
@@ -593,7 +590,7 @@ def test_dual_elbo_equals_titsias_collapsed_bound():
     gram = add_jitter(kernel.gram(inducing_inputs).as_matrix(), jitter)
     cross = kernel.cross_covariance(inducing_inputs, data.X)
     diagonal = jnp.diag(kernel.gram(data.X).as_matrix())
-    noise_variance = _val(posterior.likelihood.obs_stddev) ** 2
+    noise_variance = val(posterior.likelihood.obs_stddev) ** 2
     residual = (data.y - posterior.prior.mean_function(data.X)).squeeze(-1)
 
     root_gram = jnp.linalg.cholesky(gram)
@@ -683,7 +680,7 @@ def test_dual_elbo_dominates_when_inducing_equal_inputs():
     q = _dual_natgrad_step(q, data, 1.0)
     q_moment = _matched_variational_gaussian(q)
 
-    base_lengthscale = _val(posterior.prior.kernel.lengthscale)
+    base_lengthscale = val(posterior.prior.kernel.lengthscale)
     for shift in (-0.6, -0.3, 0.0, 0.3, 0.6):
         lengthscale = PositiveReal(base_lengthscale * jnp.exp(shift))
         where = lambda t: t.model.prior.kernel.lengthscale
@@ -885,101 +882,3 @@ def test_pinned_elbo_is_a_lower_bound_on_the_evidence(family: str):
     """
     q, data = _pinned_uncollapsed_family(family, binary=False)
     assert elbo(q, data) <= conjugate_mll(q.model, data)
-
-
-def test_with_log_prior_matches_base_objective_when_prior_is_zero():
-    """A zero log-prior must leave both the value and the gradient of the
-    wrapped objective unchanged, i.e. `with_log_prior` does not disturb plain
-    `conjugate_mll` behaviour when no meaningful prior is supplied."""
-    key = jr.key(7)
-    D = build_data(20, 1, key, binary=False)
-
-    p = gpx.gps.Prior(
-        kernel=gpx.kernels.RBF(), mean_function=gpx.mean_functions.Constant()
-    )
-    likelihood = gpx.likelihoods.Gaussian()
-    posterior = p * likelihood
-
-    zero_log_prior = lambda model: jnp.array(0.0)
-    regularised_mll = with_log_prior(conjugate_mll, zero_log_prior)
-
-    base_value = conjugate_mll(posterior, D)
-    regularised_value = regularised_mll(posterior, D)
-    assert jnp.allclose(base_value, regularised_value)
-
-    params, static = eqx.partition(posterior, eqx.is_array)
-
-    def base_loss(params):
-        model = paramax.unwrap(eqx.combine(params, static))
-        return -conjugate_mll(model, D)
-
-    def regularised_loss(params):
-        model = paramax.unwrap(eqx.combine(params, static))
-        return -regularised_mll(model, D)
-
-    base_grad = jax.grad(base_loss)(params)
-    regularised_grad = jax.grad(regularised_loss)(params)
-    for base_leaf, regularised_leaf in zip(
-        jax.tree_util.tree_leaves(base_grad),
-        jax.tree_util.tree_leaves(regularised_grad),
-        strict=True,
-    ):
-        assert jnp.allclose(base_leaf, regularised_leaf)
-
-
-def test_with_log_prior_map_regularised_fit_prefers_prior_consistent_lengthscale():
-    """MAP-style regularisation: a strong prior favouring large lengthscales
-    should pull a gradient-descent fit away from the overfitting-prone tiny
-    lengthscale an unregularised MLE fit converges to, towards the prior
-    mean, on the same data. This is the acceptance scenario for issue #515."""
-    key = jr.key(1)
-    n_points = 60
-    X = jnp.linspace(0.0, 1.0, n_points).reshape(-1, 1)
-    y = jnp.sin(2.0 * jnp.pi * 8.0 * X) + jr.normal(key, X.shape) * 0.05
-    D = Dataset(X=X, y=y)
-
-    def build_posterior():
-        kernel = gpx.kernels.RBF(lengthscale=jnp.array(0.3), variance=jnp.array(1.0))
-        meanf = gpx.mean_functions.Constant()
-        likelihood = gpx.likelihoods.Gaussian(obs_stddev=jnp.array(0.05))
-        posterior = gpx.gps.Prior(mean_function=meanf, kernel=kernel) * likelihood
-        # Freeze the noise so the kernel lengthscale alone must explain the
-        # high-frequency signal -- this isolates the lengthscale/overfitting
-        # trade-off the prior is meant to regularise.
-        return eqx.tree_at(
-            lambda m: m.likelihood.obs_stddev,
-            posterior,
-            replace_fn=paramax.non_trainable,
-        )
-
-    unregularised_nmll = lambda p, d: -conjugate_mll(p, d)
-    unregularised_model, _ = gpx.fit_scipy(
-        model=build_posterior(),
-        objective=unregularised_nmll,
-        train_data=D,
-        verbose=False,
-    )
-    unregularised_lengthscale = paramax.unwrap(
-        unregularised_model
-    ).prior.kernel.lengthscale
-
-    prior_mean = 3.0
-
-    def log_prior(model):
-        lengthscale = model.prior.kernel.lengthscale
-        return dist.LogNormal(jnp.log(prior_mean), 0.15).log_prob(lengthscale).sum()
-
-    regularised_nmll = lambda p, d: -with_log_prior(conjugate_mll, log_prior)(p, d)
-    regularised_model, _ = gpx.fit_scipy(
-        model=build_posterior(),
-        objective=regularised_nmll,
-        train_data=D,
-        verbose=False,
-    )
-    regularised_lengthscale = paramax.unwrap(regularised_model).prior.kernel.lengthscale
-
-    # Unregularised MLE overfits the high-frequency signal with a tiny lengthscale.
-    assert unregularised_lengthscale < 0.05
-    # The prior-regularised fit converges near the prior mean instead.
-    assert jnp.abs(regularised_lengthscale - prior_mean) < 1.0
-    assert regularised_lengthscale > unregularised_lengthscale

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -96,12 +96,12 @@ def test_val_unwraps_nested_wrappers():
     """
     from gpjax.parameters import (
         PositiveReal,
-        _val,
+        val,
     )
 
     p = paramax.non_trainable(PositiveReal(jnp.array(2.0)))
     assert isinstance(p._unconstrained, paramax.NonTrainable)
-    assert jnp.equal(_val(p), jnp.array(2.0))
+    assert jnp.equal(val(p), jnp.array(2.0))
 
 
 def test_lower_triangular_positive_diagonal():

--- a/tests/test_state_space/test_fit.py
+++ b/tests/test_state_space/test_fit.py
@@ -1,6 +1,7 @@
 """Tests for state_space.fit wrappers."""
 
 import gpjax as gpx
+from gpjax.parameters import val
 from gpjax.state_space.fit import (
     fit,
     fit_lbfgs,
@@ -70,14 +71,13 @@ def test_fit_scipy_recovers_matern52_hyperparameters_at_N_2000():
         max_iters=200,
         verbose=False,
     )
-    fitted = paramax.unwrap(fitted_posterior)
 
     # Loose recovery checks (within ~50% of truth).
-    assert 0.4 < float(fitted.prior.kernel.lengthscale) < 1.4, (
-        f"lengthscale recovery off: got {float(fitted.prior.kernel.lengthscale)}, true {lengthscale_true}"
+    assert 0.4 < float(val(fitted_posterior.prior.kernel.lengthscale)) < 1.4, (
+        f"lengthscale recovery off: got {float(val(fitted_posterior.prior.kernel.lengthscale))}, true {lengthscale_true}"
     )
-    assert 0.5 < float(fitted.prior.kernel.variance) < 4.0
-    assert 0.15 < float(fitted.likelihood.obs_stddev) < 0.55
+    assert 0.5 < float(val(fitted_posterior.prior.kernel.variance)) < 4.0
+    assert 0.15 < float(val(fitted_posterior.likelihood.obs_stddev)) < 0.55
 
     # Final negative-MLL strictly less than initial.
     assert history[-1] < history[0]
@@ -236,8 +236,7 @@ def test_paramax_non_trainable_freezes_lengthscale():
         max_iters=50,
         verbose=False,
     )
-    fitted = paramax.unwrap(fitted_posterior)
-    fitted_lengthscale_value = float(fitted.prior.kernel.lengthscale)
+    fitted_lengthscale_value = float(val(fitted_posterior.prior.kernel.lengthscale))
     np.testing.assert_allclose(
         fitted_lengthscale_value,
         init_lengthscale_value,
@@ -245,8 +244,8 @@ def test_paramax_non_trainable_freezes_lengthscale():
     )
 
     # Sanity: variance and/or obs_stddev DID move (otherwise the freeze test is vacuous).
-    fitted_variance = float(fitted.prior.kernel.variance)
-    fitted_obs_stddev = float(fitted.likelihood.obs_stddev)
+    fitted_variance = float(val(fitted_posterior.prior.kernel.variance))
+    fitted_obs_stddev = float(val(fitted_posterior.likelihood.obs_stddev))
     assert (
         abs(fitted_variance - init_variance) > 1e-3
         or abs(fitted_obs_stddev - init_obs_stddev) > 1e-3

--- a/tests/test_variational_families.py
+++ b/tests/test_variational_families.py
@@ -23,7 +23,7 @@ import gpjax.linalg.utils
 from gpjax.parameters import (
     LowerTriangular,
     Real,
-    _val,
+    val,
 )
 import gpjax.variational_families
 from gpjax.variational_families import (
@@ -179,10 +179,10 @@ def test_variational_gaussians(
     if isinstance(q, DualVariationalGaussian):
         # The dual family stores sites, not moments, and both default to zero so that
         # q(u) = p(u) at initialisation.
-        assert _val(q.dual_vector).shape == vector_shape(n_inducing)
-        assert _val(q.dual_matrix).shape == matrix_shape(n_inducing)
-        assert (_val(q.dual_vector) == 0.0).all()
-        assert (_val(q.dual_matrix) == 0.0).all()
+        assert val(q.dual_vector).shape == vector_shape(n_inducing)
+        assert val(q.dual_matrix).shape == matrix_shape(n_inducing)
+        assert (val(q.dual_vector) == 0.0).all()
+        assert (val(q.dual_matrix) == 0.0).all()
     else:
         assert q.variational_mean.unwrap().shape == vector_shape(n_inducing)
         assert q.variational_root_covariance.unwrap().shape == matrix_shape(n_inducing)
@@ -465,8 +465,8 @@ def _textbook_gaussian_kl(mean_q, cov_q, mean_p, cov_p):
 
 def _reference_prior_kl(family):
     """Reference prior KL built from the dense covariance matrices."""
-    variational_mean = _val(family.variational_mean).reshape(-1)
-    variational_sqrt = _val(family.variational_root_covariance)
+    variational_mean = val(family.variational_mean).reshape(-1)
+    variational_sqrt = val(family.variational_root_covariance)
     cov_q = variational_sqrt @ variational_sqrt.T
     num_inducing = variational_sqrt.shape[-1]
 
@@ -474,7 +474,7 @@ def _reference_prior_kl(family):
         mean_p = jnp.zeros_like(variational_mean)
         cov_p = jnp.eye(num_inducing, dtype=variational_sqrt.dtype)
     else:
-        inducing_inputs = _val(family.inducing_inputs)
+        inducing_inputs = val(family.inducing_inputs)
         mean_p = family.model.prior.mean_function(inducing_inputs).reshape(-1)
         cov_p = family.model.prior.kernel.gram(inducing_inputs).as_matrix()
         cov_p = (
@@ -641,9 +641,9 @@ def test_prior_kl_is_jit_grad_and_vmap_compatible(family):
         model = eqx.tree_at(lambda t: t.variational_mean.value, q, mean_value)
         return model.prior_kl()
 
-    zero_mean = jnp.zeros_like(_val(q.variational_mean))
+    zero_mean = jnp.zeros_like(val(q.variational_mean))
     batch = jnp.stack(
-        [_val(q.variational_mean), _val(q.variational_mean) + 0.5, zero_mean]
+        [val(q.variational_mean), val(q.variational_mean) + 0.5, zero_mean]
     )
     batched = jax.vmap(kl_from_mean)(batch)
 
@@ -791,8 +791,8 @@ def test_dual_prior_kl_is_jit_grad_and_vmap_compatible() -> None:
         model = eqx.tree_at(lambda t: t.dual_vector.value, q, vector_value)
         return model.prior_kl()
 
-    zero_vector = jnp.zeros_like(_val(q.dual_vector))
-    batch = jnp.stack([_val(q.dual_vector), _val(q.dual_vector) + 0.5, zero_vector])
+    zero_vector = jnp.zeros_like(val(q.dual_vector))
+    batch = jnp.stack([val(q.dual_vector), val(q.dual_vector) + 0.5, zero_vector])
     batched = jax.vmap(kl_from_vector)(batch)
 
     assert batched.shape == (3,)
@@ -811,7 +811,7 @@ def test_dual_working_matrices_reconstruct_r() -> None:
     """``Lr`` is lower triangular and satisfies ``Lr Lr^T = Kzz + Kzz L2 Kzz``."""
     q = _build_dual_family(6, seed=5)
     gram, _, root_working = q._working_matrices()
-    dual_matrix = _val(q.dual_matrix)
+    dual_matrix = val(q.dual_matrix)
 
     working = gram + gram @ dual_matrix @ gram
     np.testing.assert_allclose(
@@ -869,7 +869,7 @@ def test_dual_marginals_include_jitter() -> None:
     inputs = jnp.linspace(-3.0, 3.0, 13).reshape(-1, 1)
 
     gram, root_gram, root_working = q._working_matrices()
-    cross = q.model.prior.kernel.cross_covariance(_val(q.inducing_inputs), inputs)
+    cross = q.model.prior.kernel.cross_covariance(val(q.inducing_inputs), inputs)
     diagonal = jnp.diag(q.model.prior.kernel.gram(inputs).as_matrix())
     prior_projection = jsp.linalg.solve_triangular(root_gram, cross, lower=True)
     site_projection = jsp.linalg.solve_triangular(root_working, cross, lower=True)
@@ -988,9 +988,9 @@ def _titsias_optimal_q(family: CollapsedVariationalGaussian, train_data: gpx.Dat
     model = family.model
     kernel = model.prior.kernel
     mean_function = model.prior.mean_function
-    noise_variance = _val(model.likelihood.obs_stddev) ** 2
+    noise_variance = val(model.likelihood.obs_stddev) ** 2
 
-    inducing_inputs = _val(family.inducing_inputs)
+    inducing_inputs = val(family.inducing_inputs)
     num_inducing = inducing_inputs.shape[0]
     identity = jnp.eye(num_inducing, dtype=inducing_inputs.dtype)
 


### PR DESCRIPTION
## Checklist

- [X] I've formatted the new code by running `uv run poe format` before committing.
- [N/a] I've added tests for new code.
- [X] I've added docstrings for the new code.

## Description

This change simplifies the handling of bijections. Parameter conversion now follows a simple rule - if you want to perform arithmetic on a parameter (normally in the constrained space), simply call `val()` on the parameter. There is no need to call `paramax.unwrap()` on a model. This commit enforces this rule by:
1. Making [_val](https://github.com/thomaspinder/GPJax/blob/main/gpjax/parameters.py#L57) public.
2. Removing the [paramax.unwrap](https://github.com/thomaspinder/GPJax/blob/main/gpjax/fit.py#L117) of models in `fit` methods - parameter constraints are already handled correctly *within* objectives, where parameters are constrained when accessed, via `val`.
3. Removing the remaining model-level unwraps in `gpjax/state_space/{objectives,prediction}.py` and `gpjax/natural_gradients.py`.
4. Altered docs/tests to respect this philosophy.

All tests still pass. The main danger of things breaking would be from the removal of `paramax.unwrap()` in the `fit` methods, but in such cases, this would manifest in errors when the objective was called as arithmetic operations would be attempted on `AbstractUnwrappable`. No such instances of these errors occur.

NOTE: `with_log_prior` has been removed for now - the way this was written had the implicit assumption that the model passed to it was in an *unwrapped* state. I will be rewriting this for the new philosophy in the next PR.