### PR TITLE
test(state_space): update typecheck regex

### DIFF
--- a/tests/test_state_space/test_validation.py
+++ b/tests/test_state_space/test_validation.py
@@ -41,7 +41,9 @@ def test_kernel_construction_rejects_tuple_active_dims_upstream():
     message names the ``list[int], slice`` annotation. Either way the tuple
     cannot reach ``_validate_temporal_kernel``.
     """
-    with pytest.raises(Exception, match=r"list or slice|list\[int\], slice"):
+    with pytest.raises(
+        Exception, match=r"list or slice|list\[int\], slice|list\[int\] \| slice"
+    ):
         gpx.kernels.Matern32(active_dims=(0, 1))
 
 


### PR DESCRIPTION
## Checklist

- [x] I've formatted the new code by running `uv run poe format` before committing.
- [ ] I've added tests for new code.
- [ ] I've added docstrings for the new code.

## Description

Currently the tests error on Python 3.14 (but not Python 3.13) with the following message.

```
FAILED tests/test_state_space/test_validation.py::test_kernel_construction_rejects_tuple_active_dims_upstream - AssertionError: Regex pattern did not match.
  Expected regex: 'list or slice|list\\[int\\], slice'
  Actual message: "Type-check error whilst checking the parameters of gpjax.kernels.stationary.base.StationaryKernel.__init__.\nThe problem arose whilst typechecking parameter 'active_dims'.\nActual value: (0, 1)\nExpected type: list[int] | slice | None.\n----------------------\nCalled with parameters: {\n  'self': Matern32(...),\n  'active_dims': (0, 1),\n  'lengthscale': 1.0,\n  'variance': 1.0,\n  'n_dims': None,\n  'compute_engine':\n  <gpjax.kernels.computations.dense.DenseKernelComputation object at 0x7ae7a026a190>\n}\nParameter annotations: (self, active_dims: list[int] | slice | None = None, lengthscale: float | Float[Array, ''] | Float[ndarray, ''] | list[float] | Float[Array, 'D'] | Float[ndarray, 'D'] | Float[Array, ''] | Float[ndarray, ''] | paramax.wrappers.AbstractUnwrappable = 1.0, variance: float | Float[Array, ''] | Float[ndarray, ''] | paramax.wrappers.AbstractUnwrappable = 1.0, n_dims: int | None = None, compute_engine: gpjax.kernels.computations.base.AbstractKernelComputation = <gpjax.kernels.computations.dense.DenseKernelComputation object at 0x7ae7a026a190>) -> Any.\n"
```

This is due to a formatting difference in union types between Python 3.13,

```
Type-check error whilst checking the parameters of gpjax.kernels.stationary.base.StationaryKernel.__init__.
The problem arose whilst typechecking parameter 'active_dims'.
Actual value: (0, 1)
Expected type: typing.Union[list[int], slice, NoneType].
----------------------
Called with parameters: {
  'self': Matern32(...),
  'active_dims': (0, 1),
  'lengthscale': 1.0,
  'variance': 1.0,
  'n_dims': None,
  'compute_engine':
  <gpjax.kernels.computations.dense.DenseKernelComputation object at 0x74c34459a9e0>
}
Parameter annotations: (self, active_dims: Union[list[int], slice, NoneType] = None, lengthscale: Union[float, Float[Array, ''], Float[ndarray, ''], list[float], Float[Array, 'D'], Float[ndarray, 'D'], Float[Array, ''], Float[ndarray, ''], paramax.wrappers.AbstractUnwrappable] = 1.0, variance: Union[float, Float[Array, ''], Float[ndarray, ''], paramax.wrappers.AbstractUnwrappable] = 1.0, n_dims: Optional[int] = None, compute_engine: gpjax.kernels.computations.base.AbstractKernelComputation = <gpjax.kernels.computations.dense.DenseKernelComputation object at 0x74c34459a9e0>) -> Any.
```

and Python 3.14,

```
Type-check error whilst checking the parameters of gpjax.kernels.stationary.base.StationaryKernel.__init__.
The problem arose whilst typechecking parameter 'active_dims'.
Actual value: (0, 1)
Expected type: list[int] | slice | None.
----------------------
Called with parameters: {
  'self': Matern32(...),
  'active_dims': (0, 1),
  'lengthscale': 1.0,
  'variance': 1.0,
  'n_dims': None,
  'compute_engine':
  <gpjax.kernels.computations.dense.DenseKernelComputation object at 0x7ae7a026a190>
}
Parameter annotations: (self, active_dims: list[int] | slice | None = None, lengthscale: float | Float[Array, ''] | Float[ndarray, ''] | list[float] | Float[Array, 'D'] | Float[ndarray, 'D'] | Float[Array, ''] | Float[ndarray, ''] | paramax.wrappers.AbstractUnwrappable = 1.0, variance: float | Float[Array, ''] | Float[ndarray, ''] | paramax.wrappers.AbstractUnwrappable = 1.0, n_dims: int | None = None, compute_engine: gpjax.kernels.computations.base.AbstractKernelComputation = <gpjax.kernels.computations.dense.DenseKernelComputation object at 0x7ae7a026a190>) -> Any.
```

In particular, the expected type changed from `typing.Union[list[int], slice, NoneType]` to `list[int] | slice | None`.

After this PR, all tests pass on Python 3.14.