### PR TITLE
fix(linalg): register has_unit_diagonal for BlockDiag and Kronecker

### DIFF
--- a/gpjax/linalg/custom_operators.py
+++ b/gpjax/linalg/custom_operators.py
@@ -152,3 +152,13 @@ def _is_nsd_blockdiag(op):
 @lx.is_negative_semidefinite.register(Kronecker)
 def _is_nsd_kronecker(op):
     return False
+
+
+@lx.has_unit_diagonal.register(BlockDiag)
+def _has_unit_diagonal_blockdiag(op):
+    return all(lx.has_unit_diagonal(b) for b in op.blocks)
+
+
+@lx.has_unit_diagonal.register(Kronecker)
+def _has_unit_diagonal_kronecker(op):
+    return lx.has_unit_diagonal(op.A) and lx.has_unit_diagonal(op.B)

--- a/tests/test_distributions_kl.py
+++ b/tests/test_distributions_kl.py
@@ -10,6 +10,10 @@ from gpjax.distributions import (
     GaussianDistribution,
     _kl_divergence,
 )
+from gpjax.linalg import (
+    BlockDiag,
+    Kronecker,
+)
 import gpjax.linalg.utils as linalg_utils
 import jax
 import jax.numpy as jnp
@@ -277,3 +281,22 @@ def test_kl_is_jittable_for_diagonal_scale():
 
     result = jax.jit(kl_diag)(DIAG_Q, DIAG_P)
     assert jnp.abs(result - REFERENCE_KL[("diagonal", "diagonal")]) < 1e-10
+
+
+@pytest.mark.parametrize(
+    "make_scale",
+    [
+        lambda a, b: BlockDiag([a, b]),
+        lambda a, b: Kronecker(a, b),
+    ],
+    ids=["block_diag", "kronecker"],
+)
+def test_kl_divergence_supports_custom_operators(make_scale):
+    # Regression for #709: kl_divergence solves against the sqrt covariance
+    # with lx.Triangular(), which queries lx.has_unit_diagonal on the operator.
+    # BlockDiag and Kronecker did not register that predicate, so the call
+    # raised NotImplementedError instead of returning a KL value.
+    a = lx.MatrixLinearOperator(jnp.array([[2.0, 0.3], [0.3, 1.5]]))
+    b = lx.MatrixLinearOperator(jnp.array([[3.0, 0.1], [0.1, 2.0]]))
+    q = GaussianDistribution(jnp.zeros(4), make_scale(a, b))
+    assert jnp.allclose(q.kl_divergence(q), 0.0, atol=1e-5)


### PR DESCRIPTION
Fixes #709

`GaussianDistribution.kl_divergence` computes the Mahalanobis term with `lx.linear_solve(sqrt_p, diff, solver=lx.Triangular())`, and `lx.Triangular()` queries `lx.has_unit_diagonal` on the operator. `custom_operators.py` registers seven lineax predicates for `BlockDiag` and `Kronecker` (is_symmetric, is_diagonal, is_tridiagonal, is_lower_triangular, is_upper_triangular, is_positive_semidefinite, is_negative_semidefinite) but not `has_unit_diagonal`, so KL divergence with either operator raised:

```
NotImplementedError: `lineax.has_unit_diagonal` has not been implemented for
  <class 'gpjax.linalg.custom_operators.BlockDiag'>
```

`cholesky_factor` already dispatches on these operators (the traceback reaches `has_unit_diagonal`, past factorisation), so registering the predicate is all that is needed. I added it for both, composed over the sub-operators exactly like the neighbouring predicates: `all(has_unit_diagonal(b) for b in blocks)` for `BlockDiag`, `has_unit_diagonal(A) and has_unit_diagonal(B)` for `Kronecker`. That is conservatively correct: it only reports a unit diagonal when the composition genuinely has one, so a general block never gets treated as unit-diagonal.

Added a regression test to `test_distributions_kl.py`, parametrised over both operators, asserting `kl_divergence` runs and `KL(q || q) == 0`. It reproduces the issue's example.

Note: I could not run the suite locally because jax has no wheels for my Python version, so I verified the change against the source: it mirrors the seven existing predicate registrations, and the added test uses the same public constructors as the issue's repro. Happy to adjust if CI surfaces anything.