### PR TITLE
ci: wire up the zizmor audit and clear its findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
       day: "monday"
       time: "04:00"
       timezone: "Europe/Amsterdam"
+    # Wait a week after a release before proposing it: fresh releases are where
+    # compromised or yanked packages show up, and nothing here is urgent.
+    # Security updates are exempt from the cooldown by Dependabot itself.
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     assignees:
       - "thomaspinder"
@@ -46,6 +51,8 @@ updates:
       day: "monday"
       time: "04:00"
       timezone: "Europe/Amsterdam"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     commit-message:
       prefix: "ci"

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,6 +1,12 @@
 name: "Automatic Labeling"
 
-on:
+# `pull_request_target` is required, not incidental: labelling a PR needs write
+# access to the pull request, and the `pull_request` token is read-only for
+# fork PRs, which is most of them. The standard danger of this trigger is
+# running fork code with a privileged token, so this workflow never checks the
+# PR out and never executes anything from it — every step below talks to the
+# API only.
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types: [opened, synchronize, reopened]
   issues:
@@ -14,20 +20,19 @@ jobs:
       issues: write
       pull-requests: write
 
+    # No checkout: `actions/labeler` reads .github/labeler.yml through the API,
+    # and nothing else here touches the working tree.
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
       - name: Auto-label based on files changed
-        if: github.event_name == 'pull_request'
-        uses: actions/labeler@v7
+        if: github.event_name == 'pull_request_target'
+        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml
 
       - name: Size labeling for PRs
-        if: github.event_name == 'pull_request'
-        uses: codelytv/pr-size-labeler@v1
+        if: github.event_name == 'pull_request_target'
+        uses: codelytv/pr-size-labeler@095a41fca88b8764fd9e008ad269bcdb82bb38b9 # v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_label: 'size/xs'
@@ -45,7 +50,7 @@ jobs:
 
       - name: Label ML-specific issues
         if: github.event_name == 'issues'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const title = context.payload.issue.title.toLowerCase();
@@ -143,8 +148,8 @@ jobs:
             }
 
       - name: Label PRs based on content
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v9
+        if: github.event_name == 'pull_request_target'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const title = context.payload.pull_request.title.toLowerCase();

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -15,10 +15,10 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+# Pages publication is confined to `deploy-docs`; the build job only reads the
+# repository. Keeping `pages`/`id-token` off the workflow level means the
+# notebook execution step never runs with a deployment-capable token.
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,19 +30,21 @@ jobs:
     # Full render on main executes every example notebook for real.
     timeout-minutes: 120
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout, including the asv-results branch
     steps:
       - name: Check out the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
           enable-cache: true
@@ -58,7 +60,7 @@ jobs:
         # refuses to overwrite an existing key). Combined with jupyter-cache's
         # own content-hash invalidation, this makes the cache accumulate every
         # successfully executed notebook instead of freezing partial progress.
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             docs/_build/.jupyter_cache
@@ -83,7 +85,7 @@ jobs:
         # traceback of any failed notebook to <outdir>/reports/<docname>.err.log
         # rather than aborting. Nothing else in the deploy log carries it.
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: notebook-error-logs
           path: docs/_build/html/reports
@@ -91,7 +93,7 @@ jobs:
           retention-days: 14
 
       - name: Checkout benchmark results
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: asv-results
           path: .asv-results
@@ -110,7 +112,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: docs/_build/html
 
@@ -123,6 +125,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      pages: write # deploy to GitHub Pages
+      id-token: write # OIDC verification of the deployment
     concurrency:
       group: pages
       cancel-in-progress: false
@@ -132,4 +137,4 @@ jobs:
     steps:
       - name: Deploy documentation
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -13,9 +13,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check commit message format
         run: |

--- a/.github/workflows/full_render_notebooks.yml
+++ b/.github/workflows/full_render_notebooks.yml
@@ -11,30 +11,39 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: read
-  issues: write
+# Only the failure-reporting job files an issue. The render job itself, which
+# executes every example notebook, runs with a read-only token.
+permissions: {}
 
 jobs:
   full-render:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout
     timeout-minutes: 90
     steps:
       - name: Check out the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.11"
 
