### PR TITLE
Add functionality for MAP estimation of parameters

### DIFF
--- a/gpjax/objectives.py
+++ b/gpjax/objectives.py
@@ -13,6 +13,7 @@ from gpjax.gps import (
 from gpjax.likelihoods import (
     AbstractHeteroscedasticLikelihood,
 )
+from gpjax.parameters import collect_log_prior
 from gpjax.typing import (
     Array,
     ScalarFloat,
@@ -29,7 +30,81 @@ DVF = TypeVar("DVF", bound=DualVariationalGaussian)
 
 
 Objective = tpe.Callable[[eqx.Module, Dataset], ScalarFloat]
-LogPriorFn = tpe.Callable[[eqx.Module], ScalarFloat]
+
+
+def with_log_prior(objective: Objective) -> Objective:
+    r"""Regularise an objective with the priors attached to a model's parameters.
+
+    Returns a new :data:`Objective` computing
+    :math:`objective(model, data) + \sum_i \log p(\theta_i)`,
+    where the sum runs over every :class:`gpjax.parameters.Parameter` carrying
+    a ``prior``. The result can be passed straight to :func:`gpjax.fit`,
+    :func:`gpjax.fit_scipy`, or :func:`gpjax.fit_lbfgs`, giving MAP-regularised
+    fitting.
+
+    Parameters without a prior are left unregularised, so a prior on a single
+    hyperparameter is enough -- there is no need to specify one for every leaf.
+
+    Note:
+        Priors are evaluated on the *constrained* parameter values, so the
+        optimum is the MAP estimate under the conventional parameterisation.
+
+    Priors that are not separable over individual parameters -- a prior on a
+    derived quantity such as the signal-to-noise ratio -- do not fit on a
+    single parameter. Write those as an ordinary objective, using
+    :func:`gpjax.parameters.val` to read the parameters you need::
+
+        from gpjax.parameters import val
+
+        def snr_regularised_mll(model, data):
+            snr = val(model.prior.kernel.variance) / val(
+                model.likelihood.obs_stddev
+            ) ** 2
+            return conjugate_mll(model, data) + dist.LogNormal(
+                jnp.log(100.0), 1.0
+            ).log_prob(snr).sum()
+
+    Example:
+        >>> import gpjax as gpx
+        >>> import jax.numpy as jnp
+        >>> import numpyro.distributions as dist
+        >>> import optax as ox
+        >>>
+        >>> xtrain = jnp.linspace(0, 1, 50).reshape(-1, 1)
+        >>> ytrain = jnp.sin(xtrain)
+        >>> D = gpx.Dataset(X=xtrain, y=ytrain)
+        >>>
+        >>> kernel = gpx.kernels.RBF(
+        ...     lengthscale=gpx.parameters.PositiveReal(
+        ...         1.0, prior=dist.LogNormal(jnp.log(5.0), 0.5)
+        ...     )
+        ... )
+        >>> meanf = gpx.mean_functions.Constant()
+        >>> likelihood = gpx.likelihoods.Gaussian()
+        >>> posterior = gpx.gps.Prior(mean_function=meanf, kernel=kernel) * likelihood
+        >>>
+        >>> regularised_mll = gpx.objectives.with_log_prior(
+        ...     gpx.objectives.conjugate_mll
+        ... )
+        >>> nmll = lambda p, d: -regularised_mll(p, d)
+        >>> trained_model, history = gpx.fit(
+        ...     model=posterior, objective=nmll, train_data=D,
+        ...     optim=ox.adam(0.01), num_iters=100, verbose=False,
+        ... )
+
+    Args:
+        objective (Objective): The objective to regularise, e.g.
+            ``conjugate_mll`` or ``elbo``.
+
+    Returns:
+        Objective: A new objective adding the summed parameter log-priors to
+        ``objective``.
+    """
+
+    def _regularised_objective(model: eqx.Module, data: Dataset) -> ScalarFloat:
+        return objective(model, data) + collect_log_prior(model)
+
+    return _regularised_objective
 
 
 def conjugate_mll(model: ConjugateModel, data: Dataset) -> ScalarFloat:
@@ -510,7 +585,6 @@ def heteroscedastic_elbo(variational_family: HVF, data: Dataset) -> ScalarFloat:
 
 
 __all__ = [
-    "LogPriorFn",
     "Objective",
     "collapsed_elbo",
     "conjugate_loocv",
@@ -522,4 +596,5 @@ __all__ = [
     "log_posterior_density",
     "non_conjugate_mll",
     "variational_expectation",
+    "with_log_prior",
 ]

--- a/gpjax/parameters.py
+++ b/gpjax/parameters.py
@@ -5,6 +5,7 @@ import jax
 from jax.nn import softplus
 import jax.numpy as jnp
 import jax.random as jr
+import numpyro.distributions as npd
 from numpyro.distributions import biject_to, constraints
 from numpyro.distributions.transforms import SoftplusLowerCholeskyTransform
 import paramax
@@ -83,7 +84,48 @@ def val(x):
     return paramax.unwrap(x) if isinstance(x, AbstractUnwrappable) else x
 
 
-class PositiveReal(AbstractUnwrappable):
+class _OpaquePrior:
+    """Non-pytree holder for a prior distribution.
+
+    A NumPyro ``Distribution`` is a pytree whose hyperparameters are usually
+    JAX arrays. Holding the distribution in a plain object, which is not registered as
+    a pytree, prevents its parameters from being trained. Solely marking the NumPyro
+    ``Distribution`` itself as a static Equinox field does not work as Equinox
+    complains about having JAX arrays present in the static field.
+    """
+
+    def __init__(self, distribution: npd.Distribution):
+        self.distribution = distribution
+
+    def __repr__(self) -> str:
+        return repr(self.distribution)
+
+
+class Parameter(AbstractUnwrappable):
+    """Base class for GPJax parameters, carrying an optional prior.
+
+    The prior is static and stored as an _OpaquePrior, which is not registered as a
+    pytree node. This prevents the prior's parameters from being optimised.
+
+    Attach one by passing ``prior=`` to any parameter and read it back from the
+    ``prior`` property::
+
+        PositiveReal(1.0, prior=numpyro.distributions.LogNormal(0.0, 1.0))
+
+    :func:`collect_log_prior` sums these over a model, and
+    :func:`gpjax.objectives.with_log_prior` turns that sum into
+    MAP-regularised fitting. Note that the prior is placed in *constrained* space.
+    """
+
+    _prior: _OpaquePrior | None = eqx.field(static=True)
+
+    @property
+    def prior(self) -> npd.Distribution | None:
+        """The prior distribution attached to this parameter, if any."""
+        return None if self._prior is None else self._prior.distribution
+
+
+class PositiveReal(Parameter):
     """Strictly positive parameter.
 
     Stored unconstrained via the inverse of the softplus transform;
@@ -93,15 +135,16 @@ class PositiveReal(AbstractUnwrappable):
     _constraint = constraints.softplus_positive
     _unconstrained: jax.Array
 
-    def __init__(self, value):
+    def __init__(self, value, prior=None):
         transform = biject_to(self._constraint)
         self._unconstrained = transform.inv(jnp.asarray(value))
+        self._prior = None if prior is None else _OpaquePrior(prior)
 
     def unwrap(self):
         return biject_to(self._constraint)(self._unconstrained)
 
 
-class NonNegativeReal(AbstractUnwrappable):
+class NonNegativeReal(Parameter):
     """Non-negative parameter (semantically allows zero, e.g. jitter, noise floor).
 
     Uses the same softplus bijection as PositiveReal. The distinction is
@@ -111,40 +154,43 @@ class NonNegativeReal(AbstractUnwrappable):
     _constraint = constraints.softplus_positive
     _unconstrained: jax.Array
 
-    def __init__(self, value):
+    def __init__(self, value, prior=None):
         transform = biject_to(self._constraint)
         self._unconstrained = transform.inv(jnp.asarray(value))
+        self._prior = None if prior is None else _OpaquePrior(prior)
 
     def unwrap(self):
         return biject_to(self._constraint)(self._unconstrained)
 
 
-class Real(AbstractUnwrappable):
+class Real(Parameter):
     """Unconstrained parameter. unwrap() returns the value unchanged."""
 
     _constraint = constraints.real
     value: jax.Array
 
-    def __init__(self, value):
+    def __init__(self, value, prior=None):
         self.value = jnp.asarray(value)
+        self._prior = None if prior is None else _OpaquePrior(prior)
 
     def unwrap(self):
         return self.value
 
 
-class SigmoidBounded(AbstractUnwrappable):
+class SigmoidBounded(Parameter):
     """Parameter bounded to [low, high] via sigmoid bijection."""
 
     _unconstrained: jax.Array
     low: float = eqx.field(static=True)
     high: float = eqx.field(static=True)
 
-    def __init__(self, value, *, low=0.0, high=1.0):
+    def __init__(self, value, *, low=0.0, high=1.0, prior=None):
         value = jnp.asarray(value)
         transform = biject_to(constraints.interval(low, high))
         self._unconstrained = transform.inv(value)
         self.low = low
         self.high = high
+        self._prior = None if prior is None else _OpaquePrior(prior)
 
     @property
     def _constraint(self):
@@ -193,12 +239,42 @@ class CoregionalizationMatrix(eqx.Module):
         return w @ w.T + jnp.diag(k)
 
 
+def collect_log_prior(model) -> jax.Array:
+    r"""Sum the log-densities of every prior attached to a model's parameters.
+
+    Walks ``model`` for :class:`Parameter` leaves carrying a ``prior`` and
+    accumulates :math:`\sum_i \log p(\theta_i)`, evaluated at each parameter's
+    *constrained* value. Parameters without a prior contribute nothing.
+
+    Must be called on a model whose parameters are still wrapped --
+    ``paramax.unwrap`` replaces :class:`Parameter` leaves with bare arrays and
+    so discards the priors along with them.
+
+    Args:
+        model: Any pytree containing :class:`Parameter` leaves.
+
+    Returns:
+        Scalar total log-prior density; ``0.0`` when no parameter has a prior.
+    """
+    total = jnp.asarray(0.0)
+
+    def is_param(leaf):
+        return isinstance(leaf, Parameter)
+
+    for leaf in jax.tree.leaves(model, is_leaf=is_param):
+        if is_param(leaf) and leaf.prior is not None:
+            total = total + jnp.sum(leaf.prior.log_prob(val(leaf)))
+    return total
+
+
 __all__ = [
     "CoregionalizationMatrix",
     "LowerTriangular",
     "NonNegativeReal",
+    "Parameter",
     "PositiveReal",
     "Real",
     "SigmoidBounded",
+    "collect_log_prior",
     "val",
 ]

--- a/gpjax/summary.py
+++ b/gpjax/summary.py
@@ -141,8 +141,11 @@ def _collect(
 ) -> list[ParamRecord]:
     """Walk ``model`` and produce one :class:`ParamRecord` per parameter.
 
-    ``priors`` optionally maps a parameter's name (as shown in the Parameter
-    column) to a prior object, populating the otherwise-empty Prior column.
+    The Prior column is populated from each parameter's own
+    :attr:`~gpjax.parameters.Parameter.prior`. ``priors`` optionally maps a
+    parameter's name (as shown in the Parameter column) to a prior object,
+    overriding the attached one -- useful when the priors live outside the
+    model, as they do when sampling with NumPyro.
     """
     prior_map = priors or {}
     records: list[ParamRecord] = []
@@ -167,7 +170,7 @@ def _collect(
                 cls=cls,
                 value=value,
                 bijector=_bijector_name(leaf) if is_param else "Identity",
-                prior=prior_map.get(name),
+                prior=prior_map.get(name, getattr(leaf, "prior", None)),
                 trainable=not _is_frozen(leaf),
                 shape=tuple(getattr(value, "shape", ())),
                 dtype=_short_dtype(value.dtype) if hasattr(value, "dtype") else "?",
@@ -242,8 +245,11 @@ def summarise(
         precision: Significant figures for numeric values.
         title: Table title; defaults to the model's class name.
         priors: Optional mapping from a parameter's name (as shown in the
-            Parameter column) to a prior object (e.g. a NumPyro distribution),
-            used to populate the Prior column. Defaults to ``None`` (all ``-``).
+            Parameter column) to a prior object (e.g. a NumPyro distribution).
+            Overrides the prior attached to that parameter, and is the way to
+            show priors that live outside the model -- NumPyro ``sample`` sites,
+            for instance. Parameters absent from the mapping fall back to their
+            own ``prior``, so a model built with ``prior=`` needs no mapping.
 
     Example:
         >>> import gpjax as gpx

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -15,9 +15,11 @@ from gpjax.objectives import (
     dual_elbo,
     elbo,
     non_conjugate_mll,
+    with_log_prior,
 )
 from gpjax.parameters import (
     PositiveReal,
+    collect_log_prior,
     val,
 )
 from gpjax.variational_families import DualVariationalGaussian
@@ -28,6 +30,7 @@ import jax.random as jr
 import jax.scipy as jsp
 import jax.tree_util as jtu
 import numpy as np
+import numpyro.distributions as npd
 import pytest
 
 from tests._dual_helpers import (
@@ -882,3 +885,108 @@ def test_pinned_elbo_is_a_lower_bound_on_the_evidence(family: str):
     """
     q, data = _pinned_uncollapsed_family(family, binary=False)
     assert elbo(q, data) <= conjugate_mll(q.model, data)
+
+
+# ---------------------------------------------------------------------------
+# with_log_prior
+# ---------------------------------------------------------------------------
+
+
+def _map_data(n=30):
+    x = jnp.linspace(0.0, 1.0, n).reshape(-1, 1)
+    return Dataset(X=x, y=jnp.sin(4.0 * x))
+
+
+def _map_model(lengthscale_prior=None, lengthscale=1.0):
+    lengthscale = PositiveReal(lengthscale, prior=lengthscale_prior)
+    kernel = gpx.kernels.RBF(lengthscale=lengthscale)
+    meanf = gpx.mean_functions.Constant()
+    return Prior(mean_function=meanf, kernel=kernel) * Gaussian()
+
+
+def _svgp_model(lengthscale_prior=None):
+    """The same model behind a variational family, so the priors sit two levels
+    down and share the tree with non-Parameter variational leaves."""
+    z = jnp.linspace(0.0, 1.0, 5).reshape(-1, 1)
+    return gpx.variational_families.VariationalGaussian(
+        model=_map_model(lengthscale_prior), inducing_inputs=z
+    )
+
+
+OBJECTIVE_CASES = [(conjugate_mll, _map_model), (elbo, _svgp_model)]
+
+
+@pytest.mark.parametrize(("objective", "make_model"), OBJECTIVE_CASES)
+def test_with_log_prior_is_exactly_the_base_objective_without_priors(
+    objective, make_model
+):
+    """A model with no priors must be regularised by precisely nothing."""
+    model, D = make_model(), _map_data()
+    assert with_log_prior(objective)(model, D) == objective(model, D)
+
+
+@pytest.mark.parametrize(("objective", "make_model"), OBJECTIVE_CASES)
+def test_with_log_prior_adds_the_summed_log_prior(objective, make_model):
+    model = make_model(npd.LogNormal(jnp.log(5.0), 0.5))
+    D = _map_data()
+    expected = objective(model, D) + collect_log_prior(model)
+    assert jnp.equal(with_log_prior(objective)(model, D), expected)
+
+
+def test_with_log_prior_leaves_the_base_objective_untouched():
+    """The combinator returns a new function rather than mutating its input."""
+    model = _map_model(npd.LogNormal(jnp.log(5.0), 0.5))
+    D = _map_data()
+    before = conjugate_mll(model, D)
+    with_log_prior(conjugate_mll)(model, D)
+    assert conjugate_mll(model, D) == before
+
+
+def test_with_log_prior_shifts_the_optimum_towards_the_prior():
+    """The point of the feature: a prior favouring long lengthscales should pull
+    the MAP estimate above the unregularised MLE."""
+    D = _map_data()
+    prior = npd.LogNormal(jnp.log(10.0), 0.1)
+
+    mle_model, _ = gpx.fit_scipy(
+        model=_map_model(),
+        objective=lambda p, d: -conjugate_mll(p, d),
+        train_data=D,
+        verbose=False,
+    )
+    map_model, _ = gpx.fit_scipy(
+        model=_map_model(prior),
+        objective=lambda p, d: -with_log_prior(conjugate_mll)(p, d),
+        train_data=D,
+        verbose=False,
+    )
+
+    mle_lengthscale = val(mle_model.prior.kernel.lengthscale)
+    map_lengthscale = val(map_model.prior.kernel.lengthscale)
+    assert map_lengthscale > mle_lengthscale
+
+
+def test_with_log_prior_does_not_train_the_prior():
+    """Fitting must leave the prior's own hyperparameters exactly as supplied.
+
+    numpyro distributions are mutable, so identity alone would not catch a
+    prior whose hyperparameters had drifted in place.
+    """
+    prior = npd.LogNormal(jnp.log(5.0), 0.5)
+    trained, _ = gpx.fit_scipy(
+        model=_map_model(prior),
+        objective=lambda p, d: -with_log_prior(conjugate_mll)(p, d),
+        train_data=_map_data(),
+        verbose=False,
+    )
+    trained_prior = trained.prior.kernel.lengthscale.prior
+    assert trained_prior is prior
+    assert trained_prior.loc == jnp.log(5.0)
+    assert trained_prior.scale == 0.5
+
+
+def test_with_log_prior_is_jittable():
+    model = _map_model(npd.LogNormal(jnp.log(5.0), 0.5))
+    D = _map_data()
+    regularised = with_log_prior(conjugate_mll)
+    assert jnp.equal(eqx.filter_jit(regularised)(model, D), regularised(model, D))

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,4 +1,16 @@
+import equinox as eqx
+import gpjax as gpx
+from gpjax.parameters import (
+    NonNegativeReal,
+    PositiveReal,
+    Real,
+    SigmoidBounded,
+    collect_log_prior,
+    val,
+)
+import jax
 import jax.numpy as jnp
+import numpyro.distributions as npd
 import paramax
 from paramax import AbstractUnwrappable
 import pytest
@@ -176,3 +188,113 @@ def test_coregionalization_matrix():
     # PSD check: all eigenvalues >= 0
     eigvals = jnp.linalg.eigvalsh(B)
     assert jnp.all(eigvals >= -1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Priors
+# ---------------------------------------------------------------------------
+
+PARAMETER_TYPES = [
+    (PositiveReal, 2.0),
+    (NonNegativeReal, 2.0),
+    (Real, -0.5),
+    (SigmoidBounded, 0.5),
+]
+
+
+@pytest.mark.parametrize(("cls", "value"), PARAMETER_TYPES)
+def test_prior_defaults_to_none(cls, value):
+    assert cls(jnp.asarray(value)).prior is None
+
+
+@pytest.mark.parametrize(("cls", "value"), PARAMETER_TYPES)
+def test_prior_is_read_back_unchanged(cls, value):
+    prior = npd.Normal(0.0, 1.0)
+    assert cls(jnp.asarray(value), prior=prior).prior is prior
+
+
+@pytest.mark.parametrize(("cls", "value"), PARAMETER_TYPES)
+def test_every_parameter_type_contributes_a_log_prior(cls, value):
+    prior = npd.Normal(0.0, 1.0)
+    p = cls(jnp.asarray(value), prior=prior)
+    assert jnp.equal(collect_log_prior(p), prior.log_prob(val(p)).sum())
+
+
+def test_prior_hyperparameters_are_not_pytree_leaves():
+    """The prior's own arrays must never reach the trainable partition."""
+    prior = npd.LogNormal(jnp.array(1.2345), jnp.array(6.789))
+    p = PositiveReal(jnp.array(1.0), prior=prior)
+
+    leaves = jax.tree.leaves(p)
+    assert len(leaves) == 1
+    assert jnp.allclose(leaves[0], p._unconstrained)
+
+    params, _ = eqx.partition(p, eqx.is_array)
+    assert not any(
+        jnp.allclose(leaf, 1.2345) or jnp.allclose(leaf, 6.789)
+        for leaf in jax.tree.leaves(params)
+    )
+
+
+def test_prior_survives_partition_and_combine():
+    """``fit`` splits models this way, so the prior has to come back intact."""
+    prior = npd.LogNormal(0.0, 1.0)
+    p = PositiveReal(jnp.array(2.0), prior=prior)
+    params, static = eqx.partition(p, eqx.is_array)
+    assert eqx.combine(params, static).prior is prior
+
+
+def test_prior_receives_no_gradient():
+    """Differentiating the log-prior touches the parameter, never the prior."""
+    prior = npd.LogNormal(jnp.array(0.0), jnp.array(1.0))
+    p = PositiveReal(jnp.array(2.0), prior=prior)
+
+    grads = jax.grad(collect_log_prior)(p)
+    assert len(jax.tree.leaves(grads)) == 1
+    assert grads.prior is prior
+
+
+def test_collect_log_prior_uses_the_constrained_value():
+    """A prior on a PositiveReal is evaluated at the positive value, not at the
+    unconstrained value it is stored as."""
+    prior = npd.LogNormal(0.0, 1.0)
+    p = PositiveReal(jnp.array(2.0), prior=prior)
+
+    assert jnp.equal(collect_log_prior(p), prior.log_prob(jnp.array(2.0)))
+    assert not jnp.allclose(
+        collect_log_prior(p), prior.log_prob(p._unconstrained), atol=1e-5
+    )
+
+
+def test_collect_log_prior_is_zero_without_priors():
+    assert collect_log_prior(gpx.kernels.RBF()) == 0.0
+
+
+def test_collect_log_prior_sums_over_the_model():
+    lengthscale_prior = npd.LogNormal(0.0, 1.0)
+    variance_prior = npd.LogNormal(jnp.log(2.0), 0.5)
+    kernel = gpx.kernels.RBF(
+        lengthscale=PositiveReal(1.5, prior=lengthscale_prior),
+        variance=PositiveReal(0.5, prior=variance_prior),
+    )
+    expected = lengthscale_prior.log_prob(1.5) + variance_prior.log_prob(0.5)
+    assert jnp.equal(collect_log_prior(kernel), expected)
+
+
+def test_collect_log_prior_sums_a_batched_prior_per_dimension():
+    """An ARD lengthscale takes a different prior in each dimension."""
+    lengthscale = jnp.array([0.5, 1.0, 2.0])
+    prior = npd.LogNormal(
+        loc=jnp.array([0.0, 0.7, 1.5]), scale=jnp.array([1.0, 0.5, 0.25])
+    )
+    kernel = gpx.kernels.RBF(lengthscale=PositiveReal(lengthscale, prior=prior))
+    assert jnp.equal(collect_log_prior(kernel), prior.log_prob(lengthscale).sum())
+
+
+def test_collect_log_prior_is_jittable():
+    prior = npd.LogNormal(0.0, 1.0)
+    kernel = gpx.kernels.RBF(lengthscale=PositiveReal(2.0, prior=prior))
+    assert jnp.equal(
+        eqx.filter_jit(collect_log_prior)(kernel),
+        collect_log_prior(kernel),
+    )

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -387,3 +387,42 @@ def test_summarise_renders_prior_column_when_priors_given():
 def test_summarise_prior_column_defaults_to_dash():
     # Without a priors map the Prior column is present but unpopulated.
     assert "LogNormal" not in _capture(Prior(mean_function=Zero(), kernel=RBF()))
+
+
+def test_collect_reads_a_parameter_s_own_prior():
+    """A prior attached with ``prior=`` populates the column unaided."""
+    kernel = RBF(lengthscale=PositiveReal(1.0, prior=npd.LogNormal(0.0, 1.0)))
+    records = summary._collect(Prior(mean_function=Zero(), kernel=kernel))
+    assert isinstance(
+        _record_by_name(records, "kernel.lengthscale").prior, npd.LogNormal
+    )
+    assert _record_by_name(records, "kernel.variance").prior is None
+
+
+def test_collect_prior_map_overrides_an_attached_prior():
+    kernel = RBF(lengthscale=PositiveReal(1.0, prior=npd.LogNormal(0.0, 1.0)))
+    records = summary._collect(
+        Prior(mean_function=Zero(), kernel=kernel),
+        priors={"kernel.lengthscale": npd.Gamma(3.0, 6.0)},
+    )
+    assert isinstance(_record_by_name(records, "kernel.lengthscale").prior, npd.Gamma)
+
+
+def test_collect_reads_the_prior_of_a_frozen_parameter():
+    """Freezing wraps the parameter's array, not the parameter, so the prior
+    is still reachable."""
+    kernel = RBF(lengthscale=PositiveReal(1.0, prior=npd.LogNormal(0.0, 1.0)))
+    frozen = eqx.tree_at(
+        lambda k: k.lengthscale, kernel, replace_fn=paramax.non_trainable
+    )
+    record = _record_by_name(
+        summary._collect(Prior(mean_function=Zero(), kernel=frozen)),
+        "kernel.lengthscale",
+    )
+    assert isinstance(record.prior, npd.LogNormal)
+    assert record.trainable is False
+
+
+def test_summarise_renders_an_attached_prior():
+    kernel = RBF(lengthscale=PositiveReal(1.0, prior=npd.LogNormal(0.0, 1.0)))
+    assert "LogNormal" in _capture(Prior(mean_function=Zero(), kernel=kernel))


### PR DESCRIPTION
## Checklist

- [X] I've formatted the new code by running `uv run poe format` before committing.
- [X] I've added tests for new code.
- [X] I've added docstrings for the new code.

## Description

Adds:
- A `prior` attribute to parameters.
- A `with_log_prior` function which takes an arbitrary `Objective` and adds the log prior of the parameters of the model to it. This allows for MAP estimation of parameters, rather than solely MLE.