+      # The three cache steps below carry `zizmor: ignore[cache-poisoning]`.
+      # zizmor flags them because `release: published` makes this a publishing
+      # workflow, and a cache written under a publishing event can be restored
+      # by later runs. That is exactly what the guards prevent: caching is
+      # switched off whenever the run was triggered by a release, so only the
+      # scheduled and manual runs read or write the cache. zizmor evaluates the
+      # workflow statically and cannot see through the expression.
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7 # zizmor: ignore[cache-poisoning]
         with:
           version: "latest"
-          enable-cache: true
+          enable-cache: ${{ github.event_name != 'release' }}
 
       - name: Install docs dependencies
         run: uv sync --frozen --extra docs
@@ -46,7 +55,8 @@ jobs:
         # Same accumulate-always cache as build_docs.yml: the Sunday full render
         # warms `.jupyter_cache`, so the next production deploy reuses real
         # figures instead of re-executing every notebook (or erroring out).
-        uses: actions/cache@v6
+        if: github.event_name != 'release' # see the enable-cache note above
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning]
         with:
           path: |
             docs/_build/.jupyter_cache
@@ -64,7 +74,8 @@ jobs:
           echo "version=$(uv run --extra docs python -c 'from importlib.metadata import version; print(version("playwright"))')" >> "$GITHUB_OUTPUT"
 
       - name: Restore the Playwright browser cache
-        uses: actions/cache@v6
+        if: github.event_name != 'release' # see the enable-cache note above
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0 # zizmor: ignore[cache-poisoning]
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
@@ -92,7 +103,7 @@ jobs:
 
       - name: Upload the link-check report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: docs-linkcheck
           path: docs/_build/linkcheck
@@ -101,10 +112,12 @@ jobs:
   open-issue-on-failure:
     runs-on: ubuntu-latest
     needs: full-render
+    permissions:
+      issues: write # open the failure report
     if: failure()
     steps:
       - name: Open GitHub issue
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const title = `Notebook full render failed (${context.runNumber})`;

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# The job only reads the checkout and runs the integration script.
+permissions: {}
+
 jobs:
   integration-tests:
     name: Run Integration Tests
@@ -22,17 +25,18 @@ jobs:
       fail-fast: true
     steps:
       - name: Check out the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ matrix.python-version }}
 
       # Install uv
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
           enable-cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,29 +16,37 @@ on:
         default: false
         type: boolean
 
-permissions:
-  contents: write
-  id-token: write # For PyPI trusted publishing
+# Every job below grants itself the narrowest scope it needs. Only
+# `create-release` writes contents, and only `publish-pypi` gets an OIDC token,
+# so the test, scan and build jobs — the ones that execute repository code —
+# run with a read-only token.
+permissions: {}
 
 jobs:
   validate-release:
     name: "Release Validation"
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read # checkout
     outputs:
       version: ${{ steps.version.outputs.version }}
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Extract version
         id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version }}"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
           else
             VERSION=${GITHUB_REF#refs/tags/}
           fi
@@ -46,8 +54,9 @@ jobs:
           echo "Version: $VERSION"
 
       - name: Validate version format
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
           if [[ ! $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+)?$ ]]; then
             echo "Invalid version format: $VERSION"
             echo "Expected format: v1.2.3 or v1.2.3-alpha1"
@@ -71,20 +80,27 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    permissions:
+      contents: read # checkout
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
-          enable-cache: true
+          # No cache on a release run: a tag push is a publishing event, so
+          # anything it writes to the shared cache would be restored by later
+          # branch builds. The release path runs once, so the saving is noise.
+          enable-cache: false
 
       - name: Install dependencies
         run: |
@@ -110,20 +126,24 @@ jobs:
     needs: validate-release
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read # checkout
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
-          enable-cache: true
+          enable-cache: false # see the note in multi-platform-tests
 
       - name: Install dependencies
         run: |
@@ -139,7 +159,7 @@ jobs:
           uv run bandit -r gpjax/ -f json -o bandit-report.json || echo "Bandit scan completed with warnings"
 
       - name: Upload security reports
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: security-reports
           path: |
@@ -151,20 +171,24 @@ jobs:
     needs: [validate-release, multi-platform-tests, security-scan]
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read # checkout
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
-          enable-cache: true
+          enable-cache: false # see the note in multi-platform-tests
 
       - name: Build package
         run: |
@@ -176,7 +200,7 @@ jobs:
           uv run twine check dist/*
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dist-packages
           path: dist/
@@ -187,21 +211,25 @@ jobs:
     needs: validate-release
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read # checkout
     outputs:
       changelog: ${{ steps.changelog.outputs.changelog }}
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Generate changelog
         id: changelog
+        env:
+          CURRENT_TAG: ${{ needs.validate-release.outputs.version }}
         run: |
           # Get the previous tag
           PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo "")
-          CURRENT_TAG="${{ needs.validate-release.outputs.version }}"
 
           echo "Generating changelog from $PREVIOUS_TAG to $CURRENT_TAG"
 
@@ -270,35 +298,55 @@ jobs:
     needs: [validate-release, build-package, generate-changelog]
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write # create the release
+      actions: read # download the build artifacts
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist-packages
           path: dist/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ needs.validate-release.outputs.version }}
-          name: "GPJax ${{ needs.validate-release.outputs.version }}"
-          body: ${{ needs.generate-changelog.outputs.changelog }}
-          draft: ${{ github.event.inputs.draft == 'true' }}
-          prerelease: ${{ contains(needs.validate-release.outputs.version, '-') }}
-          files: |
-            dist/*.tar.gz
-            dist/*.whl
-          generate_release_notes: true
+        # `gh` ships on the runner, so the release is cut with the same token
+        # and no third-party action in the publishing path.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.validate-release.outputs.version }}
+          CHANGELOG: ${{ needs.generate-changelog.outputs.changelog }}
+          DRAFT: ${{ github.event.inputs.draft == 'true' }}
+          PRERELEASE: ${{ contains(needs.validate-release.outputs.version, '-') }}
+        run: |
+          printf '%s\n' "$CHANGELOG" > release-notes.md
+          args=(
+            --title "GPJax $VERSION"
+            --notes-file release-notes.md
+            --generate-notes
+            --target "$GITHUB_SHA"
+          )
+          if [ "$DRAFT" = "true" ]; then
+            args+=(--draft)
+          fi
+          if [ "$PRERELEASE" = "true" ]; then
+            args+=(--prerelease)
+          fi
+          gh release create "$VERSION" "${args[@]}" dist/*.tar.gz dist/*.whl
 
   publish-pypi:
     name: "Publish to PyPI"
     needs: [validate-release, create-release]
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      id-token: write # PyPI trusted publishing
+      actions: read # download the build artifacts
     # Only publish on actual tag push, not workflow_dispatch
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     environment:
@@ -307,12 +355,12 @@ jobs:
 
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dist-packages
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           print-hash: true

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -9,21 +9,25 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Lint only: the job reads the checkout and writes nothing back.
+permissions: {}
+
 jobs:
   ruff:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Check out the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       # Resolve ruff from uv.lock rather than the network. A floating ruff
       # means a new release can turn every open PR red without a commit having
       # been made — which is exactly what the PLR0917 stabilisation did.
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
           enable-cache: true

--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -14,28 +14,33 @@ on:
   schedule:
     - cron: '30 4 * * 1'  # Weekly on Mondays at 4:30 AM UTC
 
-permissions:
-  contents: read
-  security-events: write
-  actions: read
+# Neither job writes back to GitHub: the dependency scan uploads its reports as
+# workflow artifacts and TruffleHog reports through the step log, so no
+# security-events scope is needed. Each job grants itself read access for its
+# own checkout.
+permissions: {}
 
 jobs:
   dependency-scan:
     name: Dependency Vulnerability Scan
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    
+    permissions:
+      contents: read # checkout
+
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
       with:
         python-version: '3.11'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       with:
         version: "latest"
         enable-cache: true
@@ -57,7 +62,7 @@ jobs:
         uv run bandit -r gpjax/ -f json -o bandit-report.json -ll
 
     - name: Upload dependency scan results
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: always()
       with:
         name: security-scan-results
@@ -70,15 +75,18 @@ jobs:
     name: Secrets Detection
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    
+    permissions:
+      contents: read # checkout
+
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
-        fetch-depth: 0  # Fetch full history for comprehensive scanning
+        fetch-depth: 0 # Fetch full history for comprehensive scanning
+        persist-credentials: false
 
     - name: Run TruffleHog OSS
-      uses: trufflesecurity/trufflehog@main
+      uses: trufflesecurity/trufflehog@96b593f460badf7a3da2ad3487e0e4986243ef03 # main
       with:
         path: ./
         # `--exclude-detectors=lob`: TruffleHog's Lob key pattern is

--- a/.github/workflows/test_docs.yml
+++ b/.github/workflows/test_docs.yml
@@ -30,17 +30,17 @@ jobs:
       NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
     steps:
       - name: Check out the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.11"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
           enable-cache: true
@@ -79,7 +79,7 @@ jobs:
         # actions/cache always re-saves, with restore-keys picking up the newest
         # previous cache. Both directories are carried because the smoke and full
         # renders keep separate jupyter-cache stores.
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             docs/_build/.jupyter_cache
@@ -100,7 +100,7 @@ jobs:
           echo "version=$(uv run --extra docs python -c 'from importlib.metadata import version; print(version("playwright"))')" >> "$GITHUB_OUTPUT"
 
       - name: Restore the Playwright browser cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
@@ -124,7 +124,7 @@ jobs:
         # deployments are unsupported on this plan and silently deploy to the
         # production URL, so the job that used to live here was replacing the
         # published docs with a PR's smoke render.
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: docs-smoke-render
           path: docs/_build/html
@@ -152,7 +152,7 @@ jobs:
 
       - name: Comment the preview URL on the PR
         if: steps.netlify.outputs.url != ''
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: docs-preview
           message: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# The job reads the repository and uploads coverage with a dedicated Codecov
+# token; it never needs a GITHUB_TOKEN scope.
+permissions: {}
+
 jobs:
   unit-tests:
     name: Run Tests
@@ -21,17 +25,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ matrix.python-version }}
 
       # Install uv
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
           enable-cache: true
@@ -48,7 +53,7 @@ jobs:
 
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,10 @@ dev = [
   "poethepoet>=0.37.0",
   "twine>=6.2.0",
   "hypothesis>=6.148.2",
+  # Workflow security audit (`poe lint-actions`, .github/workflows/zizmor.yml).
+  # Pinned through uv.lock rather than `uvx zizmor@latest` so a new release
+  # cannot turn every open PR red without a commit.
+  "zizmor>=1.14",
   # Dev-only live-reload docs server (`poe docs-live`). Deliberately NOT in the
   # `docs` extra: CI has no use for a watcher, and keeping it out means it can
   # never affect a published build.
@@ -155,6 +159,15 @@ sequence = [
   { cmd = "ruff check --no-fix ./gpjax ./tests ./benchmarks" }
 ]
 help = "Check code formatting and style without mutating files (used by CI)"
+
+# Local counterpart of .github/workflows/zizmor.yml. The workflow renders SARIF
+# for code scanning; this renders the annotated form a human wants, and unlike
+# SARIF it exits 14 when there are findings, so it gates on its own exit code.
+# The online audits resolve action refs through the GitHub API: export
+# GH_TOKEN=$(gh auth token) to enable them, or they are skipped silently.
+[tool.poe.tasks.lint-actions]
+cmd = "zizmor ."
+help = "Audit the GitHub Actions workflows with zizmor"
 
 # Testing tasks
 [tool.poe.tasks.test]

--- a/uv.lock
+++ b/uv.lock
@@ -572,7 +572,7 @@ name = "cryptography"
 version = "46.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9f/33/c00162f49c0e2fe8064a62cb92b93e50c74a72bc370ab92f86112b33ff62/cryptography-46.0.3.tar.gz", hash = "sha256:a8b17438104fed022ce745b362294d9ce35b4c2e45c1d958ad4a4b019285f4a1", size = 749258, upload-time = "2025-10-15T23:18:31.74Z" }
 wheels = [
@@ -840,6 +840,7 @@ dev = [
     { name = "sphinx-autobuild" },
     { name = "twine" },
     { name = "xdoctest" },
+    { name = "zizmor" },
 ]
 
 [package.metadata]
@@ -906,6 +907,7 @@ dev = [
     { name = "sphinx-autobuild", specifier = ">=2024.10" },
     { name = "twine", specifier = ">=6.2.0" },
     { name = "xdoctest", specifier = ">=1.1.1" },
+    { name = "zizmor", specifier = ">=1.14" },
 ]
 
 [[package]]
@@ -2148,7 +2150,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3050,8 +3052,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -3127,23 +3129,23 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.12'" },
-    { name = "babel", marker = "python_full_version < '3.12'" },
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version < '3.12'" },
-    { name = "imagesize", marker = "python_full_version < '3.12'" },
-    { name = "jinja2", marker = "python_full_version < '3.12'" },
-    { name = "packaging", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "requests", marker = "python_full_version < '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version < '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -3166,23 +3168,23 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
@@ -3915,4 +3917,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
+]
+
+[[package]]
+name = "zizmor"
+version = "1.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/f8/f4e3fc0b316d5241b6d6968e8fb702e28446bc7d3c1e2b229f4caa6eacf2/zizmor-1.29.0.tar.gz", hash = "sha256:60e34e83c67064e0036989c7c525d13413e897aa4c4f683f1efb2048cdb28a47", size = 571865, upload-time = "2026-08-01T21:09:19.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/97/667ef4db0ca9225ee402c1b947b5b6f17fd234d72c15a71db150b7695c62/zizmor-1.29.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ea72f84d610643d57f96430c655a3780d0b874e477d32e14eae8e910f6cce1fd", size = 9037504, upload-time = "2026-08-01T21:08:56.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d4/9fc7deaf75778e7516fa1d6c836377c3cb5d203dedc28899946b6f11ecdb/zizmor-1.29.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5aafe617d7b1e0c0c15d58fdf20495f360f74a791dfa136f76630b4cc06c2a34", size = 8654426, upload-time = "2026-08-01T21:08:59.212Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/f6/6db714fb0aa08aeec62eb9d6ad6a443a1f4ed50d4c0b789944ae55fb83e4/zizmor-1.29.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:67644ae8d6d0394204b9a488f7d86f0dd66fe562f4ba85fc53e6105a6bfc7b6a", size = 8918927, upload-time = "2026-08-01T21:09:01.46Z" },
+    { url = "https://files.pythonhosted.org/packages/15/40/a12edc0c0c0a0101c54dbb9099ff08f8de2fcb35c36cb706db3deb2c2728/zizmor-1.29.0-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:81e4093fed5c8a41d6ae7bb773085a9d2e6c0b0a0b560d46a9c76d69be0a07ed", size = 8500655, upload-time = "2026-08-01T21:09:03.677Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f0/dfa67018b76bc4f2f50e265e8cbd1293833d1b1de5f3f02fbbb7487ae9c6/zizmor-1.29.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:587b99c2e1b34575c6c8565c2bfde415ca8bc0310f5589f19bc948c8dea10a20", size = 9351035, upload-time = "2026-08-01T21:09:06.16Z" },
+    { url = "https://files.pythonhosted.org/packages/90/1b/93cdd5a06984b394d90001f9778008a21689052904109080a09952626c99/zizmor-1.29.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:061600f23c46f2e400bcdef666c236de7e5c0b07dd6ca046daa001eb1514b909", size = 8941717, upload-time = "2026-08-01T21:09:08.861Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/f4/8d9e54405b477bc8e4b56c1a60123fca26c109ea6a762eea104fab32555e/zizmor-1.29.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:332546480be38aca95c149f835e0dcb7679ab5d74618a90c6ccb3fa6b8c7b99d", size = 8468289, upload-time = "2026-08-01T21:09:11.096Z" },
+    { url = "https://files.pythonhosted.org/packages/72/86/06d57ca830cc4653369c5aca22cccbf04c8c36ee84a67f351214e556bad8/zizmor-1.29.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a7462b9ab45d72a20ad5ab8193b430df8184c59e2bf46954ddd09496f2f00b45", size = 9446505, upload-time = "2026-08-01T21:09:13.38Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f4/253d9a3538e0ea6f96a3bcd69839c0c5a816a00299620b58a10b5bd1df59/zizmor-1.29.0-py3-none-win32.whl", hash = "sha256:8c759e68cd866375030ca39e19e2de47a056b7be7288c1620e2d5b4c274f631f", size = 7655723, upload-time = "2026-08-01T21:09:15.758Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/2d/7919bc23475273ed8038a031fc24bc3f2005c78e608ce8df96746ef0fb98/zizmor-1.29.0-py3-none-win_amd64.whl", hash = "sha256:0fb85948ba5ffc7a8116eee36fe9cfc10167225c97bd2810e3378e66a9fd27c4", size = 8785519, upload-time = "2026-08-01T21:09:17.513Z" },
 ]


### PR DESCRIPTION
Follow-up to #772, which started to track `zizmor.yml` but noted it could not pass.

## Motivation

`.github/workflows/zizmor.yml` was never functional:

1. `uv run --frozen --only-group dev zizmor` had no `zizmor` in the `dev` group.
2. The `poe lint-actions` task its error message points at did not exist.
3. The audit reported **96 findings** on this repository, so the gate step would fail as soon as the tool was installed.

All three are fixed here. `uv run poe lint-actions` now reports no findings, and the workflow's own gate counts 0 results in the SARIF.

## Tooling

- `zizmor` added to the `dev` group and resolved through `uv.lock`, the same way `ruff` is: a new zizmor release ships new audits, and an unpinned tool would turn every open PR red without a commit having been made.
- `poe lint-actions` runs the annotated output a human wants. Plain output exits 14 on findings (SARIF always exits 0), so the task gates on its own exit code.

## Findings fixed

| Rule | Count | Fix |
|---|---|---|
| `unpinned-uses` | 61 | Every action pinned to a commit SHA, with the release tag in a trailing comment for Dependabot. |
| `artipacked` | 13 | `persist-credentials: false` on every checkout. No job pushes with git. |
| `excessive-permissions` | 9 | `permissions: {}` at workflow level; each job grants itself the narrowest scope. |
| `cache-poisoning` | 6 | `release.yml` no longer caches; the full render disables caching on release-triggered runs. |
| `template-injection` | 3 | `release.yml` interpolations moved into `env`. |
| `dependabot-cooldown` | 2 | Seven-day cooldown on both update entries. |
| `dangerous-triggers` | 1 | `auto-label` keeps `pull_request_target` but no longer checks out any code. |
| `superfluous-actions` | 1 | `softprops/action-gh-release` replaced with `gh release create`. |

The permissions change is the one worth reviewing closely. The jobs that execute repository code — tests, security scans, notebook renders, package builds — now run with a read-only token. Only `create-release` holds `contents: write`, and only `deploy-docs` and `publish-pypi` hold a write or OIDC scope:

```
release.yml         workflow {}       validate/tests/scan/build/changelog: contents: read
                                      create-release:  contents: write, actions: read
                                      publish-pypi:    id-token: write, actions: read
build_docs.yml      workflow {}       build-docs:      contents: read
                                      deploy-docs:     pages: write, id-token: write
full_render.yml     workflow {}       full-render:     contents: read
                                      open-issue:      issues: write
security-analysis   workflow {}       both jobs:       contents: read
```

`security-analysis.yml` previously held `security-events: write` at workflow level, but neither job uploads SARIF — the dependency scan writes artifacts and TruffleHog reports through the step log — so the scope is gone rather than moved.

## Two scoped ignores

Both carry their reasoning in a comment next to the ignore:

- **`cache-poisoning`** on the three cache steps in `full_render_notebooks.yml`. Caching is switched off whenever the run came from `release: published`, which is the mitigation the rule asks for; zizmor evaluates statically and cannot see through `${{ github.event_name != 'release' }}`.
- **`dangerous-triggers`** on `auto-label.yml`. Labelling a fork PR needs a write-capable token, which `pull_request` does not give. The danger of the trigger is running fork code with that token, and the workflow now checks nothing out — every step talks to the API only.

## Latent bug found while editing

`auto-label.yml` guarded three of its four steps on `github.event_name == 'pull_request'`. Under `pull_request_target` that expression is never true, so file-based labelling, size labelling and content labelling had all been dead. They are now guarded on `pull_request_target`.

## Release step rewrite

`softprops/action-gh-release` became a `gh release create` script step, keeping the title, notes, draft, prerelease and asset behaviour:

```bash
printf '%s\n' "$CHANGELOG" > release-notes.md
args=(--title "GPJax $VERSION" --notes-file release-notes.md --generate-notes --target "$GITHUB_SHA")
if [ "$DRAFT" = "true" ]; then args+=(--draft); fi
if [ "$PRERELEASE" = "true" ]; then args+=(--prerelease); fi
gh release create "$VERSION" "${args[@]}" dist/*.tar.gz dist/*.whl
```

## Verification

```
uv run poe lint-actions
# No findings to report. Good job! (4 ignored, 24 suppressed) — exit 0

GH_TOKEN=... uv run --frozen --only-group dev zizmor --format sarif . > results.sarif
jq '[.runs[].results[]] | length' results.sarif   # 0
```

Every workflow file also parses as YAML and every job still has a `steps` block. `uv.lock` gained `zizmor` only — no other package moved.